### PR TITLE
Fixed babelrc to give es5 code out and fixed orgUnitTree to be compatible with es5 imports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-    "presets": ["stage-0", "react"],
+    "presets": ["stage-0", "react", "es2015"],
     "plugins": [
         "transform-class-properties",
         "transform-es2015-template-literals",

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -2,7 +2,6 @@ import React from 'react';
 import LinearProgress from 'material-ui/LinearProgress';
 
 import Model from 'd2/lib/model/Model';
-import ModelCollection from 'd2/lib/model/ModelCollection';
 
 import TreeView from '../tree-view/TreeView.component';
 
@@ -42,7 +41,7 @@ class OrgUnitTree extends React.Component {
                 : undefined,
             loading: false,
         };
-        if (props.root.children instanceof ModelCollection) {
+        if (!props.root.children instanceof Model) {
             this.state.children = props.root.children
                 .toArray()
                 // Sort here since the API returns nested children in random order


### PR DESCRIPTION
 - added es2015 preset
 - removed ModelCollection dependency from orgUnitTree as it causes a cyclic dependency which 
    es5 import is not compatible with. 
 - changed the condition check 
                             from
  if (props.root.children instanceof ModelCollection) 
                                to
  if (!props.root.children instanceof Model) 

we can also change it to something like if(props.root.children.toArray) exists or not.
or any other check like that should be fine.