### PR TITLE
Fix FileMenu fileId proptype

### DIFF
--- a/packages/file-menu/src/FileMenu.js
+++ b/packages/file-menu/src/FileMenu.js
@@ -33,15 +33,20 @@ export class FileMenu extends Component {
         d2: this.props.d2,
     });
 
-    componentWillReceiveProps = nextProps => {
-        if (nextProps.fileId) {
-            this.setFileModel(nextProps.fileId);
+    componentDidMount = () => {
+        if (this.props.fileId) {
+            this.setFileModel(this.props.fileId);
+        }
+    };
+
+    componentDidUpdate = prevProps => {
+        if (this.props.fileId && prevProps.fileId !== this.props.fileId) {
+            this.setFileModel(this.props.fileId);
         }
     };
 
     setFileModel = async id => {
         const model = await this.props.d2.models[this.props.fileType].get(id);
-
         this.setState({ fileModel: model });
     };
 
@@ -230,7 +235,7 @@ FileMenu.defaultProps = {
 FileMenu.propTypes = {
     d2: PropTypes.object,
     fileType: PropTypes.oneOf(['chart', 'eventChart', 'reportTable', 'eventReport', 'map']),
-    fileId: PropTypes.object,
+    fileId: PropTypes.string,
     onNew: PropTypes.func,
     onOpen: PropTypes.func,
     onSave: PropTypes.func,

--- a/packages/file-menu/src/__tests__/FileMenu.spec.js
+++ b/packages/file-menu/src/__tests__/FileMenu.spec.js
@@ -109,26 +109,15 @@ describe('File: FileMenu component', () => {
         fileMenu = renderComponent({ ...props, fileId: 'some-test-id' });
 
         // test async
-        Promise.resolve()
-            .then(() => {
-                fileMenu.update();
+        Promise.resolve().then(() => {
+            fileMenu.update();
 
-                return expect(fileMenu.find('SaveAsMenuItem').props().enabled).toBe(true);
-            })
-            .then(() => {
-                return expect(fileMenu.find('RenameMenuItem').props().enabled).toBe(true);
-            })
-            .then(() => {
-                return expect(fileMenu.find('TranslateMenuItem').props().enabled).toBe(true);
-            })
-            .then(() => {
-                return expect(fileMenu.find('ShareMenuItem').props().enabled).toBe(true);
-            })
-            .then(() => {
-                return expect(fileMenu.find('GetLinkMenuItem').props().enabled).toBe(true);
-            })
-            .then(() => {
-                return expect(fileMenu.find('DeleteMenuItem').props().enabled).toBe(true);
-            });
+            expect(fileMenu.find('SaveAsMenuItem').props().enabled).toBe(true);
+            expect(fileMenu.find('RenameMenuItem').props().enabled).toBe(true);
+            expect(fileMenu.find('TranslateMenuItem').props().enabled).toBe(true);
+            expect(fileMenu.find('ShareMenuItem').props().enabled).toBe(true);
+            expect(fileMenu.find('GetLinkMenuItem').props().enabled).toBe(true);
+            expect(fileMenu.find('DeleteMenuItem').props().enabled).toBe(true);
+        });
     });
 });

--- a/packages/file-menu/src/__tests__/FileMenu.spec.js
+++ b/packages/file-menu/src/__tests__/FileMenu.spec.js
@@ -11,6 +11,24 @@ describe('File: FileMenu component', () => {
     let props;
 
     const context = getStubContext();
+    context.d2.models = {
+        chart: {
+            get: jest.fn().mockReturnValue(
+                Promise.resolve({
+                    id: 'some-test-id',
+                    access: {
+                        update: true,
+                        manage: true,
+                        delete: true,
+                    },
+                })
+            ),
+        },
+    };
+
+    const renderComponent = props => {
+        return shallow(<FileMenu {...props} />);
+    };
 
     beforeEach(() => {
         props = {
@@ -30,7 +48,7 @@ describe('File: FileMenu component', () => {
             onError: jest.fn(),
         };
 
-        fileMenu = shallow(<FileMenu {...props} />);
+        fileMenu = renderComponent(props);
     });
 
     it('should have rendered a result', () => {
@@ -85,5 +103,32 @@ describe('File: FileMenu component', () => {
 
         button.simulate('click', { currentTarget: button });
         expect(fileMenu.find(Menu).props().open).toBe(false);
+    });
+
+    it('should enable the SaveAs button when an id is passed to props', () => {
+        fileMenu = renderComponent({ ...props, fileId: 'some-test-id' });
+
+        // test async
+        Promise.resolve()
+            .then(() => {
+                fileMenu.update();
+
+                return expect(fileMenu.find('SaveAsMenuItem').props().enabled).toBe(true);
+            })
+            .then(() => {
+                return expect(fileMenu.find('RenameMenuItem').props().enabled).toBe(true);
+            })
+            .then(() => {
+                return expect(fileMenu.find('TranslateMenuItem').props().enabled).toBe(true);
+            })
+            .then(() => {
+                return expect(fileMenu.find('ShareMenuItem').props().enabled).toBe(true);
+            })
+            .then(() => {
+                return expect(fileMenu.find('GetLinkMenuItem').props().enabled).toBe(true);
+            })
+            .then(() => {
+                return expect(fileMenu.find('DeleteMenuItem').props().enabled).toBe(true);
+            });
     });
 });


### PR DESCRIPTION
Fixes DHIS2-3935.

Changes proposed in this pull request:
- fix wrong prop type for fileId, it's String not Object
- add tests for the situation when fileId is passed as prop

