### PR TITLE
Fix/sharing dialog props and data table contect menu initial position

### DIFF
--- a/packages/sharing/src/SharingDialog.component.js
+++ b/packages/sharing/src/SharingDialog.component.js
@@ -44,7 +44,7 @@ class SharingDialog extends React.Component {
     componentDidMount() {
         this.loadDataSharingSettings();
         if (this.props.open && this.props.type && this.props.id) {
-            this.loadObjectFromApi();
+            this.loadObjectFromApi(this.props);
         }
     }
 
@@ -53,11 +53,11 @@ class SharingDialog extends React.Component {
 
         if (hasChanged('id') || hasChanged('type')) {
             this.resetState();
-            if (nextProps.open) this.loadObjectFromApi();
+            if (nextProps.open) this.loadObjectFromApi(nextProps);
         }
 
         if (!this.props.open && nextProps.open) {
-            this.loadObjectFromApi();
+            this.loadObjectFromApi(nextProps);
         }
     }
 
@@ -119,9 +119,8 @@ class SharingDialog extends React.Component {
         });
     }
 
-    loadObjectFromApi = () => {
+    loadObjectFromApi = ({ type, id }) => {
         const api = this.props.d2.Api.getApi();
-        const { type, id } = this.props;
 
         api
         .get('sharing', { type, id })

--- a/src/data-table/DataTableContextMenu.component.js
+++ b/src/data-table/DataTableContextMenu.component.js
@@ -13,9 +13,14 @@ function DataTableContextMenu(props, context) {
         .keys(props.actions)
         .filter(menuActionKey => typeof props.actions[menuActionKey] === 'function');
 
+    // Transition and left styles were added to prevent initial rendering in top-left
+    // https://github.com/mui-org/material-ui/issues/8040
     const cmStyle = {
         position: 'fixed',
+        left: -1000,
+        transition: 'left 0s, top 0s',
     };
+
     const {
         actions,
         activeItem,


### PR DESCRIPTION
These are two unrelated fixes:
 1. The SharingDialog would open OK from `componentDidMount`, but when called from `componentWillReceiveProps` it would be working with the old props which were about to be replaced. Now passing the props as parameters to `loadObjectFromApi ` and using nextProps in `componentWillReceiveProps`.
 2. When using React 16 and MaterialUI 0.19+ The DataTableContextMenu would initially render briefly in the top-left. Fixes with some CSS rules suggested int he issue thread https://github.com/mui-org/material-ui/issues/8040 and Eduardo's fix in the dashboard app.