### PR TITLE
Allow CheckBox wrapper to be styled and fix broken test

### DIFF
--- a/src/controlbar/ControlBar.js
+++ b/src/controlbar/ControlBar.js
@@ -44,7 +44,7 @@ const styles = {
 
 const BACKGROUND_RGB = '255,255,255';
 const BACKGROUND_RGB_EDIT = '255,248,224';
-const END_FLAP_HEIGHT = 7;
+export const END_FLAP_HEIGHT = 7;
 
 /**
  * The ControlBar component can be used to put an expandable horizontal bar underneath the DHIS header bar, useful for

--- a/src/controlbar/__tests__/ControlBar.spec.js
+++ b/src/controlbar/__tests__/ControlBar.spec.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import { getStubContext } from '../../../config/inject-theme';
 
-import ControlBar from '../ControlBar';
+import ControlBar, { END_FLAP_HEIGHT } from '../ControlBar';
 
 ControlBar.contextTypes = {
     muiTheme: PropTypes.any,
@@ -49,7 +49,7 @@ describe('ControlBar', () => {
 
     it('should set the height of the end flap to 10 when an onChangeHeight callback is specified', () => {
         const controlBar = renderControlBar({ onChangeHeight: noop });
-        expect(controlBar.find('.d2-ui-control-bar-contents + div').props().style.height).toBe(10);
+        expect(controlBar.find('.d2-ui-control-bar-contents + div').props().style.height).toBe(END_FLAP_HEIGHT);
     });
 
     it('should change the background color in edit mode', () => {

--- a/src/form-fields/CheckBox.component.js
+++ b/src/form-fields/CheckBox.component.js
@@ -1,24 +1,31 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Checkbox from 'material-ui/Checkbox';
 
-class CheckBox extends Component {
-    render() {
-        const {
-            errorStyle,
-            errorText,
-            ...other
-        } = this.props;
-        return (
-            <div style={{ marginTop: 12, marginBottom: 12 }}>
-                <Checkbox onCheck={this.props.onChange} {...other} />
-            </div>
-        );
-    }
-}
+const CheckBox = ({ onChange, wrapperStyle, errorStyle, errorText, ...other }) => {
+    const baseWrapperStyle = { marginTop: 12, marginBottom: 12 };
+    const mergedWrapperStyle = {
+        ...baseWrapperStyle,
+        ...wrapperStyle,
+    };
+    return (
+        <div style={mergedWrapperStyle}>
+            <Checkbox onCheck={onChange} {...other} />
+        </div>
+    );
+};
 
 CheckBox.propTypes = {
+    wrapperStyle: PropTypes.object,
+    errorStyle: PropTypes.object,
+    errorText: PropTypes.string,
     onChange: PropTypes.func.isRequired,
+};
+
+CheckBox.defaultProps = {
+    wrapperStyle: {},
+    errorStyle: {},
+    errorText: '',
 };
 
 export default CheckBox;


### PR DESCRIPTION
- Fixed 1 broken test so that the build will succeed. To make sure no discrepancies will happen in the future I exported the height constant from the ControlBar component.
- CheckBox wrapper can now be styled via `props.wrapperStyle`. These styles will be merged with the existing styles to ensure backwards compatibility.
- I also rewrote the CheckBox as a functional component and declared some more propTypes and defaultProps to keep the linter happy.