### PR TITLE
Fixes on TextField and DropDown:

### DIFF
--- a/examples/form-builder/index.js
+++ b/examples/form-builder/index.js
@@ -58,6 +58,7 @@ class FormExample extends React.Component {
                     style: { width: '100%' },
                     hintText: 'Example hint text',
                     changeEvent: 'onBlur',
+                    type: 'search',
                 },
                 validators: [{
                     message: 'The field must have a value',
@@ -92,11 +93,11 @@ class FormExample extends React.Component {
             },
             {
                 name: 'exampleDropDown',
-                value: '1',
+                value: null,
                 component: SelectField,
                 props: {
                     menuItems: [{ id: '1', displayName: 'Option 1' }, { id: '2', displayName: 'Option 2' }],
-                    includeEmpty: false,
+                    includeEmpty: true,
                     emptyLabel: 'No Options',
                 },
             },

--- a/src/form-fields/DropDown.component.js
+++ b/src/form-fields/DropDown.component.js
@@ -11,7 +11,8 @@ function renderMenuItems({ menuItems, includeEmpty, emptyLabel }) {
     const renderedMenuItems = menuItems.map(({ id, displayName }) => renderMenuItem(id, displayName));
 
     if (includeEmpty) {
-        renderedMenuItems.unshift(renderMenuItem({ value: 'null', text: emptyLabel }));
+        // React will render an item with key = 'null' (String) so there is no problem here
+        renderedMenuItems.unshift(renderMenuItem(null, emptyLabel));
     }
     return renderedMenuItems;
 }
@@ -20,6 +21,11 @@ function createCallbackWithFakeEventFromMaterialSelectField(callback) {
     return (event, index, value) => callback({ target: { value } });
 }
 
+function selectionRenderer(value, menuItem) {
+    // Without this the empty option label would be showing together with the hintText
+    // this makes sure only the hint text is displayed when the empty option is selected
+    return value ? menuItem.props.primaryText : null;
+}
 
 function DropDown({ fullWidth, onFocus, onBlur, onChange, value, disabled, menuItems, hintText, includeEmpty, emptyLabel, noOptionsLabel, ...other }) {
     const menuItemArray = Array.isArray(menuItems) ? menuItems : menuItems.toArray();
@@ -31,6 +37,7 @@ function DropDown({ fullWidth, onFocus, onBlur, onChange, value, disabled, menuI
             hintText={hintText}
             onChange={createCallbackWithFakeEventFromMaterialSelectField(onChange)}
             disabled={!hasOptions || disabled}
+            selectionRenderer={selectionRenderer}
             {...other}
         >
             {hasOptions

--- a/src/form-fields/TextField.js
+++ b/src/form-fields/TextField.js
@@ -19,23 +19,32 @@ class TextField extends Component {
     };
 
     render() {
-        const {
-            changeEvent,
-            ...other
-        } = this.props;
+        const { changeEvent, ...other } = this.props;
 
         const errorStyle = {
             lineHeight: this.props.multiLine ? '48px' : '12px',
             marginTop: this.props.multiLine ? -16 : 0,
         };
 
+        const inputStyle =
+            other.type === 'search'
+                ? { WebkitAppearance: 'textfield' }
+                : {};
+
         return (
-            <MuiTextField errorStyle={errorStyle} {...other} value={this.state.value} onChange={this.change} />
+            <MuiTextField
+                errorStyle={errorStyle}
+                {...other}
+                value={this.state.value}
+                onChange={this.change}
+                inputStyle={inputStyle}
+            />
         );
     }
 }
 
 TextField.propTypes = {
+    changeEvent: PropTypes.string.isRequired,
     value: PropTypes.string,
     multiLine: PropTypes.bool,
 };


### PR DESCRIPTION
- DropDown now handles emptyOptions properly
- TextField can have type="search" and Safari will render correctly
- Updated examples to reflect both changes