### PR TITLE
LocaleSelector component test assumes state is an empty object, but no state is created in constructor

### DIFF
--- a/packages/translation-dialog/src/LocaleSelector.component.js
+++ b/packages/translation-dialog/src/LocaleSelector.component.js
@@ -9,6 +9,7 @@ class LocaleSelector extends Component {
 
         const i18n = this.context.d2.i18n;
         this.getTranslation = i18n.getTranslation.bind(i18n);
+        this.state = {};
     }
 
     onLocaleChange = (event, index, locale) => {

--- a/packages/translation-dialog/src/__tests__/LocaleSelector.component.spec.js
+++ b/packages/translation-dialog/src/__tests__/LocaleSelector.component.spec.js
@@ -38,7 +38,7 @@ describe('LocaleSelector component', () => {
     });
 
     it('should change the local state when field content is changed', () => {
-        expect(Component.state()).toEqual(null);
+        expect(Component.state()).toEqual({});
 
         Component.simulate('change', {}, 2, 'noren');
 

--- a/packages/translation-dialog/src/__tests__/LocaleSelector.component.spec.js
+++ b/packages/translation-dialog/src/__tests__/LocaleSelector.component.spec.js
@@ -38,7 +38,7 @@ describe('LocaleSelector component', () => {
     });
 
     it('should change the local state when field content is changed', () => {
-        expect(Component.state()).toEqual({});
+        expect(Component.state()).toEqual(null);
 
         Component.simulate('change', {}, 2, 'noren');
 


### PR DESCRIPTION
This is a bit strange that it started to fail now. I've checked the React code and they don't create the instance property `state` until the component either:

* sets it manually in the constructor
* calls `setState`

The component test is set up to expect that `state` is an empty object after the component is created. The component does not set `state` in the constructor so the test is incorrect.

Changes proposed in this pull request:

- Change the expected value from `{}` to `null`

