### PR TITLE
Feature/checkbox wrapper style override

### DIFF
--- a/src/form-fields/__tests__/CheckBox.component.spec.js
+++ b/src/form-fields/__tests__/CheckBox.component.spec.js
@@ -7,11 +7,10 @@ import Checkbox from '../CheckBox.component';
 describe('Checkbox component', () => {
     let Component;
     let onChangeSpy;
-    const wrapperStyle = { marginTop: 20 };
 
     beforeEach(() => {
         onChangeSpy = jest.fn();
-        Component = shallow(<Checkbox onChange={onChangeSpy} wrapperStyle={wrapperStyle} />);
+        Component = shallow(<Checkbox onChange={onChangeSpy} />);
     });
 
     it('should render a Checkbox component', () => {
@@ -27,6 +26,14 @@ describe('Checkbox component', () => {
     });
 
     it('should apply styles and override default styles to the wrapper div when a wrapperStyle prop is defined', () => {
-        expect(Component.find('div').props().style.marginTop).toBe(20);
+        const defaultMarginTop = Component.find('div').props().style.marginTop;
+        let customMarginTop = 20;
+        // Ensure the custom value is actually different from the default one
+        if (defaultMarginTop === customMarginTop || `${defaultMarginTop}px` === customMarginTop) {
+            customMarginTop = 40;
+        }
+        const wrapperStyle = { marginTop: customMarginTop };
+        const ComponentWithWrapperStyle = shallow(<Checkbox onChange={onChangeSpy} wrapperStyle={wrapperStyle} />);
+        expect(ComponentWithWrapperStyle.find('div').props().style.marginTop).toBe(customMarginTop);
     });
 });

--- a/src/form-fields/__tests__/CheckBox.component.spec.js
+++ b/src/form-fields/__tests__/CheckBox.component.spec.js
@@ -29,7 +29,7 @@ describe('Checkbox component', () => {
         const defaultMarginTop = Component.find('div').props().style.marginTop;
         let customMarginTop = 20;
         // Ensure the custom value is actually different from the default one
-        if (defaultMarginTop === customMarginTop || `${defaultMarginTop}px` === customMarginTop) {
+        if (defaultMarginTop === customMarginTop || defaultMarginTop === `${customMarginTop}px`) {
             customMarginTop = 40;
         }
         const wrapperStyle = { marginTop: customMarginTop };


### PR DESCRIPTION
In the end I just introduced a backup customMarginTop value. So that if defaultMarginTop is 20 or 20px, it will set customMarginTop to 40. Now they are guaranteed to be different and the test won't produce false positives.