### PR TITLE
refactor search field reference

### DIFF
--- a/packages/header-bar/src/search/SearchField.js
+++ b/packages/header-bar/src/search/SearchField.js
@@ -81,7 +81,10 @@ class SearchField extends Component {
                 <div style={styles.searchIconContainer}>
                     <SvgIcon icon="Search" style={styles.searchIcon} />
                 </div>
-                <div style={styles.searchFieldInnerWrap}>
+                <div
+                    ref={searchBox => { this.searchBox = searchBox; }}
+                    style={styles.searchFieldInnerWrap}
+                >
                     <TextField
                         fullWidth
                         value={this.props.searchValue || ''}
@@ -103,7 +106,6 @@ class SearchField extends Component {
 								...styles.searchFieldHintText,
 							},
 						}}
-                        ref={searchBox => { this.searchBox = searchBox; }}
                     />
                     {this.props.searchValue
 						? <ClearIcon style={styles.clearIcon}
@@ -119,10 +121,10 @@ class SearchField extends Component {
     }
 
     focusSearchField() {
-        const searchField = this.searchBox;
+        const searchBox = this.searchBox;
 
-        if (searchField && searchField !== document.activeElement) {
-            searchField.querySelector('input').focus();
+        if (searchBox && searchBox !== document.activeElement) {
+            searchBox.querySelector('input').focus();
         }
     }
 


### PR DESCRIPTION
- fix warning
_index.js:2178 Warning: Stateless function components cannot be given refs. Attempts to access this ref will fail._
- *material-ui* _TextField_ does not support _ref_ references
- move search box reference to parent div
- fix naming in _focusSearchField_ func. _searchField_ is referring to _searchBox_ then trying to find _searchField_

