### PR TITLE
Filter by path instead of ID

### DIFF
--- a/examples/org-unit-tree/index.js
+++ b/examples/org-unit-tree/index.js
@@ -67,6 +67,15 @@ function OrgUnitTreeExample(props) {
                 </Card>
                 <Card style={styles.card}>
                     <CardText style={styles.cardText}>
+                        <h3 style={styles.cardHeader}>Plain OrgUnitTree with filter</h3>
+                        <OrgUnitTree
+                            root={props.root}
+                            orgUnitsPathsToInclude={['/ImspTQPwCqd/Vth0fbpFcsO/EjnIQNVAXGp', '/ImspTQPwCqd/TEQlaapDQoK/ZiOVcrSjSYe']}
+                        />
+                    </CardText>
+                </Card>
+                <Card style={styles.card}>
+                    <CardText style={styles.cardText}>
                         <h3 style={styles.cardHeader}>Three Independent Trees</h3>
                         {props.roots.length > 0 ? (
                             <div>

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -115,15 +115,25 @@ class OrgUnitTree extends React.Component {
         e.stopPropagation();
     }
 
-    renderChildren() {
-        // If initiallyExpanded is an array, remove the current root id and pass the rest on
-        // If it's a string, pass it on unless it's the current root id
-        const expandedProp = Array.isArray(this.props.initiallyExpanded)
-            ? this.props.initiallyExpanded.filter(id => id !== this.props.root.id)
-            : (this.props.initiallyExpanded !== this.props.root.id && this.props.initiallyExpanded) || [];
+    shouldIncludeOrgUnit(orgUnit) {
+        if (!this.props.orgUnitsPathsToInclude || this.props.orgUnitsPathsToInclude.length === 0) {
+            return true;
+        }
 
-        if (Array.isArray(this.state.children) && this.state.children.length > 0) {
-            return this.state.children.map(orgUnit => (
+        // Use old fashinioned for loop from which you can return directly
+        const len = this.props.orgUnitsPathsToInclude.length;
+        for (let index = 0; index < len; index++) {
+            const pathToInclude = this.props.orgUnitsPathsToInclude[index];
+            if (pathToInclude.indexOf(orgUnit.id) > -1) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    renderChild(orgUnit, expandedProp) {
+        if (this.shouldIncludeOrgUnit(orgUnit)) {
+            return (
                 <OrgUnitTree
                     key={orgUnit.id}
                     root={orgUnit}
@@ -139,7 +149,22 @@ class OrgUnitTree extends React.Component {
                     hideCheckboxes={this.props.hideCheckboxes}
                     onChildrenLoaded={this.props.onChildrenLoaded}
                     hideMemberCount={this.props.hideMemberCount}
-                />));
+                    orgUnitsPathsToInclude={this.props.orgUnitsPathsToInclude}
+                />
+            );
+        }
+        return null;
+    }
+
+    renderChildren() {
+        // If initiallyExpanded is an array, remove the current root id and pass the rest on
+        // If it's a string, pass it on unless it's the current root id
+        const expandedProp = Array.isArray(this.props.initiallyExpanded)
+            ? this.props.initiallyExpanded.filter(id => id !== this.props.root.id)
+            : (this.props.initiallyExpanded !== this.props.root.id && this.props.initiallyExpanded) || [];
+
+        if (Array.isArray(this.state.children) && this.state.children.length > 0) {
+            return this.state.children.map(orgUnit => this.renderChild(orgUnit, expandedProp));
         }
 
         if (this.state.loading) {
@@ -332,6 +357,11 @@ OrgUnitTree.propTypes = {
      * if true, don't display the selected member count next to org unit labels
      */
     hideMemberCount: PropTypes.bool,
+
+    /**
+     * Array of paths of Organisation Units to include on tree. If not defined or empty, all children from root to leafs will be shown
+     */
+    orgUnitsPathsToInclude: PropTypes.array,
 };
 
 OrgUnitTree.defaultProps = {
@@ -347,6 +377,7 @@ OrgUnitTree.defaultProps = {
     arrowSymbol: undefined,
     hideCheckboxes: false,
     hideMemberCount: false,
+    orgUnitsPathsToInclude: null,
 };
 
 export default OrgUnitTree;

--- a/src/org-unit-tree/OrgUnitTree.component.js
+++ b/src/org-unit-tree/OrgUnitTree.component.js
@@ -119,16 +119,7 @@ class OrgUnitTree extends React.Component {
         if (!this.props.orgUnitsPathsToInclude || this.props.orgUnitsPathsToInclude.length === 0) {
             return true;
         }
-
-        // Use old fashinioned for loop from which you can return directly
-        const len = this.props.orgUnitsPathsToInclude.length;
-        for (let index = 0; index < len; index++) {
-            const pathToInclude = this.props.orgUnitsPathsToInclude[index];
-            if (pathToInclude.indexOf(orgUnit.id) > -1) {
-                return true;
-            }
-        }
-        return false;
+        return !!(this.props.orgUnitsPathsToInclude.some(ou => ou.includes(`/${orgUnit.id}`)));
     }
 
     renderChild(orgUnit, expandedProp) {


### PR DESCRIPTION
Alternative suggestion for filtering the tree using path instead of id. By using this approach the parents of deeply nested children will always be displayed in the tree.

Another additional example, is that it now uses the same structure as the initiallyExpanded property. Which means you can easily expand the filtered tree too.