### PR TITLE
Add new TextField properties to support multiline fields

### DIFF
--- a/examples/text-field/index.js
+++ b/examples/text-field/index.js
@@ -23,6 +23,7 @@ class TextFields extends Component {
         valueField1: '',
         valueField2: '',
         valueField3: '',
+        valueField4: '',
     };
 
     onChangeValue = (field, value) => {
@@ -42,21 +43,21 @@ class TextFields extends Component {
             <MuiThemeProvider muiTheme={getMuiTheme()}>
                 <div style={style}>
                     <TextField
-                        label='Text'
+                        label="Text"
                         value={this.state.valueField1}
-                        onChange={(value) => this.onChangeValue('valueField1', value)}
+                        onChange={(value) => this.onChangeValue("valueField1", value)}
                     />
                     <TextField
-                        label='Number'
-                        type='number'
+                        label="Number"
+                        type="number"
                         value={this.state.valueField2}
-                        onChange={(value) => this.onChangeValue('valueField2', value)}
+                        onChange={(value) => this.onChangeValue("valueField2", value)}
                     />
                     <TextField
-                        label='Default value'
-                        type='number'
+                        label="Default value"
+                        type="number"
                         value={this.state.valueField3 || 100}
-                        onChange={(value) => this.onChangeValue('valueField3', value)}
+                        onChange={(value) => this.onChangeValue("valueField3", value)}
                     />
                     <TextField
                         placeholder="Hint text"
@@ -77,7 +78,8 @@ class TextFields extends Component {
                         placeholder="Full width"
                         type="text"
                         fullWidth
-                        onChange={() => { }}
+                        value={this.state.valueField4}
+                        onChange={(value) => this.onChangeValue("valueField4", value)}
                     />
                 </div>
             </MuiThemeProvider>

--- a/examples/text-field/index.js
+++ b/examples/text-field/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { render } from 'react-dom';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
@@ -16,45 +16,64 @@ const style = {
     justifyContent: 'space-between',
 };
 
-const textFields = (
-    <MuiThemeProvider muiTheme={getMuiTheme()}>
-        <div style={style}>
-            <TextField
-                label='Text'
-                onChange={() => {}}
-            />
-            <TextField
-                label='Number'
-                type='number'
-                onChange={() => {}}
-            />
-            <TextField
-                label='Default value'
-                type='number'
-                value={100}
-                onChange={() => {}}
-            />
-            <TextField
-                placeholder="Hint text"
-                type="text"
-                onChange={() => { }}
-            />
-            <TextField
-                placeholder="Multiline with Hint text"
-                type="text"
-                multiline
-                rows={2}
-                rowsMax={4}
-                onChange={() => { }}
-            />
-            <TextField
-                placeholder="Full width"
-                type="text"
-                fullWidth
-                onChange={() => { }}
-            />
-        </div>
-    </MuiThemeProvider>
-);
+class TextFields extends Component {
+    state = {
+        multiHintText: '',
+        singleHintText: '',
+    };
 
-render(textFields, document.getElementById('text-fields'));
+    onChangeMultiHintText = (multiHintText) => {
+        this.setState({ multiHintText });
+    }
+
+    onChangeSingleHintText = (singleHintText) => {
+        this.setState({ singleHintText });
+    }
+
+    render() {
+        return (
+            <MuiThemeProvider muiTheme={getMuiTheme()}>
+                <div style={style}>
+                    <TextField
+                        label='Text'
+                        onChange={() => { }}
+                    />
+                    <TextField
+                        label='Number'
+                        type='number'
+                        onChange={() => { }}
+                    />
+                    <TextField
+                        label='Default value'
+                        type='number'
+                        value={100}
+                        onChange={() => { }}
+                    />
+                    <TextField
+                        placeholder="Hint text"
+                        type="text"
+                        value={this.state.singleHintText}
+                        onChange={this.onChangeSingleHintText}
+                    />
+                    <TextField
+                        placeholder="Multiline field showing 2 rows and up to 4 rows"
+                        type="text"
+                        multiline
+                        rows={2}
+                        rowsMax={4}
+                        value={this.state.multiHintText}
+                        onChange={this.onChangeMultiHintText}
+                    />
+                    <TextField
+                        placeholder="Full width"
+                        type="text"
+                        fullWidth
+                        onChange={() => { }}
+                    />
+                </div>
+            </MuiThemeProvider>
+        );
+    }
+}
+
+render(<TextFields />, document.getElementById('text-fields'));

--- a/examples/text-field/index.js
+++ b/examples/text-field/index.js
@@ -34,6 +34,25 @@ const textFields = (
                 value={100}
                 onChange={() => {}}
             />
+            <TextField
+                placeholder="Hint text"
+                type="text"
+                onChange={() => { }}
+            />
+            <TextField
+                placeholder="Multiline with Hint text"
+                type="text"
+                multiline
+                rows={2}
+                rowsMax={4}
+                onChange={() => { }}
+            />
+            <TextField
+                placeholder="Full width"
+                type="text"
+                fullWidth
+                onChange={() => { }}
+            />
         </div>
     </MuiThemeProvider>
 );

--- a/examples/text-field/index.js
+++ b/examples/text-field/index.js
@@ -20,15 +20,22 @@ class TextFields extends Component {
     state = {
         multiHintText: '',
         singleHintText: '',
+        valueField1: '',
+        valueField2: '',
+        valueField3: '',
+    };
+
+    onChangeValue = (field, value) => {
+        this.setState({ [field]: value });
     };
 
     onChangeMultiHintText = (multiHintText) => {
         this.setState({ multiHintText });
-    }
+    };
 
     onChangeSingleHintText = (singleHintText) => {
         this.setState({ singleHintText });
-    }
+    };
 
     render() {
         return (
@@ -36,18 +43,20 @@ class TextFields extends Component {
                 <div style={style}>
                     <TextField
                         label='Text'
-                        onChange={() => { }}
+                        value={this.state.valueField1}
+                        onChange={(value) => this.onChangeValue('valueField1', value)}
                     />
                     <TextField
                         label='Number'
                         type='number'
-                        onChange={() => { }}
+                        value={this.state.valueField2}
+                        onChange={(value) => this.onChangeValue('valueField2', value)}
                     />
                     <TextField
                         label='Default value'
                         type='number'
-                        value={100}
-                        onChange={() => { }}
+                        value={this.state.valueField3 || 100}
+                        onChange={(value) => this.onChangeValue('valueField3', value)}
                     />
                     <TextField
                         placeholder="Hint text"

--- a/src/text-field/TextField.js
+++ b/src/text-field/TextField.js
@@ -3,17 +3,33 @@ import PropTypes from 'prop-types';
 import MuiTextField from 'material-ui/TextField';
 import { createClassName } from '../component-helpers/utils';
 
-const TextField = ({ type, label, value, onChange, style, selector }) => {
+const TextField = ({ type,
+    fullWidth,
+    label,
+    multiline,
+    onChange,
+    placeholder,
+    rows,
+    rowsMax,
+    selector,
+    style,
+    value,
+}) => {
     const className = createClassName('d2-ui-textfield', selector);
 
     return (
         <MuiTextField
-            type={type}
-            floatingLabelText={label}
-            value={value}
-            onChange={(event, value) => onChange(value)}
             className={className}
+            floatingLabelText={label}
+            fullWidth={fullWidth}
+            hintText={placeholder}
+            multiLine={multiline}
+            onChange={(event, val) => onChange(val)}
+            rows={rows}
+            rowsMax={rowsMax}
             style={style}
+            type={type}
+            value={value}
         />
     );
 };
@@ -21,9 +37,9 @@ const TextField = ({ type, label, value, onChange, style, selector }) => {
 
 TextField.propTypes = {
     /**
-     * The input type of the textfield
+     * If set, expands the TextField to the full width of its parent
      */
-    type: PropTypes.oneOf(['text', 'number']),
+    fullWidth: PropTypes.bool,
 
     /**
      * The textfield label
@@ -31,9 +47,9 @@ TextField.propTypes = {
     label: PropTypes.string,
 
     /**
-     * The value of the textfield
+     * If set, allows textfield to expand to more than one line
      */
-    value: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
+    multiline: PropTypes.bool,
 
     /**
      * onChange callback, that is fired when the textfield's value changes
@@ -43,14 +59,53 @@ TextField.propTypes = {
     onChange: PropTypes.func.isRequired,
 
     /**
-     * Override the inline-styles of the root element
+     * If set, sets the Hint text (v0.19)
      */
-    style: PropTypes.object,
+    placeholder: PropTypes.string,
+
+    /**
+     * If set, and multiline is true, sets the initial number of lines
+     */
+    rows: PropTypes.number,
+
+    /**
+     * If set, and multiline is true, sets the maximum number of lines
+     */
+    rowsMax: PropTypes.number,
 
     /**
      * If set, adds a class to the element in the format d2-ui-textfield-selector
      */
     selector: PropTypes.string,
+
+    /**
+     * Override the inline-styles of the root element
+     */
+    style: PropTypes.object,
+
+    /**
+     * The input type of the textfield
+     */
+    type: PropTypes.oneOf(['text', 'number']),
+
+    /**
+     * The value of the textfield
+     */
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
+
+TextField.defaultProps = {
+    fullWidth: false,
+    label: null,
+    multiline: false,
+    placeholder: '',
+    rows: 1,
+    rowsMax: null,
+    selector: null,
+    style: {},
+    type: 'text',
+    value: '',
+};
+
 
 export default TextField;

--- a/src/text-field/TextField.js
+++ b/src/text-field/TextField.js
@@ -94,18 +94,4 @@ TextField.propTypes = {
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
-TextField.defaultProps = {
-    fullWidth: false,
-    label: null,
-    multiline: false,
-    placeholder: '',
-    rows: 1,
-    rowsMax: null,
-    selector: null,
-    style: {},
-    type: 'text',
-    value: '',
-};
-
-
 export default TextField;

--- a/src/text-field/__tests__/TextField.spec.js
+++ b/src/text-field/__tests__/TextField.spec.js
@@ -37,4 +37,22 @@ describe('TextField', () => {
         renderWithProps({ onChange: onChangeSpy }).props().onChange({}, 'my text');
         expect(onChangeSpy).toHaveBeenCalledWith('my text');
     });
+
+    it('should render the MUITextField with the correct properties', () => {
+        const props = {
+            multiline: true,
+            fullWidth: true,
+            rows: 2,
+            rowsMax: 4,
+            placeholder: 'Getting warmer',
+        };
+
+        const muiField = renderWithProps(props).find(MuiTextField);
+
+        expect(muiField.props().multiLine).toEqual(props.multiline);
+        expect(muiField.props().fullWidth).toEqual(props.fullWidth);
+        expect(muiField.props().hintText).toEqual(props.placeholder);
+        expect(muiField.props().rows).toEqual(props.rows);
+        expect(muiField.props().rowsMax).toEqual(props.rowsMax);
+    });
 });


### PR DESCRIPTION
Also adds properties to support hint text and fullwidth. Note that the props passed in to the d2-ui component comply with the MUI 1.0 property naming. (multiline, placeholder)

I rearranged the properties alphabetically which makes the code changes appear bigger than they actually are. Apologies for that.