### PR TITLE
Hide first and then run action

### DIFF
--- a/src/data-table/DataTableContextMenu.component.js
+++ b/src/data-table/DataTableContextMenu.component.js
@@ -36,11 +36,10 @@ function DataTableContextMenu(props, context) {
                 {actionList.map((action) => {
                     const iconName = icons && icons[action] ? icons[action] : action;
                     const onClick = () => {
-                        props.actions[action].apply(props.actions, [props.activeItem]);
-
                         if (typeof props.onRequestClose === 'function') {
-                            setTimeout(() => props.onRequestClose(), 0);
+                            props.onRequestClose();
                         }
+                        props.actions[action].apply(props.actions, [props.activeItem]);
                     };
 
                     return (


### PR DESCRIPTION
- Changes execution order so that the popup is hidden first, and the action is run afterwards
- Removes timeout from code because there was no obvious need for it and it would break sequence changes
- This fix solves problems with navigating away via the contextMenu and destroying the current view in the process