### PR TITLE
Remove Favorites dialog title

### DIFF
--- a/packages/favorites-dialog/src/Favorites.js
+++ b/packages/favorites-dialog/src/Favorites.js
@@ -1,11 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import Dialog, {
-    DialogActions,
-    DialogContent,
-    DialogTitle,
-} from 'material-ui/Dialog';
+import Dialog, { DialogActions, DialogContent } from 'material-ui/Dialog';
 import Button from 'material-ui/Button';
 
 import EnhancedToolbar from './EnhancedToolbar';
@@ -32,7 +28,6 @@ class Favorites extends Component {
 
         return (
             <Dialog open={open} onClose={onRequestClose} disableEnforceFocus={true} maxWidth="md">
-                <DialogTitle>Favorites</DialogTitle>
                 <DialogContent>
                     <EnhancedToolbar />
                     <EnhancedTable onFavoriteSelect={handleOnFavoriteSelect} />


### PR DESCRIPTION
"Favorites" cannot be used as it now a confusing term.
A title is not really needed for the dialog. Removed all together.

Fixes DHIS2-3935.

Changes proposed in this pull request:

- Remove title in Favorites dialog

