### PR TITLE
Task/prefer svgicon in sharing

### DIFF
--- a/examples/svg-icon/index.js
+++ b/examples/svg-icon/index.js
@@ -32,12 +32,108 @@ const icons = (
                 <SvgIcon />
             </div>
             <div style={cardStyle}>
+                <h3>Icon with custom defined path</h3>
+                <SvgIcon>{children}</SvgIcon>
+            </div>
+            <div style={cardStyle}>
                 <h3>Icon not found</h3>
                 <SvgIcon icon={'DoesntExist'} />
             </div>
             <div style={cardStyle}>
-                <h3>Icon with custom defined path</h3>
-                <SvgIcon>{children}</SvgIcon>
+                <h3>Add</h3>
+                <SvgIcon icon={'Add'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>ArrowDownward</h3>
+                <SvgIcon icon={'ArrowDownward'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>ArrowDropRight</h3>
+                <SvgIcon icon={'ArrowDropRight'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>ArrowUpward</h3>
+                <SvgIcon icon={'ArrowUpward'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>Business</h3>
+                <SvgIcon icon={'Business'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>Cancel</h3>
+                <SvgIcon icon={'Cancel'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>ChevronLeft</h3>
+                <SvgIcon icon={'ChevronLeft'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>ChevronRight</h3>
+                <SvgIcon icon={'ChevronRight'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>Close</h3>
+                <SvgIcon icon={'Close'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>Create</h3>
+                <SvgIcon icon={'Create'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>Delete</h3>
+                <SvgIcon icon={'Delete'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>Done</h3>
+                <SvgIcon icon={'Done'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>DragHandle</h3>
+                <SvgIcon icon={'DragHandle'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>GridOn</h3>
+                <SvgIcon icon={'GridOn'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>Group</h3>
+                <SvgIcon icon={'Group'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>InfoOutline</h3>
+                <SvgIcon icon={'InfoOutline'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>InsertChart</h3>
+                <SvgIcon icon={'InsertChart'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>Message</h3>
+                <SvgIcon icon={'Message'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>MoreVert</h3>
+                <SvgIcon icon={'MoreVert'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>NotInterested</h3>
+                <SvgIcon icon={'NotInterested'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>Person</h3>
+                <SvgIcon icon={'Person'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>Public</h3>
+                <SvgIcon icon={'Public'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>Room</h3>
+                <SvgIcon icon={'Room'} />
+            </div>
+            <div style={cardStyle}>
+                <h3>ShowChart</h3>
+                <SvgIcon icon={'ShowChart'} />
             </div>
             <div style={cardStyle}>
                 <h3>Disabled icon</h3>
@@ -56,52 +152,8 @@ const icons = (
                 <SvgIcon icon={'StarBorder'} />
             </div>
             <div style={cardStyle}>
-                <h3>ArrowDropRight</h3>
-                <SvgIcon icon={'ArrowDropRight'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>Close</h3>
-                <SvgIcon icon={'Close'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>ArrowUpward</h3>
-                <SvgIcon icon={'ArrowUpward'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>ArrowDownward</h3>
-                <SvgIcon icon={'ArrowDownward'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>ChevronLeft</h3>
-                <SvgIcon icon={'ChevronLeft'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>ChevronRight</h3>
-                <SvgIcon icon={'ChevronRight'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>MoreVert</h3>
-                <SvgIcon icon={'MoreVert'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>Cancel</h3>
-                <SvgIcon icon={'Cancel'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>InfoOutline</h3>
-                <SvgIcon icon={'InfoOutline'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>Room</h3>
-                <SvgIcon icon={'Room'} />
-            </div>
-            <div style={cardStyle}>
                 <h3>ViewList</h3>
                 <SvgIcon icon={'ViewList'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>Delete</h3>
-                <SvgIcon icon={'Delete'} />
             </div>
             <div style={cardStyle}>
                 <h3>Visibility</h3>
@@ -110,34 +162,6 @@ const icons = (
             <div style={cardStyle}>
                 <h3>VisibilityOff</h3>
                 <SvgIcon icon={'VisibilityOff'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>Create</h3>
-                <SvgIcon icon={'Create'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>DragHandle</h3>
-                <SvgIcon icon={'DragHandle'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>GridOn</h3>
-                <SvgIcon icon={'GridOn'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>ShowChart</h3>
-                <SvgIcon icon={'ShowChart'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>InsertChart</h3>
-                <SvgIcon icon={'InsertChart'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>Public</h3>
-                <SvgIcon icon={'Public'} />
-            </div>
-            <div style={cardStyle}>
-                <h3>Message</h3>
-                <SvgIcon icon={'Message'} />
             </div>
         </div>
     </MuiThemeProvider>

--- a/src/sharing/Access.component.js
+++ b/src/sharing/Access.component.js
@@ -1,61 +1,63 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import { compose, mapProps, getContext, withProps } from 'recompose';
-import FontIcon from 'material-ui/FontIcon';
-import { config } from 'd2/lib/d2';
-import IconButton from 'material-ui/IconButton';
+import PropTypes from "prop-types";
+import React from "react";
+import { compose, mapProps, getContext, withProps } from "recompose";
+import { config } from "d2/lib/d2";
+import IconButton from "material-ui/IconButton";
+import SvgIcon from "../svg-icon/SvgIcon";
 
-import PermissionPicker from './PermissionPicker.component';
+import PermissionPicker from "./PermissionPicker.component";
 
-import {
-    accessStringToObject,
-    accessObjectToString,
-} from './utils';
+import { accessStringToObject, accessObjectToString } from "./utils";
 
-config.i18n.strings.add('public_access');
-config.i18n.strings.add('external_access');
-config.i18n.strings.add('anyone_can_view_without_a_login');
-config.i18n.strings.add('anyone_can_find_view_and_edit');
-config.i18n.strings.add('anyone_can_find_and_view');
-config.i18n.strings.add('no_access');
+config.i18n.strings.add("public_access");
+config.i18n.strings.add("external_access");
+config.i18n.strings.add("anyone_can_view_without_a_login");
+config.i18n.strings.add("anyone_can_find_view_and_edit");
+config.i18n.strings.add("anyone_can_find_and_view");
+config.i18n.strings.add("no_access");
 
 const styles = {
     accessView: {
-        fontWeight: '400',
-        display: 'flex',
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        padding: '4px 8px',
+        fontWeight: "400",
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+        padding: "4px 8px"
     },
     accessDescription: {
-        display: 'flex',
-        flexDirection: 'column',
+        display: "flex",
+        flexDirection: "column",
         flex: 1,
-        paddingLeft: 16,
-    },
+        paddingLeft: 16
+    }
 };
 
 const d2Context = {
-    d2: PropTypes.object.isRequired,
+    d2: PropTypes.object.isRequired
 };
 
-const getAccessIcon = (userType) => {
+const getAccessIcon = userType => {
     switch (userType) {
-    case 'user': return 'person';
-    case 'userGroup': return 'group';
-    case 'external': return 'public';
-    case 'public': return 'business';
-    default: return 'person';
+        case "user":
+            return "Person";
+        case "userGroup":
+            return "Group";
+        case "external":
+            return "Public";
+        case "public":
+            return "Business";
+        default:
+            return "Person";
     }
 };
 
 const useAccessObjectFormat = props => ({
     ...props,
     access: accessStringToObject(props.access),
-    onChange: (newAccess) => {
+    onChange: newAccess => {
         props.onChange(accessObjectToString(newAccess));
-    },
+    }
 });
 
 export const Access = ({
@@ -66,30 +68,29 @@ export const Access = ({
     secondaryText,
     onChange,
     onRemove,
-    disabled,
+    disabled
 }) => (
     <div style={styles.accessView}>
-        <FontIcon className="material-icons">
-            {getAccessIcon(accessType)}
-        </FontIcon>
+        <SvgIcon icon={getAccessIcon(accessType)} />
         <div style={styles.accessDescription}>
             <div>{primaryText}</div>
-            <div style={{ color: '#818181', paddingTop: 4 }}>{secondaryText || ' '}</div>
+            <div style={{ color: "#818181", paddingTop: 4 }}>
+                {secondaryText || " "}
+            </div>
         </div>
-
         <PermissionPicker
             access={access}
             accessOptions={accessOptions}
             onChange={onChange}
             disabled={disabled}
         />
-
         <IconButton
             disabled={!onRemove}
-            iconStyle={{ color: '#bbbbbb' }}
-            iconClassName="material-icons"
+            iconStyle={{ color: "#bbbbbb" }}
             onClick={onRemove || (() => {})}
-        >clear</IconButton>
+        >
+            <SvgIcon icon="Clear" />
+        </IconButton>
     </div>
 );
 
@@ -103,13 +104,13 @@ Access.propTypes = {
     onChange: PropTypes.func.isRequired,
     disabled: PropTypes.bool,
     secondaryText: PropTypes.string,
-    onRemove: PropTypes.func,
+    onRemove: PropTypes.func
 };
 
 Access.defaultProps = {
     secondaryText: undefined,
     onRemove: undefined,
-    disabled: false,
+    disabled: false
 };
 
 export const GroupAccess = compose(
@@ -119,52 +120,60 @@ export const GroupAccess = compose(
         primaryText: props.groupName,
         accessOptions: {
             meta: { canView: true, canEdit: true, noAccess: false },
-            data: props.dataShareable && { canView: true, canEdit: true, noAccess: true },
-        },
-    })),
+            data: props.dataShareable && {
+                canView: true,
+                canEdit: true,
+                noAccess: true
+            }
+        }
+    }))
 )(Access);
 
 export const ExternalAccess = compose(
     getContext(d2Context),
     withProps(props => ({
-        accessType: 'external',
-        primaryText: props.d2.i18n.getTranslation('external_access'),
+        accessType: "external",
+        primaryText: props.d2.i18n.getTranslation("external_access"),
         secondaryText: props.access
-            ? props.d2.i18n.getTranslation('anyone_can_view_without_a_login')
-            : props.d2.i18n.getTranslation('no_access'),
+            ? props.d2.i18n.getTranslation("anyone_can_view_without_a_login")
+            : props.d2.i18n.getTranslation("no_access"),
         access: {
             meta: { canEdit: false, canView: props.access },
-            data: { canEdit: false, canView: false },
+            data: { canEdit: false, canView: false }
         },
-        onChange: (newAccess) => {
+        onChange: newAccess => {
             props.onChange(newAccess.meta.canView);
         },
         accessOptions: {
-            meta: { canView: true, canEdit: false, noAccess: true },
-        },
-    })),
+            meta: { canView: true, canEdit: false, noAccess: true }
+        }
+    }))
 )(Access);
 
 const constructSecondaryText = ({ canView, canEdit }) => {
     if (canEdit) {
-        return 'anyone_can_find_view_and_edit';
+        return "anyone_can_find_view_and_edit";
     }
 
-    return canView
-        ? 'anyone_can_find_and_view'
-        : 'no_access';
+    return canView ? "anyone_can_find_and_view" : "no_access";
 };
 
 export const PublicAccess = compose(
     mapProps(useAccessObjectFormat),
     getContext(d2Context),
     withProps(props => ({
-        accessType: 'public',
-        primaryText: props.d2.i18n.getTranslation('public_access'),
-        secondaryText: props.d2.i18n.getTranslation(constructSecondaryText(props.access.meta)),
+        accessType: "public",
+        primaryText: props.d2.i18n.getTranslation("public_access"),
+        secondaryText: props.d2.i18n.getTranslation(
+            constructSecondaryText(props.access.meta)
+        ),
         accessOptions: {
             meta: { canView: true, canEdit: true, noAccess: true },
-            data: props.dataShareable && { canView: true, canEdit: true, noAccess: true },
-        },
-    })),
+            data: props.dataShareable && {
+                canView: true,
+                canEdit: true,
+                noAccess: true
+            }
+        }
+    }))
 )(Access);

--- a/src/sharing/Access.component.js
+++ b/src/sharing/Access.component.js
@@ -1,54 +1,54 @@
-import PropTypes from "prop-types";
-import React from "react";
-import { compose, mapProps, getContext, withProps } from "recompose";
-import { config } from "d2/lib/d2";
-import IconButton from "material-ui/IconButton";
-import SvgIcon from "../svg-icon/SvgIcon";
+import PropTypes from 'prop-types';
+import React from 'react';
+import { compose, mapProps, getContext, withProps } from 'recompose';
+import { config } from 'd2/lib/d2';
+import IconButton from 'material-ui/IconButton';
+import SvgIcon from '../svg-icon/SvgIcon';
 
-import PermissionPicker from "./PermissionPicker.component";
+import PermissionPicker from './PermissionPicker.component';
 
-import { accessStringToObject, accessObjectToString } from "./utils";
+import { accessStringToObject, accessObjectToString } from './utils';
 
-config.i18n.strings.add("public_access");
-config.i18n.strings.add("external_access");
-config.i18n.strings.add("anyone_can_view_without_a_login");
-config.i18n.strings.add("anyone_can_find_view_and_edit");
-config.i18n.strings.add("anyone_can_find_and_view");
-config.i18n.strings.add("no_access");
+config.i18n.strings.add('public_access');
+config.i18n.strings.add('external_access');
+config.i18n.strings.add('anyone_can_view_without_a_login');
+config.i18n.strings.add('anyone_can_find_view_and_edit');
+config.i18n.strings.add('anyone_can_find_and_view');
+config.i18n.strings.add('no_access');
 
 const styles = {
     accessView: {
-        fontWeight: "400",
-        display: "flex",
-        flexDirection: "row",
-        justifyContent: "space-between",
-        alignItems: "center",
-        padding: "4px 8px"
+        fontWeight: '400',
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '4px 8px',
     },
     accessDescription: {
-        display: "flex",
-        flexDirection: "column",
+        display: 'flex',
+        flexDirection: 'column',
         flex: 1,
-        paddingLeft: 16
-    }
+        paddingLeft: 16,
+    },
 };
 
 const d2Context = {
-    d2: PropTypes.object.isRequired
+    d2: PropTypes.object.isRequired,
 };
 
 const getAccessIcon = userType => {
     switch (userType) {
-        case "user":
-            return "Person";
-        case "userGroup":
-            return "Group";
-        case "external":
-            return "Public";
-        case "public":
-            return "Business";
+        case 'user':
+            return 'Person';
+        case 'userGroup':
+            return 'Group';
+        case 'external':
+            return 'Public';
+        case 'public':
+            return 'Business';
         default:
-            return "Person";
+            return 'Person';
     }
 };
 
@@ -57,7 +57,7 @@ const useAccessObjectFormat = props => ({
     access: accessStringToObject(props.access),
     onChange: newAccess => {
         props.onChange(accessObjectToString(newAccess));
-    }
+    },
 });
 
 export const Access = ({
@@ -68,14 +68,14 @@ export const Access = ({
     secondaryText,
     onChange,
     onRemove,
-    disabled
+    disabled,
 }) => (
     <div style={styles.accessView}>
         <SvgIcon icon={getAccessIcon(accessType)} />
         <div style={styles.accessDescription}>
             <div>{primaryText}</div>
-            <div style={{ color: "#818181", paddingTop: 4 }}>
-                {secondaryText || " "}
+            <div style={{ color: '#818181', paddingTop: 4 }}>
+                {secondaryText || ' '}
             </div>
         </div>
         <PermissionPicker
@@ -86,7 +86,7 @@ export const Access = ({
         />
         <IconButton
             disabled={!onRemove}
-            iconStyle={{ color: "#bbbbbb" }}
+            iconStyle={{ color: '#bbbbbb' }}
             onClick={onRemove || (() => {})}
         >
             <SvgIcon icon="Clear" />
@@ -104,13 +104,13 @@ Access.propTypes = {
     onChange: PropTypes.func.isRequired,
     disabled: PropTypes.bool,
     secondaryText: PropTypes.string,
-    onRemove: PropTypes.func
+    onRemove: PropTypes.func,
 };
 
 Access.defaultProps = {
     secondaryText: undefined,
     onRemove: undefined,
-    disabled: false
+    disabled: false,
 };
 
 export const GroupAccess = compose(
@@ -123,47 +123,47 @@ export const GroupAccess = compose(
             data: props.dataShareable && {
                 canView: true,
                 canEdit: true,
-                noAccess: true
-            }
-        }
+                noAccess: true,
+            },
+        },
     }))
 )(Access);
 
 export const ExternalAccess = compose(
     getContext(d2Context),
     withProps(props => ({
-        accessType: "external",
-        primaryText: props.d2.i18n.getTranslation("external_access"),
+        accessType: 'external',
+        primaryText: props.d2.i18n.getTranslation('external_access'),
         secondaryText: props.access
-            ? props.d2.i18n.getTranslation("anyone_can_view_without_a_login")
-            : props.d2.i18n.getTranslation("no_access"),
+            ? props.d2.i18n.getTranslation('anyone_can_view_without_a_login')
+            : props.d2.i18n.getTranslation('no_access'),
         access: {
             meta: { canEdit: false, canView: props.access },
-            data: { canEdit: false, canView: false }
+            data: { canEdit: false, canView: false },
         },
         onChange: newAccess => {
             props.onChange(newAccess.meta.canView);
         },
         accessOptions: {
-            meta: { canView: true, canEdit: false, noAccess: true }
-        }
+            meta: { canView: true, canEdit: false, noAccess: true },
+        },
     }))
 )(Access);
 
 const constructSecondaryText = ({ canView, canEdit }) => {
     if (canEdit) {
-        return "anyone_can_find_view_and_edit";
+        return 'anyone_can_find_view_and_edit';
     }
 
-    return canView ? "anyone_can_find_and_view" : "no_access";
+    return canView ? 'anyone_can_find_and_view' : 'no_access';
 };
 
 export const PublicAccess = compose(
     mapProps(useAccessObjectFormat),
     getContext(d2Context),
     withProps(props => ({
-        accessType: "public",
-        primaryText: props.d2.i18n.getTranslation("public_access"),
+        accessType: 'public',
+        primaryText: props.d2.i18n.getTranslation('public_access'),
         secondaryText: props.d2.i18n.getTranslation(
             constructSecondaryText(props.access.meta)
         ),
@@ -172,8 +172,8 @@ export const PublicAccess = compose(
             data: props.dataShareable && {
                 canView: true,
                 canEdit: true,
-                noAccess: true
-            }
-        }
+                noAccess: true,
+            },
+        },
     }))
 )(Access);

--- a/src/sharing/PermissionOption.component.js
+++ b/src/sharing/PermissionOption.component.js
@@ -1,7 +1,7 @@
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import FontIcon from 'material-ui/FontIcon';
-import MenuItem from 'material-ui/MenuItem';
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import SvgIcon from "../svg-icon/SvgIcon";
+import MenuItem from "material-ui/MenuItem";
 
 class PermissionOption extends Component {
     ref = null;
@@ -15,9 +15,7 @@ class PermissionOption extends Component {
             <MenuItem
                 insetChildren
                 leftIcon={
-                    <FontIcon className="material-icons">
-                        {this.props.isSelected ? 'done' : ''}
-                    </FontIcon>
+                    this.props.isSelected ? <SvgIcon icon="Done" /> : undefined
                 }
                 primaryText={this.props.primaryText}
                 value={this.props.value}
@@ -26,7 +24,7 @@ class PermissionOption extends Component {
                 focusState={this.props.focusState}
             />
         );
-    }
+    };
 }
 
 PermissionOption.propTypes = {
@@ -35,13 +33,13 @@ PermissionOption.propTypes = {
     primaryText: PropTypes.string.isRequired,
     value: PropTypes.object.isRequired,
     onClick: PropTypes.func,
-    focusState: PropTypes.string,
+    focusState: PropTypes.string
 };
 
 PermissionOption.defaultProps = {
     onClick: undefined,
-    focusState: 'none',
+    focusState: "none"
 };
 
-PermissionOption.muiName = 'MenuItem';
+PermissionOption.muiName = "MenuItem";
 export default PermissionOption;

--- a/src/sharing/PermissionOption.component.js
+++ b/src/sharing/PermissionOption.component.js
@@ -1,7 +1,7 @@
-import PropTypes from "prop-types";
-import React, { Component } from "react";
-import SvgIcon from "../svg-icon/SvgIcon";
-import MenuItem from "material-ui/MenuItem";
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import SvgIcon from '../svg-icon/SvgIcon';
+import MenuItem from 'material-ui/MenuItem';
 
 class PermissionOption extends Component {
     ref = null;
@@ -33,13 +33,13 @@ PermissionOption.propTypes = {
     primaryText: PropTypes.string.isRequired,
     value: PropTypes.object.isRequired,
     onClick: PropTypes.func,
-    focusState: PropTypes.string
+    focusState: PropTypes.string,
 };
 
 PermissionOption.defaultProps = {
     onClick: undefined,
-    focusState: "none"
+    focusState: 'none',
 };
 
-PermissionOption.muiName = "MenuItem";
+PermissionOption.muiName = 'MenuItem';
 export default PermissionOption;

--- a/src/sharing/PermissionPicker.component.js
+++ b/src/sharing/PermissionPicker.component.js
@@ -31,7 +31,7 @@ const getAccessIcon = metaAccess => {
         return 'Create';
     }
 
-    return metaAccess.canView ? 'RemoveRedEye' : 'NotInterested';
+    return metaAccess.canView ? 'Visibility' : 'NotInterested';
 };
 
 class PermissionPicker extends Component {

--- a/src/sharing/PermissionPicker.component.js
+++ b/src/sharing/PermissionPicker.component.js
@@ -1,48 +1,48 @@
 /* eslint react/jsx-no-bind: 0 */
 
-import PropTypes from "prop-types";
-import React, { Component } from "react";
-import IconButton from "material-ui/IconButton";
-import Divider from "material-ui/Divider";
-import Popover from "material-ui/Popover";
-import Menu from "material-ui/Menu";
-import { config } from "d2/lib/d2";
-import SvgIcon from "../svg-icon/SvgIcon";
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import IconButton from 'material-ui/IconButton';
+import Divider from 'material-ui/Divider';
+import Popover from 'material-ui/Popover';
+import Menu from 'material-ui/Menu';
+import { config } from 'd2/lib/d2';
+import SvgIcon from '../svg-icon/SvgIcon';
 
-import PermissionOption from "./PermissionOption.component";
+import PermissionOption from './PermissionOption.component';
 
-config.i18n.strings.add("can_edit_and_view");
-config.i18n.strings.add("can_capture_data");
-config.i18n.strings.add("can_view_data");
-config.i18n.strings.add("can_view_only");
-config.i18n.strings.add("no_access");
+config.i18n.strings.add('can_edit_and_view');
+config.i18n.strings.add('can_capture_data');
+config.i18n.strings.add('can_view_data');
+config.i18n.strings.add('can_view_only');
+config.i18n.strings.add('no_access');
 
 const styles = {
     optionHeader: {
         paddingLeft: 16,
         paddingTop: 16,
-        fontWeight: "400",
-        color: "gray"
-    }
+        fontWeight: '400',
+        color: 'gray',
+    },
 };
 
 const getAccessIcon = metaAccess => {
     if (metaAccess.canEdit) {
-        return "Create";
+        return 'Create';
     }
 
-    return metaAccess.canView ? "RemoveRedEye" : "NotInterested";
+    return metaAccess.canView ? 'RemoveRedEye' : 'NotInterested';
 };
 
 class PermissionPicker extends Component {
     state = {
-        open: false
+        open: false,
     };
 
     onOptionClick = (event, menuItem) => {
         const newAccess = {
             ...this.props.access,
-            ...menuItem.props.value
+            ...menuItem.props.value,
         };
 
         this.props.onChange(newAccess);
@@ -52,13 +52,13 @@ class PermissionPicker extends Component {
         event.preventDefault();
         this.setState({
             open: true,
-            anchor: event.currentTarget
+            anchor: event.currentTarget,
         });
     };
 
     closeMenu = () => {
         this.setState({
-            open: false
+            open: false,
         });
     };
 
@@ -68,7 +68,7 @@ class PermissionPicker extends Component {
         const { data, meta } = this.props.access;
         const {
             data: dataOptions,
-            meta: metaOptions
+            meta: metaOptions,
         } = this.props.accessOptions;
 
         return (
@@ -84,24 +84,24 @@ class PermissionPicker extends Component {
                     anchorEl={this.state.anchor}
                     onRequestClose={this.closeMenu}
                 >
-                    <OptionHeader text={this.translate("metadata")} />
+                    <OptionHeader text={this.translate('metadata')} />
                     <Menu onItemTouchTap={this.onOptionClick}>
                         <PermissionOption
                             disabled={!metaOptions.canEdit}
                             value={{ meta: { canView: true, canEdit: true } }}
-                            primaryText={this.translate("can_edit_and_view")}
+                            primaryText={this.translate('can_edit_and_view')}
                             isSelected={meta.canEdit}
                         />
                         <PermissionOption
                             disabled={!metaOptions.canView}
                             value={{ meta: { canView: true, canEdit: false } }}
-                            primaryText={this.translate("can_view_only")}
+                            primaryText={this.translate('can_view_only')}
                             isSelected={!meta.canEdit && meta.canView}
                         />
                         <PermissionOption
                             disabled={!metaOptions.noAccess}
                             value={{ meta: { canView: false, canEdit: false } }}
-                            primaryText={this.translate("no_access")}
+                            primaryText={this.translate('no_access')}
                             isSelected={!meta.canEdit && !meta.canView}
                         />
                     </Menu>
@@ -109,34 +109,37 @@ class PermissionPicker extends Component {
 
                     {dataOptions && (
                         <div>
-                            <OptionHeader text={this.translate("data")} />
+                            <OptionHeader text={this.translate('data')} />
                             <Menu onItemTouchTap={this.onOptionClick}>
                                 <PermissionOption
                                     disabled={!dataOptions.canEdit}
                                     value={{
-                                        data: { canView: true, canEdit: true }
+                                        data: { canView: true, canEdit: true },
                                     }}
                                     primaryText={this.translate(
-                                        "can_capture_data"
+                                        'can_capture_data'
                                     )}
                                     isSelected={data.canEdit}
                                 />
                                 <PermissionOption
                                     disabled={!dataOptions.canView}
                                     value={{
-                                        data: { canView: true, canEdit: false }
+                                        data: { canView: true, canEdit: false },
                                     }}
                                     primaryText={this.translate(
-                                        "can_view_data"
+                                        'can_view_data'
                                     )}
                                     isSelected={!data.canEdit && data.canView}
                                 />
                                 <PermissionOption
                                     disabled={!dataOptions.noAccess}
                                     value={{
-                                        data: { canView: false, canEdit: false }
+                                        data: {
+                                            canView: false,
+                                            canEdit: false,
+                                        },
                                     }}
-                                    primaryText={this.translate("no_access")}
+                                    primaryText={this.translate('no_access')}
                                     isSelected={!data.canEdit && !data.canView}
                                 />
                             </Menu>
@@ -152,15 +155,15 @@ PermissionPicker.propTypes = {
     access: PropTypes.object.isRequired,
     accessOptions: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-    disabled: PropTypes.bool
+    disabled: PropTypes.bool,
 };
 
 PermissionPicker.defaultProps = {
-    disabled: false
+    disabled: false,
 };
 
 PermissionPicker.contextTypes = {
-    d2: PropTypes.object.isRequired
+    d2: PropTypes.object.isRequired,
 };
 
 const OptionHeader = ({ text }) => (
@@ -168,7 +171,7 @@ const OptionHeader = ({ text }) => (
 );
 
 OptionHeader.propTypes = {
-    text: PropTypes.string.isRequired
+    text: PropTypes.string.isRequired,
 };
 
 export default PermissionPicker;

--- a/src/sharing/PermissionPicker.component.js
+++ b/src/sharing/PermissionPicker.component.js
@@ -1,165 +1,174 @@
 /* eslint react/jsx-no-bind: 0 */
 
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import IconButton from 'material-ui/IconButton';
-import Divider from 'material-ui/Divider';
-import Popover from 'material-ui/Popover';
-import Menu from 'material-ui/Menu';
-import { config } from 'd2/lib/d2';
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import IconButton from "material-ui/IconButton";
+import Divider from "material-ui/Divider";
+import Popover from "material-ui/Popover";
+import Menu from "material-ui/Menu";
+import { config } from "d2/lib/d2";
+import SvgIcon from "../svg-icon/SvgIcon";
 
-import PermissionOption from './PermissionOption.component';
+import PermissionOption from "./PermissionOption.component";
 
-config.i18n.strings.add('can_edit_and_view');
-config.i18n.strings.add('can_capture_data');
-config.i18n.strings.add('can_view_data');
-config.i18n.strings.add('can_view_only');
-config.i18n.strings.add('no_access');
+config.i18n.strings.add("can_edit_and_view");
+config.i18n.strings.add("can_capture_data");
+config.i18n.strings.add("can_view_data");
+config.i18n.strings.add("can_view_only");
+config.i18n.strings.add("no_access");
 
 const styles = {
     optionHeader: {
         paddingLeft: 16,
         paddingTop: 16,
-        fontWeight: '400',
-        color: 'gray',
-    },
+        fontWeight: "400",
+        color: "gray"
+    }
 };
 
-const getAccessIcon = (metaAccess) => {
+const getAccessIcon = metaAccess => {
     if (metaAccess.canEdit) {
-        return 'create';
+        return "Create";
     }
 
-    return metaAccess.canView
-        ? 'remove_red_eye'
-        : 'not_interested';
+    return metaAccess.canView ? "RemoveRedEye" : "NotInterested";
 };
 
 class PermissionPicker extends Component {
     state = {
-        open: false,
+        open: false
     };
 
     onOptionClick = (event, menuItem) => {
         const newAccess = {
             ...this.props.access,
-            ...menuItem.props.value,
+            ...menuItem.props.value
         };
 
         this.props.onChange(newAccess);
-    }
+    };
 
-    openMenu = (event) => {
+    openMenu = event => {
         event.preventDefault();
         this.setState({
             open: true,
-            anchor: event.currentTarget,
+            anchor: event.currentTarget
         });
-    }
+    };
 
     closeMenu = () => {
         this.setState({
-            open: false,
+            open: false
         });
-    }
+    };
 
     translate = s => this.context.d2.i18n.getTranslation(s);
 
     render = () => {
         const { data, meta } = this.props.access;
-        const { data: dataOptions, meta: metaOptions } = this.props.accessOptions;
+        const {
+            data: dataOptions,
+            meta: metaOptions
+        } = this.props.accessOptions;
 
         return (
             <div>
                 <IconButton
                     onClick={this.openMenu}
                     disabled={this.props.disabled}
-                    iconClassName="material-icons"
                 >
-                    {getAccessIcon(meta)}
+                    <SvgIcon icon={getAccessIcon(meta)} />
                 </IconButton>
                 <Popover
                     open={this.state.open}
                     anchorEl={this.state.anchor}
                     onRequestClose={this.closeMenu}
                 >
-                    <OptionHeader text={this.translate('metadata')} />
+                    <OptionHeader text={this.translate("metadata")} />
                     <Menu onItemTouchTap={this.onOptionClick}>
                         <PermissionOption
                             disabled={!metaOptions.canEdit}
                             value={{ meta: { canView: true, canEdit: true } }}
-                            primaryText={this.translate('can_edit_and_view')}
+                            primaryText={this.translate("can_edit_and_view")}
                             isSelected={meta.canEdit}
                         />
                         <PermissionOption
                             disabled={!metaOptions.canView}
                             value={{ meta: { canView: true, canEdit: false } }}
-                            primaryText={this.translate('can_view_only')}
+                            primaryText={this.translate("can_view_only")}
                             isSelected={!meta.canEdit && meta.canView}
                         />
                         <PermissionOption
                             disabled={!metaOptions.noAccess}
                             value={{ meta: { canView: false, canEdit: false } }}
-                            primaryText={this.translate('no_access')}
+                            primaryText={this.translate("no_access")}
                             isSelected={!meta.canEdit && !meta.canView}
                         />
                     </Menu>
                     <Divider />
 
-                    { dataOptions &&
+                    {dataOptions && (
                         <div>
-                            <OptionHeader text={this.translate('data')} />
+                            <OptionHeader text={this.translate("data")} />
                             <Menu onItemTouchTap={this.onOptionClick}>
                                 <PermissionOption
                                     disabled={!dataOptions.canEdit}
-                                    value={{ data: { canView: true, canEdit: true } }}
-                                    primaryText={this.translate('can_capture_data')}
+                                    value={{
+                                        data: { canView: true, canEdit: true }
+                                    }}
+                                    primaryText={this.translate(
+                                        "can_capture_data"
+                                    )}
                                     isSelected={data.canEdit}
                                 />
                                 <PermissionOption
                                     disabled={!dataOptions.canView}
-                                    value={{ data: { canView: true, canEdit: false } }}
-                                    primaryText={this.translate('can_view_data')}
+                                    value={{
+                                        data: { canView: true, canEdit: false }
+                                    }}
+                                    primaryText={this.translate(
+                                        "can_view_data"
+                                    )}
                                     isSelected={!data.canEdit && data.canView}
                                 />
                                 <PermissionOption
                                     disabled={!dataOptions.noAccess}
-                                    value={{ data: { canView: false, canEdit: false } }}
-                                    primaryText={this.translate('no_access')}
+                                    value={{
+                                        data: { canView: false, canEdit: false }
+                                    }}
+                                    primaryText={this.translate("no_access")}
                                     isSelected={!data.canEdit && !data.canView}
                                 />
                             </Menu>
                         </div>
-                    }
+                    )}
                 </Popover>
             </div>
         );
-    }
+    };
 }
 
 PermissionPicker.propTypes = {
     access: PropTypes.object.isRequired,
     accessOptions: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-    disabled: PropTypes.bool,
+    disabled: PropTypes.bool
 };
 
 PermissionPicker.defaultProps = {
-    disabled: false,
+    disabled: false
 };
 
 PermissionPicker.contextTypes = {
-    d2: PropTypes.object.isRequired,
+    d2: PropTypes.object.isRequired
 };
 
 const OptionHeader = ({ text }) => (
-    <div style={styles.optionHeader}>
-        {text.toUpperCase()}
-    </div>
+    <div style={styles.optionHeader}>{text.toUpperCase()}</div>
 );
 
 OptionHeader.propTypes = {
-    text: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired
 };
 
 export default PermissionPicker;

--- a/src/sharing/__tests__/Access.component.spec.js
+++ b/src/sharing/__tests__/Access.component.spec.js
@@ -31,7 +31,7 @@ describe('Sharing: Access component', () => {
     renderComponent(accessProps);
 
     it('should render subcomponents', () => {
-        expect(accessComponent.find('SvgIcon')).toHaveLength(1);
+        expect(accessComponent.find('SvgIcon')).toHaveLength(2);
         expect(accessComponent.find('PermissionPicker')).toHaveLength(1);
         expect(accessComponent.find('IconButton')).toHaveLength(1);
     });

--- a/src/sharing/__tests__/Access.component.spec.js
+++ b/src/sharing/__tests__/Access.component.spec.js
@@ -1,42 +1,42 @@
-import React from "react";
-import { shallow } from "enzyme";
-import { Access } from "../Access.component";
-import { getStubContext } from "../../../config/inject-theme";
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Access } from '../Access.component';
+import { getStubContext } from '../../../config/inject-theme';
 
-describe("Sharing: Access component", () => {
+describe('Sharing: Access component', () => {
     let accessComponent;
     const renderComponent = (props = {}) => {
         accessComponent = shallow(<Access {...props} />, {
-            context: getStubContext()
+            context: getStubContext(),
         });
     };
 
     const accessProps = {
         access: {
             data: { canView: true, canEdit: true },
-            meta: { canView: false, canEdit: false }
+            meta: { canView: false, canEdit: false },
         },
         accessOptions: {
             data: { canView: true, canEdit: true, noAccess: true },
-            meta: { canView: true, canEdit: true, noAccess: true }
+            meta: { canView: true, canEdit: true, noAccess: true },
         },
-        accessType: "user",
-        primaryText: "Tom Wakiki",
-        secondaryText: "Some description",
+        accessType: 'user',
+        primaryText: 'Tom Wakiki',
+        secondaryText: 'Some description',
         onChange: () => {},
         onRemove: () => {},
-        disabled: false
+        disabled: false,
     };
 
     renderComponent(accessProps);
 
-    it("should render subcomponents", () => {
-        expect(accessComponent.find("SvgIcon")).toHaveLength(1);
-        expect(accessComponent.find("PermissionPicker")).toHaveLength(1);
-        expect(accessComponent.find("IconButton")).toHaveLength(1);
+    it('should render subcomponents', () => {
+        expect(accessComponent.find('SvgIcon')).toHaveLength(1);
+        expect(accessComponent.find('PermissionPicker')).toHaveLength(1);
+        expect(accessComponent.find('IconButton')).toHaveLength(1);
     });
 
-    it("should show the primary and secondary text", () => {
+    it('should show the primary and secondary text', () => {
         expect(accessComponent.text()).toContain(accessProps.primaryText);
         expect(accessComponent.text()).toContain(accessProps.secondaryText);
     });

--- a/src/sharing/__tests__/Access.component.spec.js
+++ b/src/sharing/__tests__/Access.component.spec.js
@@ -1,42 +1,42 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import { Access } from '../Access.component';
-import { getStubContext } from '../../../config/inject-theme';
+import React from "react";
+import { shallow } from "enzyme";
+import { Access } from "../Access.component";
+import { getStubContext } from "../../../config/inject-theme";
 
-describe('Sharing: Access component', () => {
+describe("Sharing: Access component", () => {
     let accessComponent;
     const renderComponent = (props = {}) => {
         accessComponent = shallow(<Access {...props} />, {
-            context: getStubContext(),
+            context: getStubContext()
         });
     };
 
     const accessProps = {
         access: {
             data: { canView: true, canEdit: true },
-            meta: { canView: false, canEdit: false },
+            meta: { canView: false, canEdit: false }
         },
         accessOptions: {
             data: { canView: true, canEdit: true, noAccess: true },
-            meta: { canView: true, canEdit: true, noAccess: true },
+            meta: { canView: true, canEdit: true, noAccess: true }
         },
-        accessType: 'user',
-        primaryText: 'Tom Wakiki',
-        secondaryText: 'Some description',
+        accessType: "user",
+        primaryText: "Tom Wakiki",
+        secondaryText: "Some description",
         onChange: () => {},
         onRemove: () => {},
-        disabled: false,
+        disabled: false
     };
 
     renderComponent(accessProps);
 
-    it('should render subcomponents', () => {
-        expect(accessComponent.find('FontIcon')).toHaveLength(1);
-        expect(accessComponent.find('PermissionPicker')).toHaveLength(1);
-        expect(accessComponent.find('IconButton')).toHaveLength(1);
+    it("should render subcomponents", () => {
+        expect(accessComponent.find("SvgIcon")).toHaveLength(1);
+        expect(accessComponent.find("PermissionPicker")).toHaveLength(1);
+        expect(accessComponent.find("IconButton")).toHaveLength(1);
     });
 
-    it('should show the primary and secondary text', () => {
+    it("should show the primary and secondary text", () => {
         expect(accessComponent.text()).toContain(accessProps.primaryText);
         expect(accessComponent.text()).toContain(accessProps.secondaryText);
     });

--- a/src/sharing/__tests__/PermissionOption.component.spec.js
+++ b/src/sharing/__tests__/PermissionOption.component.spec.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import MenuItem from 'material-ui/MenuItem';
+import PermissionOption from '../PermissionOption.component';
+import { getStubContext } from '../../../config/inject-theme';
+
+const permissionOptionProps = {
+    disabled: false,
+    isSelected: false,
+    primaryText: 'Test',
+    value: {},
+    onClick: undefined,
+    focusState: 'none',
+};
+
+describe('Sharing: PermissionOption component', () => {
+    let permissionOptionComponent;
+
+    const renderComponent = (props = {}) =>
+        shallow(<PermissionOption {...props} />, {
+            context: getStubContext(),
+        });
+
+    beforeEach(() => {
+        permissionOptionComponent = renderComponent(permissionOptionProps);
+    });
+
+    it('should not render a MenuItem when disabled prop is passed', () => {
+        permissionOptionComponent = renderComponent({
+            ...permissionOptionProps,
+            disabled: true,
+        });
+
+        expect(permissionOptionComponent.find(MenuItem)).toHaveLength(0);
+    });
+
+    it('should render a MenuItem', () => {
+        expect(permissionOptionComponent.find(MenuItem)).toHaveLength(1);
+    });
+
+    it('should render the text according to the primaryText prop', () => {
+        expect(permissionOptionComponent.find(MenuItem).props().primaryText).toEqual(
+            permissionOptionProps.primaryText
+        );
+    });
+
+    it('should set the MenuItem leftIcon prop according to the isSelected prop', () => {
+        expect(permissionOptionComponent.find(MenuItem).props().leftIcon).toBeUndefined();
+
+        permissionOptionComponent = renderComponent({
+            ...permissionOptionProps,
+            isSelected: true,
+        });
+
+        expect(permissionOptionComponent.find(MenuItem).props().leftIcon).not.toBeUndefined();
+    });
+
+    it('should set the value prop', () => {
+        expect(permissionOptionComponent.find(MenuItem).props().value).toEqual(
+            permissionOptionProps.value
+        );
+
+        const newValue = { somekey: 'somevalue' };
+
+        permissionOptionComponent = renderComponent({
+            ...permissionOptionProps,
+            value: newValue,
+        });
+
+        expect(permissionOptionComponent.find(MenuItem).props().value).toEqual(newValue);
+    });
+});

--- a/src/sharing/__tests__/PermissionPicker.component.spec.js
+++ b/src/sharing/__tests__/PermissionPicker.component.spec.js
@@ -1,45 +1,45 @@
-import React from "react";
-import { shallow } from "enzyme";
-import IconButton from "material-ui/IconButton";
-import PermissionOption from "../PermissionOption.component";
-import PermissionPicker from "../PermissionPicker.component";
-import { getStubContext } from "../../../config/inject-theme";
+import React from 'react';
+import { shallow } from 'enzyme';
+import IconButton from 'material-ui/IconButton';
+import PermissionOption from '../PermissionOption.component';
+import PermissionPicker from '../PermissionPicker.component';
+import { getStubContext } from '../../../config/inject-theme';
 
 const permissionPickerProps = {
     access: {
         meta: { canView: true, canEdit: true },
-        data: { canView: true, canEdit: true }
+        data: { canView: true, canEdit: true },
     },
     accessOptions: {
         meta: { canView: true, canEdit: true, noAccess: true },
-        data: { canView: true, canEdit: true, noAccess: true }
+        data: { canView: true, canEdit: true, noAccess: true },
     },
     onChange: () => {},
-    disabled: false
+    disabled: false,
 };
 
-describe("Sharing: PermissionPicker component", () => {
+describe('Sharing: PermissionPicker component', () => {
     let permissionPickerComponent;
 
     const renderComponent = (props = {}) =>
         shallow(<PermissionPicker {...props} />, {
-            context: getStubContext()
+            context: getStubContext(),
         });
 
     beforeEach(() => {
         permissionPickerComponent = renderComponent(permissionPickerProps);
     });
 
-    it("should render an IconButton", () => {
+    it('should render an IconButton', () => {
         expect(permissionPickerComponent.find(IconButton)).toHaveLength(1);
     });
 
-    it("should render three PermissionOptions if no data options, but all metadata options are available", () => {
+    it('should render three PermissionOptions if no data options, but all metadata options are available', () => {
         permissionPickerComponent = renderComponent({
             ...permissionPickerProps,
             accessOptions: {
-                meta: { canView: true, canEdit: true, noAccess: true }
-            }
+                meta: { canView: true, canEdit: true, noAccess: true },
+            },
         });
 
         expect(permissionPickerComponent.find(PermissionOption)).toHaveLength(
@@ -47,13 +47,13 @@ describe("Sharing: PermissionPicker component", () => {
         );
     });
 
-    it("should render six PermissionOptions if all access options are available", () => {
+    it('should render six PermissionOptions if all access options are available', () => {
         expect(permissionPickerComponent.find(PermissionOption)).toHaveLength(
             6
         );
     });
 
-    it("should render the checkmark SvgIcon according to the permission values", () => {
+    it('should render the checkmark SvgIcon according to the permission values', () => {
         expect(
             permissionPickerComponent
                 .find(PermissionOption)
@@ -95,8 +95,8 @@ describe("Sharing: PermissionPicker component", () => {
             ...permissionPickerProps,
             access: {
                 data: { canView: false, canEdit: false },
-                meta: { canView: false, canEdit: false }
-            }
+                meta: { canView: false, canEdit: false },
+            },
         });
 
         expect(

--- a/src/sharing/__tests__/PermissionPicker.component.spec.js
+++ b/src/sharing/__tests__/PermissionPicker.component.spec.js
@@ -1,75 +1,139 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import IconButton from 'material-ui/IconButton';
-import PermissionOption from '../PermissionOption.component';
-import PermissionPicker from '../PermissionPicker.component';
-import { getStubContext } from '../../../config/inject-theme';
+import React from "react";
+import { shallow } from "enzyme";
+import IconButton from "material-ui/IconButton";
+import PermissionOption from "../PermissionOption.component";
+import PermissionPicker from "../PermissionPicker.component";
+import { getStubContext } from "../../../config/inject-theme";
 
 const permissionPickerProps = {
     access: {
         meta: { canView: true, canEdit: true },
-        data: { canView: true, canEdit: true },
+        data: { canView: true, canEdit: true }
     },
     accessOptions: {
         meta: { canView: true, canEdit: true, noAccess: true },
-        data: { canView: true, canEdit: true, noAccess: true },
+        data: { canView: true, canEdit: true, noAccess: true }
     },
     onChange: () => {},
-    disabled: false,
+    disabled: false
 };
 
-describe('Sharing: PermissionPicker component', () => {
+describe("Sharing: PermissionPicker component", () => {
     let permissionPickerComponent;
 
     const renderComponent = (props = {}) =>
         shallow(<PermissionPicker {...props} />, {
-            context: getStubContext(),
+            context: getStubContext()
         });
 
     beforeEach(() => {
         permissionPickerComponent = renderComponent(permissionPickerProps);
     });
 
-    it('should render an IconButton', () => {
+    it("should render an IconButton", () => {
         expect(permissionPickerComponent.find(IconButton)).toHaveLength(1);
     });
 
-    it('should render three PermissionOptions if no data options, but all metadata options are available', () => {
+    it("should render three PermissionOptions if no data options, but all metadata options are available", () => {
         permissionPickerComponent = renderComponent({
             ...permissionPickerProps,
             accessOptions: {
-                meta: { canView: true, canEdit: true, noAccess: true },
-            },
+                meta: { canView: true, canEdit: true, noAccess: true }
+            }
         });
 
-        expect(permissionPickerComponent.find(PermissionOption)).toHaveLength(3);
+        expect(permissionPickerComponent.find(PermissionOption)).toHaveLength(
+            3
+        );
     });
 
-    it('should render six PermissionOptions if all access options are available', () => {
-        expect(permissionPickerComponent.find(PermissionOption)).toHaveLength(6);
+    it("should render six PermissionOptions if all access options are available", () => {
+        expect(permissionPickerComponent.find(PermissionOption)).toHaveLength(
+            6
+        );
     });
 
-    it('should render the checkmark FontIcon according to the permission values', () => {
-        expect(permissionPickerComponent.find(PermissionOption).at(0).props().isSelected).toBe(true);
-        expect(permissionPickerComponent.find(PermissionOption).at(1).props().isSelected).toBe(false);
-        expect(permissionPickerComponent.find(PermissionOption).at(2).props().isSelected).toBe(false);
-        expect(permissionPickerComponent.find(PermissionOption).at(3).props().isSelected).toBe(true);
-        expect(permissionPickerComponent.find(PermissionOption).at(4).props().isSelected).toBe(false);
-        expect(permissionPickerComponent.find(PermissionOption).at(5).props().isSelected).toBe(false);
+    it("should render the checkmark SvgIcon according to the permission values", () => {
+        expect(
+            permissionPickerComponent
+                .find(PermissionOption)
+                .at(0)
+                .props().isSelected
+        ).toBe(true);
+        expect(
+            permissionPickerComponent
+                .find(PermissionOption)
+                .at(1)
+                .props().isSelected
+        ).toBe(false);
+        expect(
+            permissionPickerComponent
+                .find(PermissionOption)
+                .at(2)
+                .props().isSelected
+        ).toBe(false);
+        expect(
+            permissionPickerComponent
+                .find(PermissionOption)
+                .at(3)
+                .props().isSelected
+        ).toBe(true);
+        expect(
+            permissionPickerComponent
+                .find(PermissionOption)
+                .at(4)
+                .props().isSelected
+        ).toBe(false);
+        expect(
+            permissionPickerComponent
+                .find(PermissionOption)
+                .at(5)
+                .props().isSelected
+        ).toBe(false);
 
         permissionPickerComponent = renderComponent({
             ...permissionPickerProps,
             access: {
                 data: { canView: false, canEdit: false },
-                meta: { canView: false, canEdit: false },
-            },
+                meta: { canView: false, canEdit: false }
+            }
         });
 
-        expect(permissionPickerComponent.find(PermissionOption).at(0).props().isSelected).toBe(false);
-        expect(permissionPickerComponent.find(PermissionOption).at(1).props().isSelected).toBe(false);
-        expect(permissionPickerComponent.find(PermissionOption).at(2).props().isSelected).toBe(true);
-        expect(permissionPickerComponent.find(PermissionOption).at(3).props().isSelected).toBe(false);
-        expect(permissionPickerComponent.find(PermissionOption).at(4).props().isSelected).toBe(false);
-        expect(permissionPickerComponent.find(PermissionOption).at(5).props().isSelected).toBe(true);
+        expect(
+            permissionPickerComponent
+                .find(PermissionOption)
+                .at(0)
+                .props().isSelected
+        ).toBe(false);
+        expect(
+            permissionPickerComponent
+                .find(PermissionOption)
+                .at(1)
+                .props().isSelected
+        ).toBe(false);
+        expect(
+            permissionPickerComponent
+                .find(PermissionOption)
+                .at(2)
+                .props().isSelected
+        ).toBe(true);
+        expect(
+            permissionPickerComponent
+                .find(PermissionOption)
+                .at(3)
+                .props().isSelected
+        ).toBe(false);
+        expect(
+            permissionPickerComponent
+                .find(PermissionOption)
+                .at(4)
+                .props().isSelected
+        ).toBe(false);
+        expect(
+            permissionPickerComponent
+                .find(PermissionOption)
+                .at(5)
+                .props().isSelected
+        ).toBe(true);
     });
 });

--- a/src/svg-icon/SvgIcon.js
+++ b/src/svg-icon/SvgIcon.js
@@ -1,39 +1,39 @@
-import React from "react";
-import PropTypes from "prop-types";
-import Add from "material-ui/svg-icons/content/add";
-import ArrowDownward from "material-ui/svg-icons/navigation/arrow-downward";
-import ArrowDropRight from "material-ui/svg-icons/navigation-arrow-drop-right";
-import ArrowUpward from "material-ui/svg-icons/navigation/arrow-upward";
-import Business from "material-ui/svg-icons/communication/business";
-import Cancel from "material-ui/svg-icons/navigation/cancel";
-import ChevronLeft from "material-ui/svg-icons/navigation/chevron-left";
-import ChevronRight from "material-ui/svg-icons/navigation/chevron-right";
-import Clear from "material-ui/svg-icons/content/clear";
-import Close from "material-ui/svg-icons/navigation/close";
-import Create from "material-ui/svg-icons/content/create";
-import Delete from "material-ui/svg-icons/action/delete";
-import Done from "material-ui/svg-icons/action/done";
-import DragHandle from "material-ui/svg-icons/editor/drag-handle";
-import Group from "material-ui/svg-icons/social/group";
-import GridOn from "material-ui/svg-icons/image/grid-on";
-import InfoOutline from "material-ui/svg-icons/action/info-outline";
-import InsertChart from "material-ui/svg-icons/editor/insert-chart";
-import Message from "material-ui/svg-icons/communication/message";
-import MoreVert from "material-ui/svg-icons/navigation/more-vert";
-import NotInterested from "material-ui/svg-icons/av/not-interested";
-import Person from "material-ui/svg-icons/social/person";
-import Public from "material-ui/svg-icons/social/public";
-import RemoveRedEye from "material-ui/svg-icons/image/remove-red-eye";
-import Room from "material-ui/svg-icons/action/room";
-import ShowChart from "material-ui/svg-icons/editor/show-chart";
-import Star from "material-ui/svg-icons/toggle/star";
-import StarBorder from "material-ui/svg-icons/toggle/star-border";
-import ViewList from "material-ui/svg-icons/action/view-list";
-import Visibility from "material-ui/svg-icons/action/visibility";
-import VisibilityOff from "material-ui/svg-icons/action/visibility-off";
-import SentimentDissatisfied from "material-ui/svg-icons/social/sentiment-dissatisfied";
-import MUISvgIcon from "material-ui/SvgIcon";
-import { grey600, grey200 } from "material-ui/styles/colors";
+import React from 'react';
+import PropTypes from 'prop-types';
+import Add from 'material-ui/svg-icons/content/add';
+import ArrowDownward from 'material-ui/svg-icons/navigation/arrow-downward';
+import ArrowDropRight from 'material-ui/svg-icons/navigation-arrow-drop-right';
+import ArrowUpward from 'material-ui/svg-icons/navigation/arrow-upward';
+import Business from 'material-ui/svg-icons/communication/business';
+import Cancel from 'material-ui/svg-icons/navigation/cancel';
+import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
+import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
+import Clear from 'material-ui/svg-icons/content/clear';
+import Close from 'material-ui/svg-icons/navigation/close';
+import Create from 'material-ui/svg-icons/content/create';
+import Delete from 'material-ui/svg-icons/action/delete';
+import Done from 'material-ui/svg-icons/action/done';
+import DragHandle from 'material-ui/svg-icons/editor/drag-handle';
+import Group from 'material-ui/svg-icons/social/group';
+import GridOn from 'material-ui/svg-icons/image/grid-on';
+import InfoOutline from 'material-ui/svg-icons/action/info-outline';
+import InsertChart from 'material-ui/svg-icons/editor/insert-chart';
+import Message from 'material-ui/svg-icons/communication/message';
+import MoreVert from 'material-ui/svg-icons/navigation/more-vert';
+import NotInterested from 'material-ui/svg-icons/av/not-interested';
+import Person from 'material-ui/svg-icons/social/person';
+import Public from 'material-ui/svg-icons/social/public';
+import RemoveRedEye from 'material-ui/svg-icons/image/remove-red-eye';
+import Room from 'material-ui/svg-icons/action/room';
+import ShowChart from 'material-ui/svg-icons/editor/show-chart';
+import Star from 'material-ui/svg-icons/toggle/star';
+import StarBorder from 'material-ui/svg-icons/toggle/star-border';
+import ViewList from 'material-ui/svg-icons/action/view-list';
+import Visibility from 'material-ui/svg-icons/action/visibility';
+import VisibilityOff from 'material-ui/svg-icons/action/visibility-off';
+import SentimentDissatisfied from 'material-ui/svg-icons/social/sentiment-dissatisfied';
+import MUISvgIcon from 'material-ui/SvgIcon';
+import { grey600, grey200 } from 'material-ui/styles/colors';
 
 const icons = {
     Add,
@@ -66,7 +66,7 @@ const icons = {
     StarBorder,
     ViewList,
     Visibility,
-    VisibilityOff
+    VisibilityOff,
 };
 
 const SvgIcon = ({ icon, children, className, disabled, style }) => {
@@ -82,7 +82,7 @@ const SvgIcon = ({ icon, children, className, disabled, style }) => {
             className={className}
             style={{
                 ...style,
-                fill: style.fill || (disabled ? grey200 : grey600)
+                fill: style.fill || (disabled ? grey200 : grey600),
             }}
         >
             {children}
@@ -114,15 +114,15 @@ SvgIcon.propTypes = {
     /**
      * Pass inline styles to the root element
      */
-    style: PropTypes.object
+    style: PropTypes.object,
 };
 
 SvgIcon.defaultProps = {
-    icon: "",
+    icon: '',
     children: null,
-    className: "",
+    className: '',
     disabled: false,
-    style: {}
+    style: {},
 };
 
 export default SvgIcon;

--- a/src/svg-icon/SvgIcon.js
+++ b/src/svg-icon/SvgIcon.js
@@ -1,59 +1,72 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import Add from 'material-ui/svg-icons/content/add';
-import ArrowDownward from 'material-ui/svg-icons/navigation/arrow-downward';
-import ArrowDropRight from 'material-ui/svg-icons/navigation-arrow-drop-right';
-import ArrowUpward from 'material-ui/svg-icons/navigation/arrow-upward';
-import Cancel from 'material-ui/svg-icons/navigation/cancel';
-import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
-import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
-import Close from 'material-ui/svg-icons/navigation/close';
-import Create from 'material-ui/svg-icons/content/create';
-import Delete from 'material-ui/svg-icons/action/delete';
-import DragHandle from 'material-ui/svg-icons/editor/drag-handle';
-import GridOn from 'material-ui/svg-icons/image/grid-on';
-import InfoOutline from 'material-ui/svg-icons/action/info-outline';
-import InsertChart from 'material-ui/svg-icons/editor/insert-chart';
-import Message from 'material-ui/svg-icons/communication/message';
-import MoreVert from 'material-ui/svg-icons/navigation/more-vert';
-import Room from 'material-ui/svg-icons/action/room';
-import ShowChart from 'material-ui/svg-icons/editor/show-chart';
-import Star from 'material-ui/svg-icons/toggle/star';
-import StarBorder from 'material-ui/svg-icons/toggle/star-border';
-import ViewList from 'material-ui/svg-icons/action/view-list';
-import Visibility from 'material-ui/svg-icons/action/visibility';
-import VisibilityOff from 'material-ui/svg-icons/action/visibility-off';
-import SentimentDissatisfied from 'material-ui/svg-icons/social/sentiment-dissatisfied';
-import Public from 'material-ui/svg-icons/social/public';
-import MUISvgIcon from 'material-ui/SvgIcon';
-import { grey600, grey200 } from 'material-ui/styles/colors';
-
+import React from "react";
+import PropTypes from "prop-types";
+import Add from "material-ui/svg-icons/content/add";
+import ArrowDownward from "material-ui/svg-icons/navigation/arrow-downward";
+import ArrowDropRight from "material-ui/svg-icons/navigation-arrow-drop-right";
+import ArrowUpward from "material-ui/svg-icons/navigation/arrow-upward";
+import Business from "material-ui/svg-icons/communication/business";
+import Cancel from "material-ui/svg-icons/navigation/cancel";
+import ChevronLeft from "material-ui/svg-icons/navigation/chevron-left";
+import ChevronRight from "material-ui/svg-icons/navigation/chevron-right";
+import Clear from "material-ui/svg-icons/content/clear";
+import Close from "material-ui/svg-icons/navigation/close";
+import Create from "material-ui/svg-icons/content/create";
+import Delete from "material-ui/svg-icons/action/delete";
+import Done from "material-ui/svg-icons/action/done";
+import DragHandle from "material-ui/svg-icons/editor/drag-handle";
+import Group from "material-ui/svg-icons/social/group";
+import GridOn from "material-ui/svg-icons/image/grid-on";
+import InfoOutline from "material-ui/svg-icons/action/info-outline";
+import InsertChart from "material-ui/svg-icons/editor/insert-chart";
+import Message from "material-ui/svg-icons/communication/message";
+import MoreVert from "material-ui/svg-icons/navigation/more-vert";
+import NotInterested from "material-ui/svg-icons/av/not-interested";
+import Person from "material-ui/svg-icons/social/person";
+import Public from "material-ui/svg-icons/social/public";
+import RemoveRedEye from "material-ui/svg-icons/image/remove-red-eye";
+import Room from "material-ui/svg-icons/action/room";
+import ShowChart from "material-ui/svg-icons/editor/show-chart";
+import Star from "material-ui/svg-icons/toggle/star";
+import StarBorder from "material-ui/svg-icons/toggle/star-border";
+import ViewList from "material-ui/svg-icons/action/view-list";
+import Visibility from "material-ui/svg-icons/action/visibility";
+import VisibilityOff from "material-ui/svg-icons/action/visibility-off";
+import SentimentDissatisfied from "material-ui/svg-icons/social/sentiment-dissatisfied";
+import MUISvgIcon from "material-ui/SvgIcon";
+import { grey600, grey200 } from "material-ui/styles/colors";
 
 const icons = {
     Add,
     ArrowDownward,
     ArrowDropRight,
     ArrowUpward,
+    Business,
     Cancel,
     ChevronLeft,
     ChevronRight,
+    Clear,
     Close,
     Create,
     Delete,
+    Done,
     DragHandle,
     GridOn,
+    Group,
     InfoOutline,
     InsertChart,
     Message,
     MoreVert,
+    NotInterested,
+    Person,
     Public,
+    RemoveRedEye,
     Room,
     ShowChart,
     Star,
     StarBorder,
     ViewList,
     Visibility,
-    VisibilityOff,
+    VisibilityOff
 };
 
 const SvgIcon = ({ icon, children, className, disabled, style }) => {
@@ -69,7 +82,7 @@ const SvgIcon = ({ icon, children, className, disabled, style }) => {
             className={className}
             style={{
                 ...style,
-                fill: style.fill || (disabled ? grey200 : grey600),
+                fill: style.fill || (disabled ? grey200 : grey600)
             }}
         >
             {children}
@@ -101,15 +114,15 @@ SvgIcon.propTypes = {
     /**
      * Pass inline styles to the root element
      */
-    style: PropTypes.object,
+    style: PropTypes.object
 };
 
 SvgIcon.defaultProps = {
-    icon: '',
+    icon: "",
     children: null,
-    className: '',
+    className: "",
     disabled: false,
-    style: {},
+    style: {}
 };
 
 export default SvgIcon;

--- a/src/svg-icon/SvgIcon.js
+++ b/src/svg-icon/SvgIcon.js
@@ -23,7 +23,6 @@ import MoreVert from 'material-ui/svg-icons/navigation/more-vert';
 import NotInterested from 'material-ui/svg-icons/av/not-interested';
 import Person from 'material-ui/svg-icons/social/person';
 import Public from 'material-ui/svg-icons/social/public';
-import RemoveRedEye from 'material-ui/svg-icons/image/remove-red-eye';
 import Room from 'material-ui/svg-icons/action/room';
 import ShowChart from 'material-ui/svg-icons/editor/show-chart';
 import Star from 'material-ui/svg-icons/toggle/star';
@@ -59,7 +58,6 @@ const icons = {
     NotInterested,
     Person,
     Public,
-    RemoveRedEye,
     Room,
     ShowChart,
     Star,


### PR DESCRIPTION
I'm using the SharingDialog component in the new FavoritesDialog component (WIP) and got broken UI due to missing material icons font in my test app.
With nico we decided to use SvgIcon instead.

Replace FontIcon with SvgIcon in the Sharing component.
Added the missing SVG imports in the SvgIcon component.

Sorry for the huge diff, do we have special settings for prettier? I thought we run pretty much with the defaults, but I might have to tweak the settings in my editor.