### PR TITLE
Fix broken LocaleSelector component and add tests

### DIFF
--- a/src/i18n/LocaleSelector.component.js
+++ b/src/i18n/LocaleSelector.component.js
@@ -9,10 +9,9 @@ class LocaleSelector extends Component {
 
         const i18n = this.context.d2.i18n;
         this.getTranslation = i18n.getTranslation.bind(i18n);
-        this.onLocaleChange = this.onLocaleChange.bind(this);
     }
 
-    onLocaleChange(event, index, locale) {
+    onLocaleChange = (event, index, locale) => {
         this.setState({
             locale,
         });

--- a/src/i18n/LocaleSelector.component.js
+++ b/src/i18n/LocaleSelector.component.js
@@ -9,19 +9,23 @@ class LocaleSelector extends Component {
 
         const i18n = this.context.d2.i18n;
         this.getTranslation = i18n.getTranslation.bind(i18n);
+        this.onLocaleChange = this.onLocaleChange.bind(this);
+    }
+
+    onLocaleChange(event, index, locale) {
+        this.setState({
+            locale,
+        });
+
+        this.props.onChange(locale, event);
     }
 
     render() {
         const localeMenuItems = [{ payload: '', text: '' }]
             .concat(this.props.locales)
             .map((locale, index) => (
-                <MenuItem
-                    key={index}
-                    primaryText={locale.name}
-                    value={locale.locale}
-                />
+                <MenuItem key={index} primaryText={locale.name} value={locale.locale} />
             ));
-
 
         return (
             <SelectField
@@ -35,22 +39,16 @@ class LocaleSelector extends Component {
             </SelectField>
         );
     }
-
-    onLocaleChange(event, index, locale) {
-        this.setState({
-            locale,
-        });
-
-        this.props.onChange(locale, event);
-    }
 }
 
 LocaleSelector.propTypes = {
     value: PropTypes.string,
-    locales: PropTypes.arrayOf(PropTypes.shape({
-        name: PropTypes.string.isRequired,
-        locale: PropTypes.string.isRequired,
-    })).isRequired,
+    locales: PropTypes.arrayOf(
+        PropTypes.shape({
+            name: PropTypes.string.isRequired,
+            locale: PropTypes.string.isRequired,
+        })
+    ).isRequired,
     onChange: PropTypes.func.isRequired,
 };
 

--- a/src/i18n/TranslationForm.component.js
+++ b/src/i18n/TranslationForm.component.js
@@ -127,13 +127,13 @@ class TranslationForm extends Component {
         }
     }
 
-    setCurrentLocale(locale) {
+    setCurrentLocale = (locale) => {
         this.setState({
             currentSelectedLocale: locale,
         });
     }
 
-    setValue(property, event) {
+    setValue = (property, event) => {
         let newTranslations = [].concat(this.props.translations);
         let translation = newTranslations
             .find(t => t.locale === this.state.currentSelectedLocale && t.property.toLowerCase() === camelCaseToUnderscores(property));
@@ -158,7 +158,7 @@ class TranslationForm extends Component {
         this.props.setTranslations(newTranslations);
     }
 
-    saveTranslations() {
+    saveTranslations = () => {
         saveTranslations(this.props.objectToTranslate, this.props.translations)
             .subscribe(
                 this.props.onTranslationSaved,

--- a/src/i18n/__tests__/LocaleSelector.component.spec.js
+++ b/src/i18n/__tests__/LocaleSelector.component.spec.js
@@ -1,5 +1,50 @@
-import LocaleSelector from '../LocaleSelector.component';
+import React from 'react';
+import { shallow } from 'enzyme';
+import MuiSelectField from 'material-ui/SelectField/SelectField';
+import MenuItem from 'material-ui/MenuItem';
 
-xdescribe('LocaleSelector component', () => {
-    it('has no tests');
+import LocaleSelector from '../LocaleSelector.component';
+import { getStubContext } from '../../../config/inject-theme';
+
+describe('LocaleSelector component', () => {
+    let Component;
+    let locales;
+    let onChangeLocaleSpy;
+
+    beforeEach(() => {
+        onChangeLocaleSpy = jest.fn();
+
+        locales = [{ locale: 'elf', name: 'Elfish' }, { locale: 'noren', name: 'Norglish' }];
+
+        Component = shallow(<LocaleSelector locales={locales} onChange={onChangeLocaleSpy} />, {
+            context: getStubContext(),
+        });
+    });
+
+    it('should render a MuiSelectField component', () => {
+        expect(Component.type()).toBe(MuiSelectField);
+    });
+
+    it('should render items array as menu items', () => {
+        expect(Component.contains(<MenuItem value="elf" primaryText="Elfish" />)).toBe(true);
+    });
+
+    it('should render list of items with length 1 greater than the passed in list', () => {
+        expect(Component.children()).toHaveLength(locales.length + 1);
+    });
+
+    it('should call onChange function when field content is changed', () => {
+        Component.simulate('change', {}, 6, 'noren');
+
+        expect(onChangeLocaleSpy).toHaveBeenCalled();
+        expect(onChangeLocaleSpy.mock.calls[0][0]).toBe('noren');
+    });
+
+    it('should change the local state when field content is changed', () => {
+        expect(Component.state()).toBeNull();
+
+        Component.simulate('change', {}, 6, 'noren');
+
+        expect(Component.state().locale).toEqual('noren');
+    });
 });

--- a/src/i18n/__tests__/LocaleSelector.component.spec.js
+++ b/src/i18n/__tests__/LocaleSelector.component.spec.js
@@ -31,7 +31,7 @@ describe('LocaleSelector component', () => {
     });
 
     it('should call onChange function when field content is changed', () => {
-        Component.simulate('change', {}, 6, 'noren');
+        Component.simulate('change', {}, 2, 'noren');
 
         expect(onChangeLocaleSpy).toHaveBeenCalled();
         expect(onChangeLocaleSpy.mock.calls[0][0]).toBe('noren');
@@ -40,7 +40,7 @@ describe('LocaleSelector component', () => {
     it('should change the local state when field content is changed', () => {
         expect(Component.state()).toBeNull();
 
-        Component.simulate('change', {}, 6, 'noren');
+        Component.simulate('change', {}, 2, 'noren');
 
         expect(Component.state().locale).toEqual('noren');
     });

--- a/src/i18n/__tests__/LocaleSelector.component.spec.js
+++ b/src/i18n/__tests__/LocaleSelector.component.spec.js
@@ -8,14 +8,11 @@ import { getStubContext } from '../../../config/inject-theme';
 
 describe('LocaleSelector component', () => {
     let Component;
-    let locales;
     let onChangeLocaleSpy;
+    const locales = [{ locale: 'elf', name: 'Elfish' }, { locale: 'noren', name: 'Norglish' }];
 
     beforeEach(() => {
         onChangeLocaleSpy = jest.fn();
-
-        locales = [{ locale: 'elf', name: 'Elfish' }, { locale: 'noren', name: 'Norglish' }];
-
         Component = shallow(<LocaleSelector locales={locales} onChange={onChangeLocaleSpy} />, {
             context: getStubContext(),
         });


### PR DESCRIPTION
Changing from React.createClass to class x extends Component means that the component (non-lifecycle) methods need to explicitly bind 'this'.

There were no unit tests for for this component. Unit tests are now added and they would catch the error that has been fixed in this commit.