### PR TITLE
Add multiple selection to data table

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "precommit-hook": "^3.0.0",
     "proxyquire": "^1.7.10",
     "react": "^15.3.0",
+    "react-addons-update": "^15.3.2",    
     "react-addons-test-utils": "^15.3.1",
     "react-color": "^2.2.7",
     "react-dom": "^15.3.0",
@@ -87,8 +88,7 @@
     "draft-js": "^0.7.0",
     "lodash": "^4.12.0",
     "loglevel": "1.4.0",
-    "moment": "^2.11.2",
-    "react-addons-update": "^15.3.2",
+    "moment": "^2.11.2",    
     "react-color": "^2.2.7",
     "recompose": "^0.20.2",
     "rx": "^4.0.8"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "draft-js": "^0.7.0",
     "lodash": "^4.12.0",
     "loglevel": "1.4.0",
-    "moment": "^2.11.2",    
+    "moment": "^2.11.2",
     "react-color": "^2.2.7",
     "recompose": "^0.20.2",
     "rx": "^4.0.8"

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "lodash": "^4.12.0",
     "loglevel": "1.4.0",
     "moment": "^2.11.2",
+    "react-addons-update": "^15.3.2",
     "react-color": "^2.2.7",
     "recompose": "^0.20.2",
     "rx": "^4.0.8"

--- a/scss/_DataTableRow.scss
+++ b/scss/_DataTableRow.scss
@@ -17,3 +17,7 @@
   transition: all .3s ease;
   position: relative;
 }
+
+.data-table__rows__row.selected{
+    background-color: $table-row-hover-color;
+}

--- a/src/data-table/DataTable.component.js
+++ b/src/data-table/DataTable.component.js
@@ -37,7 +37,7 @@ const DataTable = React.createClass({
     },
 
     renderContextMenu() {
-        const actionAccessChecker = (this.props.isContextActionAllowed && this.props.isContextActionAllowed.bind(null, this.state.activeRow)) || (() => true);
+        const actionAccessChecker = (this.props.isContextActionAllowed && this.props.isContextActionAllowed.bind(null, this.state.activeRows)) || (() => true);
 
         const actionsToShow = Object.keys(this.props.contextMenuActions || {})
             .filter(actionAccessChecker)

--- a/src/data-table/DataTable.component.js
+++ b/src/data-table/DataTable.component.js
@@ -2,8 +2,8 @@ import isArrayOfStrings from 'd2-utilizr/lib/isArrayOfStrings';
 import isIterable from 'd2-utilizr/lib/isIterable';
 import React from 'react';
 import update from 'react-addons-update';
-import DataTableRow from './DataTableRow.component';
 import DataTableHeader from './DataTableHeader.component';
+import DataTableRow from './DataTableRow.component';
 import DataTableContextMenu from './DataTableContextMenu.component';
 
 const DataTable = React.createClass({
@@ -74,9 +74,9 @@ const DataTable = React.createClass({
                         key={dataRowsId}
                         dataSource={dataRowsSource}
                         columns={this.state.columns}
-                        isActive={this.isRowActive(dataRowsSource)}                        
+                        isActive={this.isRowActive(dataRowsSource)}
                         itemClicked={this.handleRowClick}
-                        primaryClick={this.handlePrimaryClick}                                                                     
+                        primaryClick={this.handlePrimaryClick}
                     />
                 );
             });
@@ -127,7 +127,7 @@ const DataTable = React.createClass({
             contextMenuTarget: event.currentTarget,
             showContextMenu: true,
             activeRows: newActiveRows
-        });       
+        });
     },
     
     handlePrimaryClick(event, rowSource) {        
@@ -150,7 +150,7 @@ const DataTable = React.createClass({
        
     _hideContextMenu() {
         this.setState({
-            activeRows: [],         
+            activeRows: [],
             showContextMenu: false,
         });
     },    

--- a/src/data-table/DataTable.component.js
+++ b/src/data-table/DataTable.component.js
@@ -1,9 +1,9 @@
 import isArrayOfStrings from 'd2-utilizr/lib/isArrayOfStrings';
 import isIterable from 'd2-utilizr/lib/isIterable';
 import React from 'react';
-
-import DataTableHeader from './DataTableHeader.component';
+import update from 'react-addons-update';
 import DataTableRow from './DataTableRow.component';
+import DataTableHeader from './DataTableHeader.component';
 import DataTableContextMenu from './DataTableContextMenu.component';
 
 const DataTable = React.createClass({
@@ -12,6 +12,7 @@ const DataTable = React.createClass({
         contextMenuIcons: React.PropTypes.object,
         primaryAction: React.PropTypes.func,
         isContextActionAllowed: React.PropTypes.func,
+        isMultipleSelectionAllowed: React.PropTypes.bool
     },
 
     getInitialState() {
@@ -50,7 +51,8 @@ const DataTable = React.createClass({
                     target={this.state.contextMenuTarget}
                     onRequestClose={this._hideContextMenu}
                     actions={actionsToShow}
-                    activeItem={this.state.activeRow}
+                    activeItems={this.state.activeRows}
+                    showContextMenu={this.state.showContextMenu}
                     icons={this.props.contextMenuIcons}
                 />
         );
@@ -72,9 +74,9 @@ const DataTable = React.createClass({
                         key={dataRowsId}
                         dataSource={dataRowsSource}
                         columns={this.state.columns}
-                        isActive={this.state.activeRow === dataRowsId}
+                        isActive={this.isRowActive(dataRowsSource)}                        
                         itemClicked={this.handleRowClick}
-                        primaryClick={this.props.primaryAction || (() => {})}
+                        primaryClick={this.handlePrimaryClick}                                                                     
                     />
                 );
             });
@@ -93,22 +95,90 @@ const DataTable = React.createClass({
                {this.renderContextMenu()}
            </div>
         );
+    },    
+    
+    isRowActive(rowSource){                
+        if(!this.state.activeRows){
+            return false;
+        }
+        return this.state.activeRows.filter((row) => row===rowSource).length>0;
+    },
+    
+    isEventCtrlClick(event){
+        return this.props.isMultipleSelectionAllowed && event && event.ctrlKey;       
     },
 
     handleRowClick(event, rowSource) {
+        //Update activeRows according to click|ctlr+click
+        var newActiveRows;
+        //A click on itemMenu clears selection        
+        if(event.isIconMenuClick){
+            newActiveRows = [];
+        }else if (this.isEventCtrlClick(event) || this.isRowActive(rowSource)){
+            //Remain selection + rowSource if not already selected
+            newActiveRows = this.updateContextSelection(rowSource);                            
+        }else{
+            //Context click just selects current row
+            newActiveRows =[rowSource];
+        }
+          
+        //Update state        
         this.setState({
             contextMenuTarget: event.currentTarget,
             showContextMenu: true,
-            activeRow: rowSource !== this.state.activeRow ? rowSource : undefined,
-        });
+            activeRows: newActiveRows
+        });       
     },
-
-    _hideContextMenu() {
+    
+    handlePrimaryClick(event, rowSource) {        
+        //Click -> Clears selection, Invoke external action (passing event)
+        if(!this.isEventCtrlClick(event)){     
+            this.setState({
+                activeRows: []
+            });            
+            this.props.primaryAction(rowSource);
+            return;
+        }
+        
+        //Ctrl + Click -> Update selection
+        const newActiveRows = this.updatePrimarySelection(rowSource);
         this.setState({
-            activeRow: undefined,
+            activeRows:newActiveRows,
             showContextMenu: false,
         });
+    },      
+       
+    _hideContextMenu() {
+        this.setState({
+            activeRows: [],         
+            showContextMenu: false,
+        });
+    },    
+    
+    updateContextSelection(rowSource){
+        return this.updateSelection(rowSource,true);        
     },
+    
+    updatePrimarySelection(rowSource){
+        return this.updateSelection(rowSource, false);        
+    },    
+    
+    updateSelection(rowSource, isContextClick){   
+        const alreadySelected = this.isRowActive(rowSource);      
+        
+        //ctx click + Already selected -> Same selection
+        if(isContextClick && alreadySelected){
+            return this.state.activeRows
+        }
+                 
+        //click + Already selected -> Remove from selection
+        if(alreadySelected){
+            return this.state.activeRows.filter((nRow) => nRow!==rowSource);                      
+        }
+        
+        //!already selected -> Add to selection
+        return update(this.state.activeRows?this.state.activeRows:[], {$push: [rowSource]});            
+    }
 });
 
 export default DataTable;

--- a/src/data-table/DataTableContextMenu.component.js
+++ b/src/data-table/DataTableContextMenu.component.js
@@ -7,8 +7,7 @@ import Paper from 'material-ui/Paper';
 import addD2Context from '../component-helpers/addD2Context';
 
 function handleClick(props, action) {
-    props.actions[action].apply(props.actions, [props.activeItem]);
-
+    props.actions[action].apply(props.actions, props.activeItems);
     if (props.onRequestClose) {
         props.onRequestClose();
     }
@@ -25,7 +24,7 @@ function DataTableContextMenu(props, context) {
     return (
         <Popover
             {...props}
-            open={Boolean(props.activeItem)}
+            open={props.showContextMenu}
             anchorEl={props.target}
             anchorOrigin={{ horizontal: 'middle', vertical: 'center' }}
             animated={false}
@@ -39,7 +38,7 @@ function DataTableContextMenu(props, context) {
                     return (
                         <MenuItem
                             key={action}
-                            data-object-id={props.activeItem && props.activeItem.id}
+                            data-object-id={props.activeItems}
                             className={'data-table__context-menu__item'}
                             onClick={() => handleClick(props, action)}
                             primaryText={context.d2.i18n.getTranslation(action)}
@@ -59,7 +58,8 @@ DataTableContextMenu.defaultProps = {
 
 DataTableContextMenu.propTypes = {
     actions: PropTypes.objectOf(PropTypes.func),
-    activeItem: PropTypes.object,
+    showContextMenu: React.PropTypes.bool,
+    activeItems: React.PropTypes.array,
     icons: PropTypes.object,
     target: PropTypes.object,
     onRequestClose: PropTypes.func,

--- a/src/data-table/DataTableRow.component.js
+++ b/src/data-table/DataTableRow.component.js
@@ -37,6 +37,7 @@ const DataTableRow = React.createClass({
     propTypes: {
         columns: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
         dataSource: React.PropTypes.object,
+        isActive: React.PropTypes.bool,
         isEven: React.PropTypes.bool,
         isOdd: React.PropTypes.bool,
         itemClicked: React.PropTypes.func.isRequired,
@@ -51,6 +52,7 @@ const DataTableRow = React.createClass({
             {
                 'data-table__rows__row--even': !this.props.isOdd,
                 'data-table__rows__row--odd': this.props.isOdd,
+                'selected':this.props.isActive  
             });
 
         const columns = this.props.columns.map((columnName, index) => {
@@ -123,16 +125,18 @@ const DataTableRow = React.createClass({
 
     iconMenuClick(event) {
         event && event.preventDefault() && event.stopPropagation();
-        this.props.itemClicked(event, this.props.dataSource);
+        event.isIconMenuClick = true;
+        this.props.itemClicked(event, this.props.dataSource);                
     },
 
     handleContextClick(event) {
         event && event.preventDefault();
+        event.isIconMenuClick = false;
         this.props.itemClicked(event, this.props.dataSource);
     },
 
-    handleClick() {
-        this.props.primaryClick(this.props.dataSource);
+    handleClick(event) {
+        this.props.primaryClick(event, this.props.dataSource);
     },
 });
 

--- a/test/data-table/DataTable.component.test.js
+++ b/test/data-table/DataTable.component.test.js
@@ -144,9 +144,9 @@ describe('DataTable component', () => {
             expect(contextMenuComponent).to.have.length(0);
         });
 
-        it('should not render the context menu when the activeRow is undefined', () => {
+        it('should not render the context menu when the activeRows are empty', () => {
             const fakeRowSource = {name: 'My item'};
-            dataTableComponent.setState({contextMenuTarget: {}, activeRow: fakeRowSource});
+            dataTableComponent.setState({contextMenuTarget: {},activeRows: [fakeRowSource]});
 
             dataTableComponent.instance()._hideContextMenu();
             dataTableComponent.update();
@@ -154,9 +154,8 @@ describe('DataTable component', () => {
             const contextMenuComponent = dataTableComponent.find('.data-table__context-menu');
 
             expect(contextMenuComponent).to.have.length(0);
-            //TODO Review
-            // expect(dataTableComponent.state('activeRow')).to.be.undefined;
-        });
+            expect(dataTableComponent.state('activeRows')).to.have.length(0);
+        });            
 
         it('should initially not show the contextmenu', () => {
             expect(dataTableComponent.find('.data-table__context-menu')).to.have.length(0);
@@ -182,6 +181,34 @@ describe('DataTable component', () => {
             expect(dataTableComponent.find('.data-table__context-menu')).to.have.length(0);
         });
     });
+    
+    describe('multiple selection table', function(){
+        beforeEach(() => {
+            dataTableComponent = renderComponent({isMultipleSelectionAllowed: true});
+        });     
+        
+        it('should add row to selection with ctrl+click', () => {
+            const fakeRowSource = {name: 'My item'};
+            const firstItemSelected = dataTableComponent.state('dataRows')[0];
+            dataTableComponent.setState({contextMenuTarget: {},activeRows: [firstItemSelected]});
+
+            dataTableComponent.instance().handlePrimaryClick({clientY: 100, clientX: 100, ctrlKey:true}, fakeRowSource);
+            dataTableComponent.update();
+            
+            expect(dataTableComponent.state('activeRows')).to.have.length(2);    
+        });    
+        
+        it('should remove row from selection with ctrl+click"', () => {            
+            const firstItemSelected = dataTableComponent.state('dataRows')[0];
+            dataTableComponent.setState({contextMenuTarget: {},activeRows: [firstItemSelected]});
+
+            dataTableComponent.instance().handlePrimaryClick({clientY: 100, clientX: 100, ctrlKey:true}, firstItemSelected);
+            dataTableComponent.update();
+            
+            expect(dataTableComponent.state('activeRows')).to.have.length(0);             
+        });                      
+       
+    });
 
     describe('context menu action filtering', () => {
         let isContextActionAllowed;
@@ -203,19 +230,19 @@ describe('DataTable component', () => {
 
         it('should pass through when the actions are allowed', () => {
             // Show context menu initially
-            dataTableComponent.setState({contextMenuTarget: {}, activeRow: fakeRowSource});
+            dataTableComponent.setState({contextMenuTarget: {}, activeRows: [fakeRowSource]});
             const passedContextMenuActions = dataTableComponent.find(DataTableContextMenu).props().actions;
 
             expect(Object.keys(passedContextMenuActions)).to.deep.equal(['edit', 'delete', 'translate']);
         });
 
         it('should not pass actions that are not allowed', () => {
-            isContextActionAllowed.withArgs(fakeRowSource, 'delete').returns(false);
+            isContextActionAllowed.withArgs([fakeRowSource], 'delete').returns(false);
 
             dataTableComponent = renderComponent({isContextActionAllowed, contextMenuActions});
 
             // Show context menu initially
-            dataTableComponent.setState({contextMenuTarget: {}, activeRow: fakeRowSource});
+            dataTableComponent.setState({contextMenuTarget: {}, activeRows: [fakeRowSource]});
             const passedContextMenuActions = dataTableComponent.find(DataTableContextMenu).props().actions;
 
             expect(Object.keys(passedContextMenuActions)).to.deep.equal(['edit', 'translate']);

--- a/test/data-table/DataTable.component.test.js
+++ b/test/data-table/DataTable.component.test.js
@@ -154,7 +154,8 @@ describe('DataTable component', () => {
             const contextMenuComponent = dataTableComponent.find('.data-table__context-menu');
 
             expect(contextMenuComponent).to.have.length(0);
-            expect(dataTableComponent.state('activeRow')).to.be.undefined;
+            //TODO Review
+            // expect(dataTableComponent.state('activeRow')).to.be.undefined;
         });
 
         it('should initially not show the contextmenu', () => {

--- a/test/data-table/DataTableRow.component.test.js
+++ b/test/data-table/DataTableRow.component.test.js
@@ -80,23 +80,22 @@ describe('DataTableRow component', () => {
         });
 
         dataTableRow.find('.data-table__rows__row__column').first().simulate('click');
-        //TODO Review
-        // expect(primaryClickCallback).to.be.calledWith(dataElement);
+        expect(primaryClickCallback).to.be.calledWith(undefined,dataElement);
     });
 
     it('should fire the itemClicked callback when a row is clicked', () => {
+        const fakeEvent = {preventDefault:sinon.stub().returns(true)};
         const contextClickCallback = spy();
         dataTableRow = renderComponent({
             dataSource: dataElement,
             columns: ['name', 'code', 'objectValue1', 'objectValue2'],
             itemClicked: contextClickCallback,
         });
-
-        //TODO Review
-        // dataTableRow.find('.data-table__rows__row__column').first().simulate('contextMenu');
+        
+        dataTableRow.find('.data-table__rows__row__column').first().simulate('contextMenu',fakeEvent);
        
-        // expect(contextClickCallback).to.be.called;
-        // expect(contextClickCallback.getCall(0).args[1]).to.equal(dataElement);
+        expect(contextClickCallback).to.be.called;
+        expect(contextClickCallback.getCall(0).args[1]).to.equal(dataElement);
     });
 
     describe('transformation of', () => {

--- a/test/data-table/DataTableRow.component.test.js
+++ b/test/data-table/DataTableRow.component.test.js
@@ -91,9 +91,9 @@ describe('DataTableRow component', () => {
             columns: ['name', 'code', 'objectValue1', 'objectValue2'],
             itemClicked: contextClickCallback,
         });
-        
+
         dataTableRow.find('.data-table__rows__row__column').first().simulate('contextMenu',fakeEvent);
-       
+
         expect(contextClickCallback).to.be.called;
         expect(contextClickCallback.getCall(0).args[1]).to.equal(dataElement);
     });

--- a/test/data-table/DataTableRow.component.test.js
+++ b/test/data-table/DataTableRow.component.test.js
@@ -80,8 +80,8 @@ describe('DataTableRow component', () => {
         });
 
         dataTableRow.find('.data-table__rows__row__column').first().simulate('click');
-
-        expect(primaryClickCallback).to.be.calledWith(dataElement);
+        //TODO Review
+        // expect(primaryClickCallback).to.be.calledWith(dataElement);
     });
 
     it('should fire the itemClicked callback when a row is clicked', () => {
@@ -92,10 +92,11 @@ describe('DataTableRow component', () => {
             itemClicked: contextClickCallback,
         });
 
-        dataTableRow.find('.data-table__rows__row__column').first().simulate('contextMenu');
-
-        expect(contextClickCallback).to.be.called;
-        expect(contextClickCallback.getCall(0).args[1]).to.equal(dataElement);
+        //TODO Review
+        // dataTableRow.find('.data-table__rows__row__column').first().simulate('contextMenu');
+       
+        // expect(contextClickCallback).to.be.called;
+        // expect(contextClickCallback.getCall(0).args[1]).to.equal(dataElement);
     });
 
     describe('transformation of', () => {

--- a/test/forms/FormBuilder.component.test.js
+++ b/test/forms/FormBuilder.component.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import FormBuilder from '../../src/forms/FormBuilder.component';
 import { shallow } from 'enzyme';
 import { getStubContext } from '../../config/inject-theme';
-import Textfield from 'material-ui/Textfield/Textfield';
+import TextField from 'material-ui/TextField/TextField';
 import AsyncValidatorRunner from '../../src/forms/AsyncValidatorRunner';
 
 describe('FormBuilder component', () => {
@@ -16,7 +16,7 @@ describe('FormBuilder component', () => {
 
     beforeEach(() => {
         const fields = [
-            { name: 'name', component: Textfield, value: 'John' },
+            { name: 'name', component: TextField, value: 'John' },
         ];
 
         function onUpdateField(fieldName, value) {
@@ -31,14 +31,14 @@ describe('FormBuilder component', () => {
     });
 
     describe('field rendering', () => {
-        it('should render a the Textfield', () => {
-            const textField = formComponent.find(Textfield);
+        it('should render a the TextField', () => {
+            const textField = formComponent.find(TextField);
 
             expect(textField).to.have.length(1);
         });
 
-        it('should pass the value to the Textfield', () => {
-            const textField = formComponent.find(Textfield);
+        it('should pass the value to the TextField', () => {
+            const textField = formComponent.find(TextField);
 
             expect(textField.props().value).to.equal('John');
         });
@@ -46,12 +46,12 @@ describe('FormBuilder component', () => {
         it('should pass the new value to the TextField when props has changed', () => {
             formComponent.setProps({
                 fields: [
-                    {name: 'name', component: Textfield, value: 'Mike'},
+                    {name: 'name', component: TextField, value: 'Mike'},
                 ],
             });
             formComponent.update();
 
-            const textField = formComponent.find(Textfield);
+            const textField = formComponent.find(TextField);
 
             expect(textField.props().value).to.equal('Mike');
         });
@@ -66,7 +66,7 @@ describe('FormBuilder component', () => {
             fields = [
                 {
                     name: 'name',
-                    component: Textfield,
+                    component: TextField,
                     value: 'John',
                     validators: [
                         {
@@ -92,7 +92,7 @@ describe('FormBuilder component', () => {
         });
 
         it('should mark the field as valid', () => {
-            const textField = formComponent.find(Textfield);
+            const textField = formComponent.find(TextField);
 
             expect(textField.props().errorText).to.be.undefined;
         });
@@ -103,7 +103,7 @@ describe('FormBuilder component', () => {
                     fields: [
                         {
                             name: 'name',
-                            component: Textfield,
+                            component: TextField,
                             value: '',
                             validators: [
                                 {
@@ -121,7 +121,7 @@ describe('FormBuilder component', () => {
             });
 
             it('should pass the error message to the text field', () => {
-                expect(formComponent.find(Textfield).first().props().errorText).to.equal('field_is_required');
+                expect(formComponent.find(TextField).first().props().errorText).to.equal('field_is_required');
             });
 
             it('should mark the form as invalid', () => {
@@ -131,7 +131,7 @@ describe('FormBuilder component', () => {
 
         describe('when changing textfield value', () => {
             it('should run the validator on value change', () => {
-                const textField = formComponent.find(Textfield);
+                const textField = formComponent.find(TextField);
 
                 textField.props().onChange({ target: { value: 'John1' }});
 
@@ -139,7 +139,7 @@ describe('FormBuilder component', () => {
             });
 
             it('should emit the value of the field from the form', () => {
-                const textField = formComponent.find(Textfield);
+                const textField = formComponent.find(TextField);
 
                 textField.props().onChange({ target: { value: 'John1' }});
 
@@ -147,7 +147,7 @@ describe('FormBuilder component', () => {
             });
 
             it('should run the validator with an empty value', () => {
-                const textField = formComponent.find(Textfield);
+                const textField = formComponent.find(TextField);
 
                 textField.props().onChange({ target: { value: '' }});
 
@@ -155,7 +155,7 @@ describe('FormBuilder component', () => {
             });
 
             it('should still emit the value from the form when it is invalid', () => {
-                const textField = formComponent.find(Textfield);
+                const textField = formComponent.find(TextField);
 
                 textField.props().onChange({ target: { value: 'ddd' }});
 
@@ -163,7 +163,7 @@ describe('FormBuilder component', () => {
             });
 
             it('should not run the validator when the values are the same', () => {
-                const textField = formComponent.find(Textfield);
+                const textField = formComponent.find(TextField);
 
                 textField.props().onChange({ target: { value: 'John' }});
 
@@ -171,7 +171,7 @@ describe('FormBuilder component', () => {
             });
 
             it('should still emit the value when the values are the same', () => {
-                const textField = formComponent.find(Textfield);
+                const textField = formComponent.find(TextField);
 
                 textField.props().onChange({ target: { value: 'John' }});
 
@@ -233,7 +233,7 @@ describe('FormBuilder component', () => {
 
         describe('onUpdateFormStatus callback', () => {
             it('should emit the formStatus when a field was changed and the value is valid', () => {
-                const textField = formComponent.find(Textfield);
+                const textField = formComponent.find(TextField);
 
                 textField.props().onChange({ target: { value: 'John1' }});
 
@@ -241,7 +241,7 @@ describe('FormBuilder component', () => {
             });
 
             it('should emit the formStatus when a field was changed but the value is invalid', () => {
-                const textField = formComponent.find(Textfield);
+                const textField = formComponent.find(TextField);
 
                 textField.props().onChange({ target: { value: '' }});
 
@@ -260,7 +260,7 @@ describe('FormBuilder component', () => {
             fields = [
                 {
                     name: 'name',
-                    component: Textfield,
+                    component: TextField,
                     value: 'John',
                     asyncValidators: [
                         sinon.spy(() => new Promise(() => {}))
@@ -296,7 +296,7 @@ describe('FormBuilder component', () => {
         });
 
         it('should emit the formStatus with validating set to true before running the async validators', () => {
-            const textField = formComponent.find(Textfield);
+            const textField = formComponent.find(TextField);
 
             textField.props().onChange({ target: { value: 'John1' }});
 
@@ -305,7 +305,7 @@ describe('FormBuilder component', () => {
 
         // TODO: Incorrectly(?) sets pristine state to true?
         it('should emit the formStatus after the async validators complete', (done) => {
-            const textField = formComponent.find(Textfield);
+            const textField = formComponent.find(TextField);
 
             fields[0].asyncValidators[0] = sinon.spy(() => Promise.resolve('Success'));
 
@@ -328,7 +328,7 @@ describe('FormBuilder component', () => {
 
         // TODO: Incorrectly(?) sets pristine state to true?
         it('should emit the formStatus after the async validators failed', (done) => {
-            const textField = formComponent.find(Textfield);
+            const textField = formComponent.find(TextField);
 
             fields[0].asyncValidators[0] = sinon.spy(() => Promise.reject('Failure'));
 
@@ -357,7 +357,7 @@ describe('FormBuilder component', () => {
         });
 
         it('should call the onUpdateField after the async validators completed', (done) => {
-            const textField = formComponent.find(Textfield);
+            const textField = formComponent.find(TextField);
 
             fields[0].asyncValidators[0] = sinon.spy(() => Promise.resolve('Success'));
 
@@ -377,7 +377,7 @@ describe('FormBuilder component', () => {
         });
 
         it('should call the onUpdateField after the async validators failed', (done) => {
-            const textField = formComponent.find(Textfield);
+            const textField = formComponent.find(TextField);
 
             fields[0].asyncValidators[0] = sinon.spy(() => Promise.reject('Failure'));
 
@@ -397,7 +397,7 @@ describe('FormBuilder component', () => {
         });
 
         it('should cancel the running async validators when the value is changed again', () => {
-            const textField = formComponent.find(Textfield);
+            const textField = formComponent.find(TextField);
 
             fields[0].asyncValidators[0] = sinon.spy(() => new Promise(() => {}));
 
@@ -425,7 +425,7 @@ describe('FormBuilder component', () => {
             fields = [
                 {
                     name: 'name',
-                    component: Textfield,
+                    component: TextField,
                     value: 'John',
                     props: {
                         changeEvent: 'onBlur',
@@ -450,7 +450,7 @@ describe('FormBuilder component', () => {
         it('should not run the handler for onChange', () => {
             sinon.spy(FormBuilder.prototype, 'updateFieldState');
 
-            const textField = formComponent.find(Textfield);
+            const textField = formComponent.find(TextField);
             textField.props().onChange({ target: { value: 'John2' }});
             textField.props().onBlur({ target: { value: 'John2' }});
 


### PR DESCRIPTION
Allows multiple selection in data table. It can be enabled/disabled using the property isMultipleSelectionAllowed, by default it is set to false therefore no changes are expected for current data tables. The only way to execute an action on the selected rows is using the right-click. The three dots at the right side of the row will execute action only for a single row. Regular click works as usual, ctrl+click allows multiple selection.

This PR also fixes some bugs in /FormBuilder.component.test.js due to a typo (Textfield instead of TextField).

We have changed the selection tests in order to make them work with this new property. We have added a couple of tests to test this new feature.

@Markionium Let us know about question or changes @ivanarrizabalaga is the main person behind this feature. He will be more than happy to answer any question you may have.
