### PR TITLE
Fix FileMenu/Save when dealing with a new analytics object

### DIFF
--- a/packages/file-menu/src/FileMenu.js
+++ b/packages/file-menu/src/FileMenu.js
@@ -142,7 +142,10 @@ export class FileMenu extends Component {
                             !this.state.fileModel ||
                                 (this.state.fileModel && this.state.fileModel.access.update)
                         )}
+                        fileType={fileType}
+                        fileModel={this.state.fileModel}
                         onSave={this.onAction(onSave)}
+                        onSaveAs={this.onAction(onSaveAs)}
                         onClose={this.onAction()}
                     />
                     <SaveAsMenuItem

--- a/packages/file-menu/src/FileMenu.js
+++ b/packages/file-menu/src/FileMenu.js
@@ -102,11 +102,22 @@ export class FileMenu extends Component {
     };
 
     render() {
-        const { fileType, onSave, onSaveAs, onRename, onTranslate, onShare, onError } = this.props;
+        const {
+            classes,
+            fileType,
+            onSave,
+            onSaveAs,
+            onRename,
+            onTranslate,
+            onShare,
+            onError,
+        } = this.props;
 
         return (
             <Fragment>
-                <Button onClick={this.toggleMenu}>{i18n.t('File')}</Button>
+                <Button className={classes.menuButton} onClick={this.toggleMenu}>
+                    {i18n.t('File')}
+                </Button>
                 <Menu
                     disableEnforceFocus
                     open={this.state.menuIsOpen}
@@ -229,10 +240,10 @@ FileMenu.propTypes = {
 };
 
 const styles = theme => ({
-    menuItem: {
-        '&:focus': {
-            background: theme.palette.primary[500],
-        },
+    menuButton: {
+        textTransform: 'none',
+        fontSize: '16px',
+        fontWeight: 400,
     },
 });
 

--- a/packages/file-menu/src/SaveAsDialog.js
+++ b/packages/file-menu/src/SaveAsDialog.js
@@ -21,7 +21,7 @@ class SaveAsDialog extends Component {
 
     componentWillReceiveProps(nextProps) {
         // reset form to initial value when reopening the save as dialog
-        if (nextProps.open === true && !this.state.name) {
+        if (nextProps.open === true && nextProps.fileModel && !this.state.name) {
             this.setState({
                 name: nextProps.fileModel.displayName || '',
                 description: nextProps.fileModel.displayDescription || '',

--- a/packages/file-menu/src/SaveMenuItem.js
+++ b/packages/file-menu/src/SaveMenuItem.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import { ListItemIcon, ListItemText } from 'material-ui/List';
@@ -6,24 +6,81 @@ import { MenuItem } from 'material-ui/Menu';
 import Save from 'material-ui-icons/Save';
 
 import i18n from '@dhis2/d2-i18n';
+import SaveAsDialog from './SaveAsDialog';
 
-const SaveMenuItem = props => (
-    <MenuItem button onClick={props.onSave} disabled={!props.enabled}>
-        <ListItemIcon>
-            <Save />
-        </ListItemIcon>
-        <ListItemText primary={i18n.t('Save')} />
-    </MenuItem>
-);
+class SaveMenuItem extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            dialogIsOpen: false,
+        };
+    }
+
+    onClose = () => {
+        this.toggleSaveAsDialog();
+
+        if (this.props.onClose) {
+            this.props.onClose();
+        }
+    };
+
+    onSaveAs = form => {
+        this.toggleSaveAsDialog();
+
+        if (this.props.onSaveAs) {
+            this.props.onSaveAs(form);
+        }
+    };
+
+    toggleSaveAsDialog = () => {
+        this.setState({ dialogIsOpen: !this.state.dialogIsOpen });
+    };
+
+    render() {
+        const { enabled, fileType, fileModel, onSave } = this.props;
+
+        return (
+            <Fragment>
+                <MenuItem
+                    button
+                    onClick={fileModel ? onSave : this.toggleSaveAsDialog}
+                    disabled={!enabled}
+                >
+                    <ListItemIcon>
+                        <Save />
+                    </ListItemIcon>
+                    <ListItemText primary={i18n.t('Save')} />
+                </MenuItem>
+                {fileModel ? null : (
+                    <SaveAsDialog
+                        open={this.state.dialogIsOpen}
+                        fileType={fileType}
+                        onRequestClose={this.onClose}
+                        onRequestSaveAs={this.onSaveAs}
+                    />
+                )}
+            </Fragment>
+        );
+    }
+}
 
 SaveMenuItem.defaultProps = {
     enabled: false,
+    fileType: null,
+    fileModel: null,
     onSave: null,
+    onSaveAs: null,
+    onClose: null,
 };
 
 SaveMenuItem.propTypes = {
     enabled: PropTypes.bool,
+    fileType: PropTypes.oneOf(['chart', 'eventChart', 'reportTable', 'eventReport', 'map']),
+    fileModel: PropTypes.object,
     onSave: PropTypes.func,
+    onSaveAs: PropTypes.func,
+    onClose: PropTypes.func,
 };
 
 export default SaveMenuItem;

--- a/packages/file-menu/src/__tests__/FileMenu.spec.js
+++ b/packages/file-menu/src/__tests__/FileMenu.spec.js
@@ -14,6 +14,9 @@ describe('File: FileMenu component', () => {
 
     beforeEach(() => {
         props = {
+            classes: {
+                menuButton: { textDecoration: 'none' },
+            },
             d2: context.d2,
             fileType: 'chart',
             onNew: jest.fn(),

--- a/packages/file-menu/src/__tests__/SaveMenuItem.spec.js
+++ b/packages/file-menu/src/__tests__/SaveMenuItem.spec.js
@@ -3,22 +3,32 @@ import { shallow } from 'enzyme';
 import { MenuItem } from 'material-ui/Menu';
 import { ListItemText, ListItemIcon } from 'material-ui/List';
 
+import SaveAsDialog from '../SaveAsDialog';
 import SaveMenuItem from '../SaveMenuItem';
 
 describe('Favorites: FavoritesMenu > SaveMenuItem component', () => {
     let saveMenuItem;
     let onSave;
+    let onSaveAs;
     let props;
+    let saveAsDialog;
+
+    const renderComponent = props => {
+        return shallow(<SaveMenuItem {...props} />);
+    };
 
     beforeEach(() => {
         onSave = jest.fn();
+        onSaveAs = jest.fn();
 
         props = {
             enabled: true,
             onSave,
+            onSaveAs,
+            fileType: 'map',
         };
 
-        saveMenuItem = shallow(<SaveMenuItem {...props} />);
+        saveMenuItem = renderComponent(props);
     });
 
     it('should render the Save button', () => {
@@ -26,7 +36,33 @@ describe('Favorites: FavoritesMenu > SaveMenuItem component', () => {
         expect(saveMenuItem.find(ListItemText).props().primary).toEqual('Save');
     });
 
-    it('should trigger the onSave callback when the button is clicked', () => {
+    it('should open the SaveAs dialog on button click when no file object is present', () => {
+        const menuItem = saveMenuItem.find(MenuItem);
+        expect(menuItem.props().disabled).toBe(false);
+
+        menuItem.simulate('click');
+
+        saveAsDialog = saveMenuItem.find(SaveAsDialog);
+        expect(saveAsDialog.props().open).toBe(true);
+    });
+
+    it('should close the SaveAs dialog on click', () => {
+        saveMenuItem.find(MenuItem).simulate('click');
+        saveMenuItem.find(MenuItem).simulate('click');
+
+        saveAsDialog = saveMenuItem.find(SaveAsDialog);
+        expect(saveAsDialog.props().open).toBe(false);
+    });
+
+    it('should trigger the onSaveAs callback on form submit', () => {
+        saveMenuItem.find(SaveAsDialog).simulate('requestSaveAs');
+
+        expect(onSaveAs).toHaveBeenCalledTimes(1);
+    });
+
+    it('should trigger the onSave callback when the button is clicked and a file object is present', () => {
+        saveMenuItem = renderComponent({ ...props, fileModel: { id: 'some-file' } });
+
         const menuItem = saveMenuItem.find(MenuItem);
         expect(menuItem.props().disabled).toBe(false);
 


### PR DESCRIPTION
Fixes DHIS2-3935.

Changes proposed in this pull request:

- show the dialog for requesting name/description when saving a new analytics object and use the SaveAs callback (POST request)
- if an existing analytics object is available, use the Save callback (PUT request)
