### PR TITLE
feature/sharing-dialog: Load shared object only when the dialog is open.

### DIFF
--- a/test/sharing/SharingDialog.component.test.js
+++ b/test/sharing/SharingDialog.component.test.js
@@ -111,7 +111,7 @@ describe('Sharing: SharingDialog component', () => {
             sinon.stub(log, 'warn');
         });
 
-        it('should render when objectToShare is undefined', () => {
+        it('should render when objectToShare is undefined and dialog is open', () => {
             renderComponent({ open: true, onRequestClose: () => {}, type: 'report', id: 'AMERNML55Tg' });
             expect(sharingDialogComponent.find(LoadingMask)).to.have.length(1);
         });


### PR DESCRIPTION
Fixes a bug where the Sharing dialog would load with an invalid id- and type combination when navigating between categories in the maintenance app. Attempting to fetch the shared object only when the dialog is open fixes this problem.