### PR TITLE
Alternative way to display emptyOption

### DIFF
--- a/src/form-fields/DropDown.component.js
+++ b/src/form-fields/DropDown.component.js
@@ -11,20 +11,14 @@ function renderMenuItems({ menuItems, includeEmpty, emptyLabel }) {
     const renderedMenuItems = menuItems.map(({ id, displayName }) => renderMenuItem(id, displayName));
 
     if (includeEmpty) {
-        // React will render an item with key = 'null' (String) so there is no problem here
-        renderedMenuItems.unshift(renderMenuItem(null, emptyLabel));
+        const emptyMenuItem = <MenuItem primaryText={emptyLabel} key="no_value" value={null} label=" " />;
+        renderedMenuItems.unshift(emptyMenuItem);
     }
     return renderedMenuItems;
 }
 
 function createCallbackWithFakeEventFromMaterialSelectField(callback) {
     return (event, index, value) => callback({ target: { value } });
-}
-
-function selectionRenderer(value, menuItem) {
-    // Without this the empty option label would be showing together with the hintText
-    // this makes sure only the hint text is displayed when the empty option is selected
-    return value ? menuItem.props.primaryText : null;
 }
 
 function DropDown({ fullWidth, onFocus, onBlur, onChange, value, disabled, menuItems, hintText, includeEmpty, emptyLabel, noOptionsLabel, ...other }) {
@@ -37,7 +31,6 @@ function DropDown({ fullWidth, onFocus, onBlur, onChange, value, disabled, menuI
             hintText={hintText}
             onChange={createCallbackWithFakeEventFromMaterialSelectField(onChange)}
             disabled={!hasOptions || disabled}
-            selectionRenderer={selectionRenderer}
             {...other}
         >
             {hasOptions


### PR DESCRIPTION
- selectionRenderer function was causing problems in maintenance app so removed that
- Instead the empty items gets " " as a label which will still prevent anything from showing over the hintText