### PR TITLE
Sidebar with container element

### DIFF
--- a/examples/sidebar/index.js
+++ b/examples/sidebar/index.js
@@ -156,14 +156,14 @@ function SidebarExample(props) {
             </div>
             <div style={styles.box}>
                 <div style={styles.header}>
-                    <div style={styles.headerText}>Simple Sidebar with paths</div>
+                    <div style={styles.headerText}>Simple Sidebar with container elements</div>
                 </div>
                 <div style={styles.leftBar}>
                     <Sidebar
                         sections={sections.map(({ key, label }, i) => ({
                             key,
                             label,
-                            path: key,
+                            containerElement: (<a href="path" />),
                         }))}
                         currentSection={props.currentSection}
                     />

--- a/src/sidebar/Sidebar.component.js
+++ b/src/sidebar/Sidebar.component.js
@@ -135,18 +135,13 @@ class Sidebar extends Component {
                         ? <FontIcon className="material-icons">{section.icon}</FontIcon>
                         : section.icon;
 
-                    const otherProps = {};
-                    if (section.path) {
-                        otherProps.containerElement = <a href={section.path} />;
-                    }
-
                     return (<ListItem
                         key={section.key}
                         primaryText={section.label}
                         onClick={this.setSection.bind(this, section.key)}
                         style={listItemStyle}
                         leftIcon={icon}
-                        { ...otherProps }
+                        containerElement={section.containerElement}
                     />);
                 })}
             </List>
@@ -168,7 +163,7 @@ Sidebar.propTypes = {
     sections: PropTypes.arrayOf(PropTypes.shape({
         key: PropTypes.string,
         label: PropTypes.string,
-        path: PropTypes.string,
+        containerElement: PropTypes.object,
         icon: PropTypes.oneOfType([
             PropTypes.string,
             PropTypes.element,


### PR DESCRIPTION
Sidebar improvement in regard the previous addition of path. I have noticed it would be more flexible if we have the possibility to define the container element. It will make it easier to integrate with React Router for example.

@varl review it and merge please.