### PR TITLE
Scope packages for dhis2

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "d2-ui-core",
+  "name": "@dhis2/d2-ui-core",
   "version": "1.0.0",
-  "description": "d2-ui-core",
+  "description": "Core components for DHIS2 in d2-ui",
   "main": "./build/cjs/index.js",
   "module": "./build/es/index.js",
   "files": [ "build" ],

--- a/packages/favorites-dialog/package.json
+++ b/packages/favorites-dialog/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "d2-ui-favorites-dialog",
-  "version": "1.0.4",
-  "description": "Favorite component for DHIS2",
+  "name": "@dhis2/d2-ui-favorites-dialog",
+  "version": "1.0.0",
+  "description": "Favorite Dialog component for DHIS2",
   "main": "./build/cjs/index.js",
   "module": "./build/es/index.js",
   "files": [ "build" ],

--- a/packages/favorites-menu/package.json
+++ b/packages/favorites-menu/package.json
@@ -1,10 +1,12 @@
 {
     "name": "d2-ui-favorites-menu",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Favorites menu component for DHIS2",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
-    "files": ["build"],
+    "files": [
+        "build"
+    ],
     "license": "BSD-3-Clause",
     "author": "Edoardo Sabadelli <edoardo@dhis2.org>",
     "peerDependencies": {
@@ -15,8 +17,7 @@
     "scripts": {
         "prebuild": "rimraf ./build/*",
         "build": "npm run build:commonjs && npm run build:es && npm run build:umd",
-        "build:commonjs":
-            "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
+        "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
         "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
         "build:umd": "cross-env && webpack -p",
         "watch": "npm run build:es -- --watch",
@@ -32,6 +33,8 @@
         "prop-types": "^15.6.0"
     },
     "jest": {
-        "transformIgnorePatterns": ["node_modules/(?!react-native|react-navigation)/"]
+        "transformIgnorePatterns": [
+            "node_modules/(?!react-native|react-navigation)/"
+        ]
     }
 }

--- a/packages/favorites-menu/package.json
+++ b/packages/favorites-menu/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "d2-ui-favorites-menu",
-    "version": "1.0.1",
+    "name": "@dhis2/d2-ui-favorites-menu",
+    "version": "1.0.0",
     "description": "Favorites menu component for DHIS2",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "d2-ui-formula-editor",
-  "version": "1.0.2",
-  "description": "DHIS2 component for sharing dialog",
+  "name": "@dhis2/d2-ui-formula-editor",
+  "version": "1.0.0",
+  "description": "Formula editor component for DHIS2",
   "main": "./build/cjs/index.js",
   "module": "./build/es/index.js",
   "files": [

--- a/packages/group-editor/package.json
+++ b/packages/group-editor/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "d2-ui-group-editor",
-  "version": "1.0.2",
-  "description": "DHIS2 component for sharing dialog",
+  "name": "@dhis2/d2-ui-group-editor",
+  "version": "1.0.0",
+  "description": "Group editor component for DHIS2",
   "main": "./build/cjs/index.js",
   "module": "./build/es/index.js",
   "files": [ "build" ],

--- a/packages/header-bar/package.json
+++ b/packages/header-bar/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "d2-ui-header-bar",
+  "name": "@dhis2/d2-ui-header-bar",
   "version": "1.0.0",
-  "description": "The header bar for all applications ",
+  "description": "The header bar for all DHIS2 applications",
   "main": "./build/cjs/index.js",
   "module": "./build/es/index.js",
   "files": [ "build" ],

--- a/packages/icon-picker/package.json
+++ b/packages/icon-picker/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "d2-ui-icon-picker",
-    "version": "1.0.2",
+    "name": "@dhis2/d2-ui-icon-picker",
+    "version": "1.0.0",
     "description": "DHIS2 component for selecting icon",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",

--- a/packages/legend/package.json
+++ b/packages/legend/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "d2-ui-legend",
-  "version": "1.0.2",
-  "description": "DHIS2 component for sharing dialog",
+  "name": "@dhis2/d2-ui-legend",
+  "version": "1.0.0",
+  "description": "Legend component for DHIS2",
   "main": "./build/cjs/index.js",
   "module": "./build/es/index.js",
   "files": [ "build" ],

--- a/packages/org-unit-select/package.json
+++ b/packages/org-unit-select/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "d2-ui-org-unit-select",
-  "version": "1.0.2",
-  "description": "DHIS2 component for sharing dialog",
+  "name": "@dhis2/d2-ui-org-unit-select",
+  "version": "1.0.0",
+  "description": "Org Unit Selection component for D2-UI",
   "main": "./build/cjs/index.js",
   "module": "./build/es/index.js",
   "files": [ "build" ],

--- a/packages/org-unit-tree/package.json
+++ b/packages/org-unit-tree/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "d2-ui-org-unit-tree",
-  "version": "1.0.2",
-  "description": "DHIS2 component for sharing dialog",
+  "name": "@dhis2/d2-ui-org-unit-tree",
+  "version": "1.0.0",
+  "description": "Org Unit Tree component for d2-ui",
   "main": "./build/cjs/index.js",
   "module": "./build/es/index.js",
   "files": [ "build" ],

--- a/packages/sharing-dialog/package.json
+++ b/packages/sharing-dialog/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "d2-ui-sharing-dialog",
-  "version": "1.0.2",
+  "name": "@dhis2/d2-ui-sharing-dialog",
+  "version": "1.0.0",
   "description": "DHIS2 component for sharing dialog",
   "main": "./build/cjs/index.js",
   "module": "./build/es/index.js",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "d2-ui-table",
-  "version": "1.0.2",
-  "description": "DHIS2 component for sharing dialog",
+  "name": "@dhis2/d2-ui-table",
+  "version": "1.0.0",
+  "description": "Table components for d2-ui",
   "main": "./build/cjs/index.js",
   "module": "./build/es/index.js",
   "files": [ "build" ],

--- a/packages/translation-dialog/package.json
+++ b/packages/translation-dialog/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "d2-ui-translation-dialog",
-  "version": "1.0.2",
-  "description": "DHIS2 component for sharing dialog",
+  "name": "@dhis2/d2-ui-translation-dialog",
+  "version": "1.0.0",
+  "description": "Translation Dialog for DHIS2",
   "main": "./build/cjs/index.js",
   "module": "./build/es/index.js",
   "files": [ "build" ],


### PR DESCRIPTION

Changes proposed in this pull request:

- Use semantic-release notation for commits
- add org scope (dhis2) to packages so we can deal with updates on a scope basis (`yarn upgrade --scope=dhis2`)
- update versions (copypaste mangled)
- update descriptions (copypaste mangled)

