### PR TITLE
Rework value rendering in DataTable

### DIFF
--- a/examples/data-table/index.js
+++ b/examples/data-table/index.js
@@ -45,8 +45,8 @@ function renderExamples(d2) {
     };
 
     const myRows = [
-        { firstName: 'Mark', lastName: 'Polak' },
-        { firstName: 'Nicolay', lastName: 'Ramm' },
+        { firstName: 'John', lastName: 'Traore', lastUpdated: '2014-11-11T21:56:05.469' },
+        { firstName: 'Tom', lastName: 'Wakiki', lastUpdated: '2015-08-06T13:28:05.512' },
     ];
 
     const cma = {
@@ -58,7 +58,7 @@ function renderExamples(d2) {
     const app = (
         <Example>
             <DataTable
-                columns={['firstName', 'lastName']}
+                columns={['firstName', 'lastName', 'lastUpdated']}
                 rows={myRows}
                 contextMenuActions={cma}
             />

--- a/src/data-table/DataTableRow.component.js
+++ b/src/data-table/DataTableRow.component.js
@@ -5,35 +5,15 @@ import { isString } from 'lodash/fp';
 import moment from 'moment';
 import IconButton from 'material-ui/IconButton';
 import MoreVert from 'material-ui/svg-icons/navigation/more-vert';
-import Color from './data-value/Color.component';
+import Translate from '../i18n/Translate.component';
+import addD2Context from '../component-helpers/addD2Context';
+import { findValueRenderer } from './data-value/valueRenderers';
 
-import Translate from '../i18n/Translate.mixin';
-
-function valueTypeGuess(valueType, value) {
-    switch (valueType) {
-    case 'DATE':
-        return moment(new Date(value)).fromNow();
-    case 'TEXT':
-        if (/#([a-z0-9]{6})$/i.test(value)) {
-            return (<Color value={value} />);
-        }
-        return value;
-    default:
-        break;
-    }
-
-    return value;
+function getD2ModelValueType(dataSource, columnName) {
+    return dataSource && dataSource.modelDefinition && dataSource.modelDefinition.modelValidations && dataSource.modelDefinition.modelValidations[columnName] && dataSource.modelDefinition.modelValidations[columnName].type
 }
 
-function getValueAfterValueTypeGuess(dataSource, columnName) {
-    if (dataSource && dataSource.modelDefinition && dataSource.modelDefinition.modelValidations && dataSource.modelDefinition.modelValidations[columnName]) {
-        return valueTypeGuess(dataSource.modelDefinition.modelValidations[columnName].type, dataSource[columnName]);
-    }
-
-    return dataSource[columnName];
-}
-
-const DataTableRow = React.createClass({
+const DataTableRow = addD2Context(React.createClass({
     propTypes: {
         columns: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
         dataSource: React.PropTypes.object,
@@ -42,8 +22,6 @@ const DataTableRow = React.createClass({
         itemClicked: React.PropTypes.func.isRequired,
         primaryClick: React.PropTypes.func.isRequired,
     },
-
-    mixins: [Translate],
 
     render() {
         const classList = classes(
@@ -54,48 +32,13 @@ const DataTableRow = React.createClass({
             });
 
         const columns = this.props.columns.map((columnName, index) => {
-            const rowValue = getValueAfterValueTypeGuess(this.props.dataSource, columnName);
-            let displayValue;
-
-            // Render objects by name or otherwise by their toString method.
-            // ReactElements are also objects but we want to render them out normally, so they are excluded.
-            if (isObject(rowValue) && !isValidElement(rowValue)) {
-                displayValue = rowValue.displayName || rowValue.name || rowValue.toString();
-            } else {
-                displayValue = rowValue;
-            }
-
-            // TODO: PublicAccess Hack - need to make it so that value transformers can be registered
-            if (columnName === 'publicAccess') {
-                const dataSource = this.props.dataSource;
-
-                if (dataSource[columnName]) {
-                    if (dataSource[columnName] === 'rw------') {
-                        displayValue = this.getTranslation('public_can_edit');
-                    }
-
-                    if (dataSource[columnName] === 'r-------') {
-                        displayValue = this.getTranslation('public_can_view');
-                    }
-
-                    if (dataSource[columnName] === '--------') {
-                        displayValue = this.getTranslation('public_none');
-                    }
-                }
-            }
-
-            const textWrapStyle = {
-                width: '100%',
-                textOverflow: 'ellipsis',
-                overflow: 'hidden',
-                whiteSpace: 'nowrap',
-                position: 'absolute',
-                wordBreak: 'break-all',
-                wordWrap: 'break-word',
-                top: 0,
-                lineHeight: '50px',
-                paddingRight: '1rem',
+            const valueDetails = {
+                valueType: getD2ModelValueType(this.props.dataSource, columnName),
+                value: this.props.dataSource[columnName],
+                columnName,
             };
+
+            const Value = findValueRenderer(valueDetails);
 
             return (
                 <div
@@ -104,7 +47,7 @@ const DataTableRow = React.createClass({
                     onContextMenu={this.handleContextClick}
                     onClick={this.handleClick}
                 >
-                    {isString(displayValue) ? <span title={displayValue} style={textWrapStyle} >{displayValue}</span> : displayValue}
+                    <Value {...valueDetails} />
                 </div>
             );
         });
@@ -112,7 +55,7 @@ const DataTableRow = React.createClass({
             <div className={classList}>
                 {columns}
                 <div className={'data-table__rows__row__column'} style={{width: '1%'}}>
-                    <IconButton tooltip={this.getTranslation('actions')} onClick={this.iconMenuClick}>
+                    <IconButton tooltip={this.context.d2.i18n.getTranslation('actions')} onClick={this.iconMenuClick}>
                         <MoreVert />
                     </IconButton>
                 </div>
@@ -121,7 +64,6 @@ const DataTableRow = React.createClass({
     },
 
     iconMenuClick(event) {
-        event && event.preventDefault() && event.stopPropagation();
         this.props.itemClicked(event, this.props.dataSource);
     },
 
@@ -133,6 +75,6 @@ const DataTableRow = React.createClass({
     handleClick(event) {
         this.props.primaryClick(this.props.dataSource, event);
     },
-});
+}));
 
 export default DataTableRow;

--- a/src/data-table/data-value/Color.component.js
+++ b/src/data-table/data-value/Color.component.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import {hcl} from 'd3-color';
 
-export default function Color (props) {
+export default function Color ({ color, value }) {
     const styles = {
         color: {
-            backgroundColor: props.value,
-            color: hcl(props.value).l < 70 ? '#fff' : '#000',
+            backgroundColor: value,
+            color: hcl(value).l < 70 ? '#FFF' : '#000',
             textAlign: 'center',
             position: 'relative',
             width: 90,
@@ -16,6 +16,6 @@ export default function Color (props) {
     };
 
     return (
-        <div style={styles.color}>{props.value}</div>
+        <div style={styles.color}>{value}</div>
     );
 };

--- a/src/data-table/data-value/valueRenderers.js
+++ b/src/data-table/data-value/valueRenderers.js
@@ -1,0 +1,132 @@
+import React, { isValidElement } from 'react';
+import Color from './Color.component';
+import Translate from '../../i18n/Translate.component';
+import addD2Context from '../../component-helpers/addD2Context';
+
+function TextValue({ value = '', columnName }) {
+    const textWrapStyle = {
+        width: '100%',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+        position: 'absolute',
+        wordBreak: 'break-all',
+        wordWrap: 'break-word',
+        top: 0,
+        lineHeight: '50px',
+        paddingRight: '1rem',
+    };
+
+    const displayValue = value.toString();
+
+    return (<span title={displayValue} style={textWrapStyle} >{displayValue}</span>);
+}
+
+function getDateToShowInList(value, locale = 'en') {
+    if (typeof global.Intl !== 'undefined' && Intl.DateTimeFormat) {
+        return new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'long', day: 'numeric' }).format(new Date(value));
+    }
+
+    return value.substr(0, 19).replace('T', ' ');
+}
+
+const DateValue = addD2Context(function ({ value }, { d2 }) {
+    const displayDate = getDateToShowInList(value, d2.currentUser.uiLocale);
+
+    return (
+        <TextValue value={displayDate} />
+    );
+});
+
+function ObjectWithDisplayName(props) {
+    const textValue = props.value && (props.value.displayName || props.value.name);
+    return (<TextValue {...props} value={textValue} />);
+}
+
+const dhis2DateFormat = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{2,3}$/
+function isDateValue({ valueType, value }) {
+    return valueType === 'DATE' || dhis2DateFormat.test(value);
+}
+
+function isColorValue({ value }) {
+    return /#([a-z0-9]{6})$/i.test(value);
+}
+
+function isObjectWithDisplayName({ value }) {
+    return value && (value.displayName || value.name);
+}
+
+function PublicAccessValue({ columnName, value }) {
+    if (value) {
+        if (value === 'rw------') {
+            return <Translate>public_can_edit</Translate>;
+        }
+
+        if (value === 'r-------') {
+            return <Translate>public_can_view</Translate>;
+        }
+
+        if (value === '--------') {
+            return <Translate>public_none</Translate>;
+        }
+    }
+
+    return <TextValue value={value} />;
+}
+
+function isPublicAccess({ columnName }) {
+    return columnName === 'publicAccess';
+}
+
+let valueRenderers = [
+    [isPublicAccess, PublicAccessValue],
+    [isDateValue, DateValue],
+    [isObjectWithDisplayName, ObjectWithDisplayName],
+    [isColorValue, Color],
+];
+
+/**
+ * Register a new ValueRenderer. The value renderers are used to render different values in the DataTable. (e.g. colors should be rendered as a Color component).
+ * The new renderer is added to the start of the renderer list. If your passed `checker` is too specific the `component` might be used for values that you might not want.
+ * Passing `() => true` as a checker will result the passed `component` to be used for every value in the DataTable.
+ * 
+ * @param {function} checker Check if the value is valid for the `component` to be rendered. This function receives an object with `value`, `valueType` and `columnName` that can be used to determine if this `component` should render the value.
+ * @param {function} component A React component to render when the `checker` returns true. This is the component that will be returned from `findValueRenderer`.
+ * 
+ * @returns {function} A de-register function to unregister the checker. If you want to remove the valueRenderer from the list of renderers you can use this function to undo the add.
+ */
+export function addValueRenderer(checker, component) {
+    valueRenderers.unshift([checker, component]);
+
+    /**
+     * Un-register the valueRenderer
+     */
+    return function removeValueRenderer() {
+        const rendererMap = new Map(valueRenderers);
+
+        rendererMap.delete(checker);
+
+        valueRenderers = Array.from(rendererMap);
+    };
+}
+
+/**
+ * This method is used by the DataTableRow component to find a ValueRenderer for the value that should be displayed in the table's cell.
+ * It will recieve an object like the one below and loop through a list of renderers until it finds one that will handle this type of value.
+ * ```json
+ * {
+ *   "value": "#FFFFFF",
+ *   "valueType": "TEXT",
+ *   "columnName": "color",
+ * }
+ * ```
+ * 
+ * @param {object} valueDetails The value and its details. The object has the properties `columnName`, `value` and `valueType`.
+ * @returns {function} The React component that can render a value for the passed `valueDetails`.
+ */
+export const findValueRenderer = (valueDetails) => {
+    const valueCheckers = valueRenderers.map(([checker]) => checker);
+    const checkerIndex = valueCheckers.findIndex(checker => checker(valueDetails))
+
+    return (valueRenderers[checkerIndex] && valueRenderers[checkerIndex][1]) || TextValue;
+};

--- a/test/data-table/DataTableRow.component.test.js
+++ b/test/data-table/DataTableRow.component.test.js
@@ -3,6 +3,7 @@ import {shallow} from 'enzyme';
 
 import DataTableRow from '../../src/data-table/DataTableRow.component';
 import Color from '../../src/data-table/data-value/Color.component';
+import Translate from '../../src/i18n/Translate.component';
 
 describe('DataTableRow component', () => {
     let dataTableRow;
@@ -40,6 +41,15 @@ describe('DataTableRow component', () => {
             objectValue2: {
                 name: 'ANC-1',
             },
+
+            // Fake d2 model structure
+            modelDefinition: {
+                modelValidations: {
+                    name: {
+                        type: 'TEXT',
+                    },
+                },
+            },
         };
 
         dataTableRow = renderComponent({dataSource: dataElement, columns: ['name', 'code', 'objectValue1', 'objectValue2']});
@@ -56,19 +66,22 @@ describe('DataTableRow component', () => {
     it('should render the name into the first column', () => {
         const firstColumn = dataTableRow.find('.data-table__rows__row__column').first();
 
-        expect(firstColumn.text()).to.equal('Centre de Diagnostic et de Traitement de Bongouanou');
+        expect(firstColumn.find('TextValue').first().prop('columnName')).to.equal('name');
+        expect(firstColumn.find('TextValue').first().prop('value')).to.equal('Centre de Diagnostic et de Traitement de Bongouanou');
     });
 
-    it('should render the name into the second column', () => {
+    it('should render the code into the second column', () => {
         const secondColumn = dataTableRow.find('.data-table__rows__row__column').at(1);
 
-        expect(secondColumn.text()).to.equal('p.ci.ipsl.xxxx');
+        expect(secondColumn.find('TextValue').first().prop('columnName')).to.equal('code');
+        expect(secondColumn.find('TextValue').first().prop('value')).to.equal('p.ci.ipsl.xxxx');
     });
 
-    it('should render the displayName when the value is an object', () => {
+    it('should render the ObjectWithDisplayName field type when the value has a displayName', () => {
         const thirdColumn = dataTableRow.find('.data-table__rows__row__column').at(2);
 
-        expect(thirdColumn.text()).to.equal('ANC');
+        expect(thirdColumn.find('ObjectWithDisplayName')).to.have.length(1);
+        expect(thirdColumn.find('ObjectWithDisplayName').prop('value')).to.deep.equal(dataElement.objectValue1);
     });
 
     it('should fire the primaryClick callback when a row is clicked', () => {
@@ -98,169 +111,17 @@ describe('DataTableRow component', () => {
         expect(contextClickCallback.getCall(0).args[1]).to.equal(dataElement);
     });
 
-    describe('transformation of', () => {
-        let dataTableRowProps;
-
-        describe('publicAccess values', () => {
-            beforeEach(() => {
-                dataTableRowProps = {
-                    dataSource: dataElement,
-                    columns: ['publicAccess'],
-                };
-            });
-
-            it('should transformation the r------- publicAccess pattern to their textual values', () => {
-                dataElement.publicAccess = 'r-------';
-
-                dataTableRow = renderComponent(dataTableRowProps).find('.data-table__rows__row__column').first();
-
-                expect(dataTableRow.text()).to.equal('public_can_view_translated');
-            });
-
-            it('should transformation the rw------ publicAccess pattern to their textual values', () => {
-                dataElement.publicAccess = 'rw------';
-
-                dataTableRow = renderComponent(dataTableRowProps).find('.data-table__rows__row__column').first();
-
-                expect(dataTableRow.text()).to.equal('public_can_edit_translated');
-            });
-
-            it('should transformation the -------- publicAccess pattern to their textual values', () => {
-                dataElement.publicAccess = '--------';
-
-                dataTableRow = renderComponent(dataTableRowProps).find('.data-table__rows__row__column').first();
-
-                expect(dataTableRow.text()).to.equal('public_none_translated');
-            });
-
-            it('should not transformation an unknown publicAccess pattern', () => {
-                dataElement.publicAccess = 'rwx-----';
-
-                dataTableRow = renderComponent(dataTableRowProps).find('.data-table__rows__row__column').first();
-
-                expect(dataTableRow.text()).to.equal('rwx-----');
-            });
-
-            it('should not transformation an empty value', () => {
-                dataTableRow = renderComponent(dataTableRowProps).find('.data-table__rows__row__column').first();
-
-                expect(dataTableRow.text()).to.equal('');
-            });
+    it('should fre the itemClicked callback when the icon is clicked', () => {
+        const contextClickCallback = spy();
+        dataTableRow = renderComponent({
+            dataSource: dataElement,
+            columns: ['name', 'code', 'objectValue1', 'objectValue2'],
+            itemClicked: contextClickCallback,
         });
 
-        describe('guessing of the value type', () => {
-            beforeEach(() => {
-                dataTableRowProps = {
-                    dataSource: dataElement,
-                    columns: ['lastUpdated'],
-                };
-            });
+        dataTableRow.find('IconButton').first().simulate('click');
 
-            it('should return a human readable string for a year ago', () => {
-                const dateAYearAgo = (new Date(Date.now() - 31540000000)).toISOString();
-
-                dataTableRowProps.dataSource.lastUpdated = dateAYearAgo;
-                dataTableRowProps.dataSource.modelDefinition = {
-                    modelValidations: {
-                        lastUpdated: {
-                            type: 'DATE',
-                        },
-                    },
-                };
-
-                dataTableRow = renderComponent(dataTableRowProps).find('.data-table__rows__row__column').first();
-
-                expect(dataTableRow.text()).to.equal('a year ago');
-            });
-
-            it('should just return the plain value if the value can not be guessed', () => {
-                dataTableRowProps.columns = ['unknownProperty'];
-                dataTableRowProps.dataSource.unknownProperty = 'unknown value';
-                dataTableRowProps.dataSource.modelDefinition = {
-                    modelValidations: {
-                        unknownProperty: {
-                            type: 'UNKNOWN_TYPE',
-                        },
-                    },
-                };
-
-                dataTableRow = renderComponent(dataTableRowProps).find('.data-table__rows__row__column').first();
-
-                expect(dataTableRow.text()).to.equal('unknown value');
-            });
-
-            it('should render a Color component when the value is a hex color', () => {
-                dataTableRowProps = {
-                    dataSource: dataElement,
-                    columns: ['color'],
-                };
-
-                dataTableRowProps.dataSource.color = '#FF35CC';
-                dataTableRowProps.dataSource.modelDefinition = {
-                    modelValidations: {
-                        color: {
-                            type: 'TEXT',
-                        },
-                    },
-                };
-
-                dataTableRow = renderComponent(dataTableRowProps).find('.data-table__rows__row__column').first();
-
-                expect(dataTableRow.find(Color)).to.have.length(1);
-                expect(dataTableRow.find(Color).props().value).to.equal('#FF35CC');
-
-            });
-        });
-
-        describe('complex values with names', () => {
-            it('should render the displayName property of the value if it has one', () => {
-                dataTableRowProps.columns = ['user'];
-                dataTableRowProps.dataSource.user = {
-                    displayName: 'Mark',
-                };
-
-                dataTableRow = renderComponent(dataTableRowProps).find('.data-table__rows__row__column').first();
-
-                expect(dataTableRow.text()).to.equal('Mark');
-            });
-
-            it('should render the name propery of the value if the displayName property is not there', () => {
-                dataTableRowProps.columns = ['user'];
-                dataTableRowProps.dataSource.user = {
-                    name: 'Mark',
-                };
-
-                dataTableRow = renderComponent(dataTableRowProps).find('.data-table__rows__row__column').first();
-
-                expect(dataTableRow.text()).to.equal('Mark');
-            });
-
-            it('should render the object if there is no name or displayName property', () => {
-                dataTableRowProps.columns = ['user'];
-                dataTableRowProps.dataSource.user = {
-                    access: 'all',
-                    id: 'id',
-                };
-
-                dataTableRow = renderComponent(dataTableRowProps).find('.data-table__rows__row__column').first();
-
-                expect(dataTableRow.text()).to.equal('[object Object]');
-            });
-
-            it('should use the objects toString method if it has one', () => {
-                dataTableRowProps.columns = ['user'];
-                dataTableRowProps.dataSource.user = {
-                    access: 'all',
-                    id: 'id',
-                    toString() {
-                        return 'access: all, id: id';
-                    },
-                };
-
-                dataTableRow = renderComponent(dataTableRowProps).find('.data-table__rows__row__column').first();
-
-                expect(dataTableRow.text()).to.equal('access: all, id: id');
-            });
-        });
+        expect(contextClickCallback).to.be.called;
+        expect(contextClickCallback.getCall(0).args[1]).to.equal(dataElement);
     });
 });

--- a/test/data-table/dataTableValueRenderers.test.js
+++ b/test/data-table/dataTableValueRenderers.test.js
@@ -1,0 +1,184 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import DataTableRow from '../../src/data-table/DataTableRow.component';
+import Color from '../../src/data-table/data-value/Color.component';
+import Translate from '../../src/i18n/Translate.component';
+import { findValueRenderer, addValueRenderer } from '../../src/data-table/data-value/valueRenderers';
+
+describe('dataTableValueRenderers', () => {
+    describe('publicAccess', () => {
+        it('should find the correct renderer', () => {
+            const PublicAccessRenderer = findValueRenderer({ value: 'r-------', columnName: 'publicAccess' });
+            const renderedComponent = shallow(<PublicAccessRenderer value="r-------" />);
+
+            expect(renderedComponent.find(Translate)).to.have.length(1);
+        });
+
+        it('should render the r------- publicAccess pattern to its correct text value', () => {
+            const PublicAccessRenderer = findValueRenderer({ value: 'r-------', columnName: 'publicAccess' });
+            const renderedComponent = shallow(<PublicAccessRenderer value="r-------" />);
+
+            expect(renderedComponent.find(Translate).prop('children')).to.equal('public_can_view');
+        });
+
+        it('should render the rw------ publicAccess pattern to its correct text value', () => {
+            const PublicAccessRenderer = findValueRenderer({ value: 'rw------', columnName: 'publicAccess' });
+            const renderedComponent = shallow(<PublicAccessRenderer value="rw------" />);
+
+            expect(renderedComponent.find(Translate).prop('children')).to.equal('public_can_edit');
+        });
+
+        it('should render the -------- publicAccess pattern to its correct text value', () => {
+            const PublicAccessRenderer = findValueRenderer({ value: '--------', columnName: 'publicAccess' });
+            const renderedComponent = shallow(<PublicAccessRenderer value="--------" />);
+
+            expect(renderedComponent.find(Translate).prop('children')).to.equal('public_none');
+        });
+
+        it('should not transform an unknown publicAccess pattern', () => {
+            const PublicAccessRenderer = findValueRenderer({ value: 'rwx-----', columnName: 'publicAccess' });
+            const renderedComponent = shallow(<PublicAccessRenderer value="rwx-----" />);
+
+            expect(renderedComponent.find('TextValue').prop('value')).to.equal('rwx-----');
+        });
+
+        it('should not transform an empty value', () => {
+            const PublicAccessRenderer = findValueRenderer({ value: '', columnName: 'publicAccess' });
+            const renderedComponent = shallow(<PublicAccessRenderer value="" />);
+
+            expect(renderedComponent.find('TextValue').prop('value')).to.equal('');
+        });
+    });
+
+    describe('DATE valueType', () => {
+        const renderOptions = {
+            context: { 
+                d2: {
+                    currentUser: {
+                        uiLocale: 'en',
+                    },
+                },
+            },
+        };
+
+        it('should find the correct renderer', () => {
+            const DateValueRenderer = findValueRenderer({ value: '2016-02-18T11:21:32.992', columnName: 'lastUpdated', valueType: 'DATE' });
+            const renderedComponent = shallow(<DateValueRenderer value="2016-02-18T11:21:32.992" />, renderOptions);
+
+            expect(renderedComponent.find('TextValue')).to.have.length(1);
+        });
+
+        it('should render the the date using Intl', () => {
+            const DateValueRenderer = findValueRenderer({ value: '2016-02-18T11:21:32.992', columnName: 'lastUpdated', valueType: 'DATE' });
+            const renderedComponent = shallow(<DateValueRenderer value="2016-02-18T11:21:32.992" />, renderOptions);
+
+            expect(renderedComponent.find('TextValue').prop('value')).to.equal('February 18, 2016');
+        });
+
+        it('should render the the date using string replacement when Intl is not defined', () => {
+            const intl = global.Intl;
+            global.Intl = undefined;
+
+            const DateValueRenderer = findValueRenderer({ value: '2016-02-18T11:21:32.992', columnName: 'lastUpdated', valueType: 'DATE' });
+            const renderedComponent = shallow(<DateValueRenderer value="2016-02-18T11:21:32.992" />, renderOptions);
+
+            expect(renderedComponent.find('TextValue').prop('value')).to.equal('2016-02-18 11:21:32');
+            global.Intl = intl;
+        });
+    });
+
+    describe('objects with displayName', () => {
+        it('should find the correct renderer', () => {
+            const ObjectWithDisplayNameRenderer = findValueRenderer({ value: { displayName: 'ANC' }, columnName: 'indicator' });
+            const renderedComponent = shallow(<ObjectWithDisplayNameRenderer value={{ displayName: 'ANC' }} />);
+
+            expect(renderedComponent.find('TextValue')).to.have.length(1);
+        });
+
+        it('should render the text from displayName as the text value', () => {
+            const ObjectWithDisplayNameRenderer = findValueRenderer({ value: { displayName: 'ANC' }, columnName: 'indicator' });
+            const renderedComponent = shallow(<ObjectWithDisplayNameRenderer value={{ displayName: 'ANC' }} />);
+
+            expect(renderedComponent.find('TextValue').prop('value')).to.equal('ANC');
+        });
+
+        it('should fall back to the name property when the displayName does not exist', () => {
+            const ObjectWithDisplayNameRenderer = findValueRenderer({ value: { name: 'ANC' }, columnName: 'indicator' });
+            const renderedComponent = shallow(<ObjectWithDisplayNameRenderer value={{ name: 'ANC' }} />);
+
+            expect(renderedComponent.find('TextValue').prop('value')).to.equal('ANC');
+        });
+
+        it('should not throw when the value is undefined and render an empty span', () => {
+            const ObjectWithDisplayNameRenderer = findValueRenderer({ value: undefined, columnName: 'indicator' });
+            const renderedComponent = shallow(<ObjectWithDisplayNameRenderer value={undefined} />);
+
+            expect(renderedComponent.is('span')).to.be.true;
+            expect(renderedComponent.text()).to.equal('');
+        });
+    });
+
+    describe('color values', () => {
+        it('should find the correct renderer', () => {
+            const ColorRenderer = findValueRenderer({ value: '#FFFDDD', columnName: 'color' });
+
+            expect(ColorRenderer).to.equal(Color)
+        });
+
+        it('should render the value as the text of the Color component', () => {
+            const ColorRenderer = findValueRenderer({ value: '#FFFDDD', columnName: 'color' });
+            const renderedComponent = shallow(<ColorRenderer value="#FFFDDD" />);
+
+            expect(renderedComponent.text()).to.equal('#FFFDDD');
+        });
+
+        it('should render a dark text color for a light color', () => {
+            const ColorRenderer = findValueRenderer({ value: '#FFFDDD', columnName: 'color' });
+            const renderedComponent = shallow(<ColorRenderer value="#FFFDDD" />);
+
+            expect(renderedComponent.prop('style').color).to.equal('#000');
+        });
+
+        it('should render a light text color for a light color', () => {
+            const ColorRenderer = findValueRenderer({ value: '#222222', columnName: 'color' });
+            const renderedComponent = shallow(<ColorRenderer value="#222222" />);
+
+            expect(renderedComponent.prop('style').color).to.equal('#FFF');
+        });
+    });
+
+    describe('addValueRenderer to add custom renderers', () => {
+        const MyComponent = () => (<div />);
+        let checker;
+        let removeRenderer;
+
+        beforeEach(() => {
+            checker = sinon.stub().returns(true);
+            removeRenderer = addValueRenderer(checker, MyComponent);
+        });
+
+        afterEach(() => {
+            removeRenderer();
+        });
+
+        it('should register a new renderer', () => {
+            const Renderer = findValueRenderer({});
+
+            expect(Renderer).to.equal(MyComponent);
+        });
+
+        it('should call the checker to find the renderer', () => {
+            const Renderer = findValueRenderer({});
+
+            expect(checker).to.have.been.called;
+        });
+
+        it('should unregister the renderer when remove is called', () => {
+            removeRenderer();
+
+            const Renderer = findValueRenderer({});
+
+            expect(Renderer).not.to.equal(MyComponent);
+        });
+    });
+});


### PR DESCRIPTION
Specifically related to the date bug (DHIS2-955)
Dates will now be displayed using the Intl.dateFormat (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat)
When this is not available we'll parse the string and display it.

Additionally the rework makes adding custom renderers for values easier.
The old solution required modification of the Row component to be able
to displayer other values. With the new solution addValueRenderer can be used.