### PR TITLE
Don't wrap floating label texts

### DIFF
--- a/src/text-field/TextField.js
+++ b/src/text-field/TextField.js
@@ -32,6 +32,7 @@ const TextField = ({ type,
             type={type}
             value={value}
             onClick={onClick}
+            floatingLabelStyle={{ whiteSpace: 'nowrap' }} // Avoids overlapping the input field
         />
     );
 };


### PR DESCRIPTION
Text wrapped floating label texts overlaps the inputfield, and this style fix only allows single line labels. 