### PR TITLE
[interpretations] Ckeditor and mentions for interpretations and comments

### DIFF
--- a/packages/interpretations/README.md
+++ b/packages/interpretations/README.md
@@ -39,6 +39,24 @@ $ yarn link @dhis2/d2-ui-interpretations
 
 ## Usage
 
+This component uses CKEditor, so you'll need to load this resource from _dhis-web-core-resource_. Typically,
+this means adding this entry to `./webpack.config.js` under _vendorScripts_ (see an example [here](https://github.com/dhis2/maintenance-app/blob/bd75c6855eee603ce24fbd7b31464b6e1071d3c2/webpack.config.js#L124)):
+
+```js
+  plugins: [
+    new HTMLWebpackPlugin({
+      ...
+      vendorScripts: [
+        ...
+        [`${scriptPrefix}/dhis-web-core-resource/ckeditor/4.6.1/ckeditor.js`, 'defer async'],
+      ],
+    })
+  ]
+  ...
+```
+
+Finally, use the component in your React code:
+
 ```js
 import Interpretations from '@dhis2/d2-ui-interpretations';
 

--- a/packages/interpretations/i18n/en.pot
+++ b/packages/interpretations/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-06-14T08:22:53.939Z\n"
-"PO-Revision-Date: 2018-06-14T08:22:53.939Z\n"
+"POT-Creation-Date: 2018-06-15T10:55:59.533Z\n"
+"PO-Revision-Date: 2018-06-15T10:55:59.533Z\n"
 
 msgid "No description"
 msgstr ""
@@ -26,7 +26,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-msgid "User groups"
+msgid "user groups"
 msgstr ""
 
 msgid "Details"
@@ -47,6 +47,12 @@ msgstr ""
 msgid "Sharing"
 msgstr ""
 
+msgid "Most common users matching"
+msgstr ""
+
+msgid "Other users matching"
+msgstr ""
+
 msgid "OK"
 msgstr ""
 
@@ -65,6 +71,9 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
+msgid "Reply"
+msgstr ""
+
 msgid "Edit"
 msgstr ""
 
@@ -78,6 +87,9 @@ msgid "people commented"
 msgstr ""
 
 msgid "Are you sure you want to remove this comment?"
+msgstr ""
+
+msgid "more comments"
 msgstr ""
 
 msgid "Edit interpretation"

--- a/packages/interpretations/package.json
+++ b/packages/interpretations/package.json
@@ -21,14 +21,14 @@
     "build:es": "cross-env BABEL_ENV=es babel src --copy-files --out-dir build/es --ignore spec.js",
     "build:umd": "cross-env && webpack -p",
     "prestart": "yarn localize",
-    "watch": "npm run build:es --  --watch",
+    "watch": "yarn localize && npm run build:es -- --watch",
     "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
     "localize": "yarn extract-pot && d2-i18n-generate -n d2-ui-interpretations -p ./i18n/ -o ./src/locales/",
     "test-ci": "jest --config=../../jest.config.js packages/interpretations"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn extract-pot && CI=true yarn test && git add -A ."
+      "pre-commit": "yarn extract-pot && CI=true yarn test-ci"
     }
   },
   "dependencies": {
@@ -42,11 +42,13 @@
     "material-ui": "^0.19.3",
     "postcss-rtl": "^1.3.0",
     "prop-types": "^15.5.10",
+    "react-portal": "^4.1.5",
     "recompose": "^0.26.0",
     "rxjs": "^5.5.7"
   },
   "devDependencies": {
     "css-loader": "^0.28.7",
+    "sinon": "^6.0.0",
     "style-loader": "^0.18.2"
   },
   "jest": {

--- a/packages/interpretations/src/components/html-editor/CKEditor.js
+++ b/packages/interpretations/src/components/html-editor/CKEditor.js
@@ -1,0 +1,309 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { noop, some } from 'lodash/fp';
+import log from 'loglevel';
+
+/* Additions from standard CKEditor:
+
+    - Tweak internal editor CSS (CKEDITOR.addCss)
+    - Tweak external (toolbar, dialogs) CSS
+    - Add cke_smiley class to dialog to allow custom styling.
+    - Dock position of smiley dialog to button
+    - Hide dialogs on click outside dialog.
+*/
+
+class WrappedEditor {
+    constructor(editor) {
+        this.editor = editor;
+    }
+
+    getValue() {
+        return this.editor.getData();
+    }
+
+    setCursorAtEnd() {
+        setTimeout(() => {
+            this.editor.focus();
+            const range = this.editor.createRange();
+            const selection = this.editor.getSelection();
+            if (range && selection) {
+                range.moveToElementEditEnd(range.root);
+                this.editor.getSelection().selectRanges([range]);
+            }
+        }, 300);
+    }
+
+    getPosition(offset = null) {
+        const range = this.editor.getSelection().getRanges()[0];
+        const bbox = range ? range.startContainer.$.parentNode.getBoundingClientRect() : {top: 0, left: 0};
+        const iframe = this.editor.container.$.getElementsByTagName("iframe")[0];
+        const iframeBbox = iframe.getBoundingClientRect();
+        const pos = { top: bbox.top + iframeBbox.top, left: bbox.left + iframeBbox.left };
+        return offset ? { top: pos.top + offset.top, left: pos.left + offset.left } : pos;
+    }
+
+    getCurrentWord() {
+        const range = this.editor.getSelection().getRanges()[0];
+        if (range) {
+            const text = range.startContainer.type === CKEDITOR.NODE_TEXT ? range.startContainer.getText() : "";
+            const startOffset = range.startOffset;
+            return text.slice(0, startOffset).split(/\s+/).slice(-1)[0].replace(/[^\x00-\x7F]/g, "");
+        } else {
+            return "";
+        }
+    }
+
+    replaceCurrentWord(newText) {
+        const range = this.editor.getSelection().getRanges()[0];
+        if (range) {
+            // Replace current word
+            const container = range.startContainer.$;
+            const text = container.textContent;
+            const startOffset = range.startOffset;
+            const index = text.slice(0, startOffset).lastIndexOf(" ");
+            const before = text.slice(0, index + 1);
+            const after = text.slice(startOffset, -1);
+            const containerText = before + newText + "\xA0" + after.replace(/^\s+/, '');
+            container.textContent = containerText;
+
+            // Move to the end of word
+            const newRange = this.editor.createRange();
+            const newOffset = (before + newText).length + 1;
+            newRange.setStart(range.startContainer, newOffset);
+            newRange.setEnd(range.startContainer, newOffset);
+            this.editor.getSelection().selectRanges([newRange]);
+
+            return containerText;
+        } else {
+            return null;
+        }
+    }
+}
+
+export default class CKEditor extends Component {
+    static defaultOptions = {
+        plugins: [
+            'link', 'smiley', 'toolbar', 'undo', 'wysiwygarea',
+        ].join(','),
+        removePlugins: 'scayt,wsc,about,elementspath',
+        toolbar: [
+            {name: 'actions', items: ['Link', 'Smiley']},
+        ],
+        smiley_images: [
+            'regular_smile.png',
+            'sad_smile.png',
+            'wink_smile.png',
+            'thumbs_down.png',
+            'thumbs_up.png'
+        ],
+        resize_enabled: false,
+        allowedContent: true,
+        extraPlugins: 'div',
+        height: 80,
+    };
+
+    static editorCss = `
+        body { margin: 0; margin-left: 5px; font-family: Helvetica !important; font-size: 14px !important; }
+        p { margin: 0px; line-height: auto; }
+        img { width: 1.3em; height: 1.3em; }
+    `;
+
+    static externalCss = `
+        .cke_top {
+            padding: 0 !important;
+        }
+
+        .cke_toolgroup {
+            margin: 0;
+        }
+
+        .cke_dialog {
+            z-index: 20000 !important;
+        }
+
+        .cke_smiley .cke_dialog_footer {
+            display: none;
+        }
+
+        .cke_smiley .cke_dialog_title,
+        .cke_smiley .cke_dialog_close_button {
+            display: none;
+        }
+
+        .cke_dialog_background_cover {
+            opacity: 0 !important;
+            z-index: 19500 !important;
+        }
+
+        a.cke_button_off.active {
+            background: #e5e5e5;
+            border: 1px #bcbcbc solid;
+            padding: 3px 5px;
+        }
+
+        .cke_dialog_contents_body {
+            padding: 9px 10px 9px 10px !important;
+            height: auto !important;
+        }
+
+        .cke_smiley .cke_dialog_contents_body {
+            width: 150px !important;
+        }
+    `;
+
+    constructor(props, context) {
+        super(props, context);
+        this._onDocumentClick = this._onDocumentClick.bind(this);
+        this.setContainerRef = this.setContainerRef.bind(this);
+    }
+
+    componentWillReceiveProps(newProps) {
+        if (this.editor && newProps.refresh !== this.props.refresh) {
+            this.editor.setData(newProps.initialContent);
+            const wrappedEditor = new WrappedEditor(this.editor);
+            wrappedEditor.setCursorAtEnd();
+        }
+    }
+
+    componentDidMount() {
+        const { onEditorChange = noop, onEditorInitialized = noop, options = {}, onEditorKey } = this.props;
+        const { editorCss } = this.constructor;
+
+        if (!window.CKEDITOR) {
+            log.error('CKEDITOR namespace can not be found on the window. You probably forgot to load the CKEditor script');
+        }
+
+        if (!CKEDITOR.getCss().includes(editorCss)) {
+            CKEDITOR.addCss(editorCss);
+        }
+
+        const fullOptions = {...this.constructor.defaultOptions, ...options};
+        this.editor = window.CKEDITOR.replace(this.editorContainer, fullOptions);
+
+        this.editor.setData(this.props.initialContent);
+        this.editor.on("dialogShow", this._onDialogShow.bind(this));
+        this.editor.on("dialogHide", this._onDialogHide.bind(this));
+        this.editor.on('change', () => onEditorChange(this.editor.getData()));
+        if (onEditorKey)
+            this.editor.on('key', this._onEditorKey.bind(this, onEditorKey));
+
+        // Callback to the parent to pass the editor instance so the parent can call functions on it like insertHTML.
+        onEditorInitialized(new WrappedEditor(this.editor));
+    }
+
+    _onEditorKey(onEditorKey, ev) {
+        onEditorKey(ev);
+    }
+
+    _onDialogShow(ev) {
+        const {data: dialog, editor} = ev;
+        const {name, element} = dialog._;
+        this.dialog = dialog;
+
+        const button = document.getElementsByClassName("cke_button__" + name)[0];
+        if (button) {
+            button.classList.add("active");
+        }
+
+        if (name === "smiley") {
+            element.addClass("cke_smiley");
+        }
+
+        document.body.addEventListener('click', this._onDocumentClick);
+        this._setDialogPosition(editor, dialog);
+    }
+
+    _onDialogHide(ev) {
+        Array.from(document.getElementsByClassName("cke_button"))
+            .forEach(el => el.classList.remove("active"));
+        document.body.removeEventListener('click', this._onDocumentClick);
+        this.dialog = null;
+    }
+
+    _onDocumentClick(ev) {
+        if (!this.dialog)
+            return;
+        let parents = [];
+        let el = ev.target;
+        while (el) {
+            parents.push(el);
+            el = el.parentElement;
+        }
+        const clickInsideDialog = some(node => node.classList.contains("cke_dialog"), parents);
+        if (!clickInsideDialog) {
+            this.dialog.hide();
+        }
+    }
+
+    _setDialogPosition(editor, dialog) {
+        const buttonObj = editor.toolbar[0].items.find(item => item.name == "smiley");
+        if (dialog._.name != "smiley" || !buttonObj)
+            return;
+        const button = document.getElementById(buttonObj._.id);
+        if (!button)
+            return;
+        const {top: buttonTop, left: buttonLeft, width: buttonWidth, height: buttonHeight} =
+            button.getBoundingClientRect();
+        const {width: dialogWidth, height: dialogHeight} = dialog.getSize();
+        const newDialogPosition = {
+            top: buttonTop < window.innerHeight / 2 ? buttonTop + buttonHeight : buttonTop - dialogHeight,
+            left: buttonLeft < window.innerWidth / 2 ? buttonLeft : buttonLeft + buttonWidth - dialogWidth,
+        };
+
+        dialog.move(newDialogPosition.left, newDialogPosition.top);
+    }
+
+    componentWillUnmount() {
+        if (this.editor) {
+            this.editor.destroy();
+        }
+    }
+
+    shouldComponentUpdate() {
+        return false;
+    }
+
+    setContainerRef(textarea) {
+        this.editorContainer = textarea;
+    }
+
+    render() {
+        return (
+            <div>
+                <style>{this.constructor.externalCss}</style>
+                <textarea ref={this.setContainerRef} />
+            </div>
+        );
+    }
+}
+
+CKEditor.propTypes = {
+    /**
+     * Object for CKEditor.replace.
+     */
+    options: PropTypes.object,
+    /**
+     * Change handler that will be called when the content of the editor changed.
+     */
+    onEditorChange: PropTypes.func,
+    /**
+     * This callback will be called when the editor is mounted to the DOM. It will receive the instance of the CKEditor
+     * that was mounted.
+     */
+    onEditorInitialized: PropTypes.func,
+    /**
+     * This is the initial content that the editor should render with. This content will only be added on the
+     * `componentDidMount` lifecycle, updating the content will need to be done though setting it on the editor instance
+     * directly by calling CKEditor functions like `editor.insertHtml()`.
+     */
+    initialContent: PropTypes.string,
+    /**
+     * Value of any type used to refresh key. Simply send a new value whenever you want to
+     * set the editor contents (from props.initialContent).
+     */
+    refresh: PropTypes.any,
+    /**
+      * This callback will be called when a key is pressed in the editor
+      */
+    onEditorKey: PropTypes.func,
+};

--- a/packages/interpretations/src/components/html-editor/RichEditor.js
+++ b/packages/interpretations/src/components/html-editor/RichEditor.js
@@ -1,0 +1,255 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Dialog from 'material-ui/Dialog';
+import { Portal } from 'react-portal';
+import { findIndex } from 'lodash/fp';
+import i18n from '@dhis2/d2-i18n'
+import CKEditor from './CKEditor';
+
+const styles = {
+    mentions: {
+        position: "absolute",
+        boxShadow: "rgb(136, 136, 136) 0px 0px 4px 0px",
+        margin: 0,
+        padding: 4,
+        zIndex: 1000000,
+        backgroundColor: "#FAFFFA",
+        listStyleType: "none",
+        fontFamily: "Roboto, sans-serif",
+        maxHeight: "200px",
+        overflowY: "auto"
+    },
+    mentionTitle: {
+        padding: "5px 15px",
+        borderBottom: "1px solid rgb(224, 224, 224)",
+        fontSize: "0.75rem",
+        fontWeight: 500
+    },
+    userMention: {
+        cursor: "pointer",
+        padding: "5px 15px",
+        borderBottom: "1px solid rgb(224, 224, 224)",
+        fontSize: "0.75rem"
+    },
+    userMentionSelected: {
+        backgroundColor: "#ACD",
+    },
+};
+
+class UserMatch extends Component {
+    constructor(props, context) {
+        super(props, context);
+        this.onUserClick = this.onUserClick.bind(this);
+        this.onMouseEnter = this.onChangeSelected.bind(this, true);
+        this.onMouseLeave = this.onChangeSelected.bind(this, false);
+    }
+
+    onUserClick() {
+        this.props.onClick(this.props.user);
+    }
+
+    onChangeSelected(isSelected) {
+        this.props.onMouseSelected(this.props.user, isSelected);
+    }
+
+    render() {
+        const { user, isSelected, pattern } = this.props;
+        const style = { ...styles.userMention, ...(isSelected ? styles.userMentionSelected : {}) };
+        const text = `${user.displayName} (${user.username})`;
+        let formatted;
+        if (pattern) {
+            formatted = text
+                .split(new RegExp(`(${pattern})`, 'gi'))
+                .map((part, idx) => part.toLowerCase() === pattern.toLowerCase() ? <b key={idx}>{part}</b> : part);
+        }
+        else {
+            formatted = text;
+        }
+
+        return (
+            <li
+                style={style}
+                onClick={this.onUserClick}
+                onMouseEnter={this.onMouseEnter}
+                onMouseLeave={this.onMouseLeave}
+            >
+                <span>{formatted}</span>
+            </li>
+        );
+    };
+}
+
+const keycodes = {up: 38, down: 40, enter: 13, tab: 9};
+
+const userType = PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    displayName: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
+});
+
+export default class RichEditor extends Component {
+    static propTypes = {
+        ...CKEditor.propTypes,
+        mentions: PropTypes.shape({
+            allUsers: PropTypes.arrayOf(userType).isRequired,
+            mostMentionedUsers: PropTypes.arrayOf(userType).isRequired,
+        }),
+    };
+
+    constructor(props, context) {
+        super(props, context);
+        this.onEditorInitialized = this.onEditorInitialized.bind(this);
+        this.onEditorChange = this.onEditorChange.bind(this);
+        this.insertUser = this.insertUser.bind(this);
+        this.onEditorKey = this.onEditorKey.bind(this);
+        this.onMouseSelected = this.onMouseSelected.bind(this);
+        this.setMentionsRef = this.setMentionsRef.bind(this);
+        this.onDocumentClick = this.onDocumentClick.bind(this);
+        this.userMatchRefs = {};
+        this.state = {matchingUsers: [], currentUserIndex: null, splitListIndex: null, pattern: null, position: null};
+    }
+
+    componentDidMount () {
+      document.addEventListener('click', this.onDocumentClick);
+    }
+
+    componentWillUnmount () {
+      document.removeEventListener('click', this.onDocumentClick);
+    }
+
+    onDocumentClick(ev) {
+      const area = ReactDOM.findDOMNode(this.mentionsArea);
+
+      if (area && !area.contains(ev.target)) {
+        this.clearMentions();
+      }
+    }
+
+    insertUser(user) {
+        this.editor.replaceCurrentWord(`@${user.username}`);
+        this.props.onEditorChange(this.editor.getValue());
+        this.clearMentions();
+    }
+
+    clearMentions() {
+        this.setState({matchingUsers: [], currentUserIndex: null});
+    }
+
+    onEditorInitialized(editor) {
+        this.editor = editor;
+        editor.setCursorAtEnd();
+    }
+
+    selectUser(offset) {
+        const { matchingUsers, currentUserIndex } = this.state;
+        const nUsers = matchingUsers.length;
+        const newIndex = (currentUserIndex + offset + nUsers) % nUsers;
+        this.setState({currentUserIndex: newIndex});
+        const el = this.userMatchRefs[newIndex];
+        if (el) {
+            ReactDOM.findDOMNode(el).scrollIntoView();
+        }
+    }
+
+    onEditorKey(ev) {
+        const { matchingUsers, currentUserIndex } = this.state;
+        const { keyCode } = ev.data;
+
+        if (currentUserIndex === null) {
+            return;
+        } else if (keyCode == keycodes.up) {
+            ev.cancel();
+            this.selectUser(-1);
+        } else if (keyCode == keycodes.down) {
+            ev.cancel();
+            this.selectUser(+1);
+        } else if (keyCode == keycodes.enter || keyCode == keycodes.tab) {
+            ev.cancel();
+            const currentUser = matchingUsers[currentUserIndex];
+            this.insertUser(currentUser);
+        }
+    }
+
+    onEditorChange(newValue) {
+        const { mentions, onEditorChange } = this.props;
+        onEditorChange(newValue);
+        if (mentions)
+            this.showMentions(mentions);
+    }
+
+    showMentions(mentions) {
+        const currentWord = this.editor.getCurrentWord();
+        let matchingUsers;
+
+        if (currentWord.startsWith("@")) {
+            const pattern = currentWord.slice(1);
+            const filter = users => users
+                .filter(user => user.displayName.includes(pattern) || user.username.includes(pattern));
+            const mostMentionedUsersFiltered = filter(mentions.mostMentionedUsers);
+            const allUsersFiltered = filter(mentions.allUsers);
+            const matchingUsers = mostMentionedUsersFiltered.concat(allUsersFiltered);
+            const splitListIndex = mostMentionedUsersFiltered.length;
+            const position = this.editor.getPosition({top: 25, left: 0});
+            this.setState({ pattern, matchingUsers, currentUserIndex: 0, splitListIndex, position });
+        } else {
+            this.setState({ pattern: null, matchingUsers: [], currentUserIndex: null });
+        }
+    }
+
+    onMouseSelected(user, isSelected) {
+        if (isSelected) {
+            const index = findIndex(u => user.id === u.id, this.state.matchingUsers);
+            if (index >= 0)
+                this.setState({ currentUserIndex: index });
+        }
+    }
+
+    setMentionsRef(mentionsArea) {
+        this.mentionsArea = mentionsArea;
+    }
+
+    setUserMatchRef(userMatchEl, idx) {
+        this.userMatchRefs[idx] = userMatchEl;
+    }
+
+    render() {
+        const { pattern, matchingUsers, currentUserIndex, splitListIndex, position } = this.state;
+        const { mentions, ...ckeditorProps } = this.props;
+        const getTitleItem = title => (
+            <li key="most-mentioned" style={styles.mentionTitle}>
+                {title} @{pattern}
+            </li>
+        );
+
+        return (
+            <div>
+                {matchingUsers.length > 0 && position &&
+                    <Portal>
+                        <ul style={{...styles.mentions, ...position}} ref={this.setMentionsRef}>
+                            {matchingUsers.map((user, idx) => [
+                                idx === 0 && idx !== splitListIndex && getTitleItem(i18n.t("Most common users matching")),
+                                idx === splitListIndex && getTitleItem(i18n.t("Other users matching")),
+                                <UserMatch
+                                    ref={el => this.setUserMatchRef(el, idx)}
+                                    key={"user-" + user.id}
+                                    pattern={pattern}
+                                    isSelected={idx === currentUserIndex}
+                                    user={user}
+                                    onClick={this.insertUser}
+                                    onMouseSelected={this.onMouseSelected}
+                                />,
+                            ])}
+                        </ul>
+                    </Portal>
+                }
+
+                <CKEditor
+                    {...ckeditorProps}
+                    onEditorChange={this.onEditorChange}
+                    onEditorKey={this.onEditorKey}
+                    onEditorInitialized={this.onEditorInitialized}
+                />
+            </div>
+        );
+    }
+}

--- a/packages/interpretations/src/components/html-editor/__tests__/CKEditor.spec.js
+++ b/packages/interpretations/src/components/html-editor/__tests__/CKEditor.spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import CKEditor from '../CKEditor';
+
+const renderComponent = (partialProps = {}, partialContext = {}) => {
+    const baseProps = {};
+    const props = {...baseProps, ...partialProps};
+    return shallow(<CKEditor {...props} />);
+};
+
+class CKEditorStub {
+    setData(data) {}
+    on() {}
+}
+
+window.CKEDITOR = {
+    replace: () => new CKEditorStub(),
+    getCss: () => "",
+    addCss: (css) => {},
+};
+
+let ckeditorComponent;
+
+describe('html-editor: CKEditor component', () => {
+    beforeEach(() => {
+        ckeditorComponent = renderComponent();
+    });
+
+    it('should render a textarea', () => {
+        expect(ckeditorComponent.find('textarea')).toHaveLength(1);
+    });
+});

--- a/packages/interpretations/src/components/html-editor/__tests__/RichEditor.spec.js
+++ b/packages/interpretations/src/components/html-editor/__tests__/RichEditor.spec.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import RichEditor from '../RichEditor';
+
+const mentions = {
+    mostMentionedUsers: [{
+        "displayName": "Didier Konan",
+        "id": "I9fMsY4pRKk",
+        "username": "konan"
+    }, {
+        "displayName": "Donor User",
+        "id": "cddnwKV2gm9",
+        "username": "donor"
+    }, {
+        "displayName": "Bombali District",
+        "id": "NOOF56dveaZ",
+        "username": "bombali"
+    }],
+    allUsers: [{
+        id: 'rWLrZL8rP3K',
+        displayName: 'Guest User',
+        username: 'guest'
+    }]
+};
+
+const renderComponent = (partialProps = {}, partialContext = {}) => {
+    const baseProps = {
+      mentions: mentions,
+    };
+    const props = {...baseProps, ...partialProps};
+    return shallow(<RichEditor {...props} />);
+};
+
+let richEditorComponent;
+
+describe('html-editor: RichEditor component', () => {
+    beforeEach(() => {
+        richEditorComponent = renderComponent();
+    });
+
+    it('should render a CKEditor component', () => {
+        expect(richEditorComponent.find('CKEditor')).toHaveLength(1);
+    });
+
+    it('should not render a portal component for mentions', () => {
+        expect(richEditorComponent.find('Portal')).toHaveLength(0);
+    });
+});

--- a/packages/interpretations/src/components/interpretations/CommentTextarea.js
+++ b/packages/interpretations/src/components/interpretations/CommentTextarea.js
@@ -3,26 +3,31 @@ import PropTypes from 'prop-types'
 import { Link, ActionSeparator } from './misc';
 import i18n from '@dhis2/d2-i18n'
 import styles from './InterpretationsStyles.js';
+import RichEditor from '../html-editor/RichEditor';
 
 class CommentTextarea extends React.Component {
     static propTypes = {
         comment: PropTypes.object.isRequired,
         onPost: PropTypes.func.isRequired,
         onCancel: PropTypes.func,
+        mentions: PropTypes.object,
     };
 
     constructor(props) {
         super(props);
-        this.state = { text: props.comment.text || "" };
+        this.state = { text: props.comment.text || "", refresh: new Date() };
         this.onPost = this.onPost.bind(this);
+        this.onChange = this.onChange.bind(this);
     }
 
-    componentWillReceiveProps(nextProps) {
-        this.setState({ text: nextProps.comment.text });
+    componentWillReceiveProps(newProps) {
+        if (this.props.comment !== newProps.comment) {
+            this.setState({ text: newProps.comment.text, refresh: new Date() });
+        }
     }
 
-    onChange(ev) {
-        this.setState({ text: ev.target.value });
+    onChange(newText) {
+        this.setState({ text: newText });
     }
 
     onPost() {
@@ -31,19 +36,26 @@ class CommentTextarea extends React.Component {
             const newComment = this.props.comment;
             newComment.text = newText;
             this.props.onPost(newComment);
-            this.setState({ text: "" });
+            this.setState({ text: "", refresh: new Date().getTime() });
         }
     }
 
     render() {
-        const { comment, onCancel } = this.props;
-        const { text } = this.state;
+        const { comment, onCancel, mentions } = this.props;
+        const { text, refresh } = this.state;
         const postText = onCancel ? i18n.t("OK") : i18n.t('Post comment');
 
         return (
             <div>
-                <textarea style={styles.commentArea} value={text} rows={4} onChange={ev => this.onChange(ev)} />
+                <RichEditor
+                    onEditorChange={this.onChange}
+                    initialContent={text}
+                    refresh={refresh}
+                    mentions={mentions}
+                />
+
                 <Link disabled={!text} label={postText} onClick={this.onPost} />
+
                 {onCancel &&
                     <span>
                         <ActionSeparator />

--- a/packages/interpretations/src/components/interpretations/InterpretationsCard.js
+++ b/packages/interpretations/src/components/interpretations/InterpretationsCard.js
@@ -38,6 +38,7 @@ const getInterpretationsList = props => {
                         interpretation={interpretation}
                         onChange={onChange}
                         extended={false}
+                        mentions={model.mentions}
                     />
                 </div>
             ))}
@@ -56,6 +57,7 @@ const getInterpretationDetails = props => {
             interpretation={interpretation}
             onChange={onChange}
             extended={true}
+            mentions={model.mentions}
         />
     );
 };
@@ -190,6 +192,7 @@ class InterpretationsCard extends React.Component {
                         interpretation={interpretationToEdit}
                         onSave={this.saveInterpretationAndClose}
                         onClose={this.closeInterpretationDialog}
+                        mentions={model.mentions}
                     />
                 }
 

--- a/packages/interpretations/src/components/interpretations/InterpretationsStyles.js
+++ b/packages/interpretations/src/components/interpretations/InterpretationsStyles.js
@@ -41,6 +41,10 @@ export default {
         "marginLeft": 4,
     },
 
+    actions: {
+        "marginBottom": 5,
+    },
+
     greyBackground: {
         "backgroundColor": "#efefef",
         "marginTop": 2,
@@ -80,10 +84,19 @@ export default {
         "display": "inline-block",
     },
 
-    interpretationText: {
+    interpretationTextWrapper: {
         "marginBottom": 5,
         "marginLeft": 0,
         "marginTop": 5,
+    },
+
+    interpretationTextLimited: {
+        "display": "block",
+        "textOverflow": "ellipsis",
+        "wordWrap": "break-word",
+        "overflow": "hidden",
+        "maxHeight": "3.0em",
+        "lineHeight": "1.5em",
     },
 
     interpretationsCard: {
@@ -146,4 +159,20 @@ export default {
         "fontWeight": "bold",
         "textDecoration": "none",
     },
+
+    showMoreComments: {
+        "fontSize": "11px",
+        "textTransform": "uppercase",
+        "paddingLeft": "16px",
+        "paddingRight": "16px",
+        "fontWeight": "500",
+    },
+
+    richTextCss: `
+        .richText p { margin: 0; padding: 0 }
+        .richText img { width: 1.3em; height: 1.3em; }
+        .richText strong { font-weight: bold; }
+        .richText em { font-style: italic; }
+        .richText a { text-decoration: none; }
+    `,
 };

--- a/packages/interpretations/src/components/interpretations/__tests__/CommentTextarea.spec.js
+++ b/packages/interpretations/src/components/interpretations/__tests__/CommentTextarea.spec.js
@@ -36,8 +36,8 @@ describe('Interpretations: Interpretations -> CommentTextarea component', () => 
             commentTextarea = renderComponent({onPost: jest.fn(), onCancel: undefined});
         });
 
-        it('should render a textarea with the comment text', () => {
-            expect(commentTextarea.find("textarea")).toHaveProp("value", comment.text)
+        it('should render a RichEditor with the comment text', () => {
+            expect(commentTextarea.find("RichEditor")).toHaveProp("initialContent", comment.text)
         });
 
         it('should render a post link', () => {
@@ -52,7 +52,7 @@ describe('Interpretations: Interpretations -> CommentTextarea component', () => 
 
         describe("when post is clicked with new text on textarea", () => {
             beforeEach(() => {
-                commentTextarea.find("textarea").simulate('change', {target: {value: "new text"}});
+                commentTextarea.find("RichEditor").props().onEditorChange("new text");
                 const links = commentTextarea.find("Link");
                 const postLink = links.findWhere(link => link.props().label === "Post comment");
                 postLink.simulate("click");
@@ -76,7 +76,7 @@ describe('Interpretations: Interpretations -> CommentTextarea component', () => 
         });
 
         it('should render a textarea with the comment text', () => {
-            expect(commentTextarea.find("textarea")).toHaveProp("value", comment.text)
+            expect(commentTextarea.find("RichEditor")).toHaveProp("initialContent", comment.text)
         });
 
         it('should render an ok link', () => {
@@ -101,7 +101,7 @@ describe('Interpretations: Interpretations -> CommentTextarea component', () => 
                     .simulate("click");
             });
 
-            it("should call onCancel with the updated comment", () => {
+            it("should call onCancel", () => {
                 const onCancel = commentTextarea.instance().props.onCancel;
                 expect(onCancel).toHaveBeenCalledTimes(1);
             });
@@ -125,8 +125,8 @@ describe('Interpretations: Interpretations -> CommentTextarea component', () => 
                 }));
             });
 
-            it("should clear the textarea", () => {
-                expect(commentTextarea.find("textarea")).toHaveProp("value", "");
+            it("should clear the RichEditor", () => {
+                expect(commentTextarea.find("RichEditor")).toHaveProp("initialContent", "");
             });
         });
     });

--- a/packages/interpretations/src/components/interpretations/__tests__/InterpretationComments.spec.js
+++ b/packages/interpretations/src/components/interpretations/__tests__/InterpretationComments.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import _ from 'lodash';
 import InterpretationComments from '../InterpretationComments';
+import InterpretationModel from '../../../models/interpretation';
 import { getStubContext } from '../../../../../../config/inject-theme';
 
 const context = getStubContext();
@@ -35,7 +36,7 @@ const interpretation = {
 
 const renderComponent = (partialProps = {}, partialContext = {}) => {
     const baseProps = {
-        interpretation: interpretation,
+        interpretation: new InterpretationModel({}, interpretation),
         onSave: jest.fn(),
         onDelete: jest.fn(),
     };
@@ -63,29 +64,23 @@ describe('Interpretations: Interpretations -> InterpretationComments component',
         commentComponents = interpretationComments.find("Comment");
     });
 
-    it('should render a non-cancellable comment text area component', () => {
-        const commentTextarea = interpretationComments.find("CommentTextarea");
-        expect(commentTextarea.props().comment.text).toEqual("");
-        expect(commentTextarea).not.toHaveProp("onCancel");
-    });
-
     describe('list of comments', () => {
         it('should render interpretation comments', () => {
             expect(commentComponents).toHaveLength(interpretation.comments.length);
         });
 
-        it('should be sorted by date (from newest to oldest)', () => {
+        it('should be sorted by date (from oldest to newest)', () => {
             const commentIds = commentComponents.map(commentComponent => commentComponent.props().comment.id);
-            expect(commentIds).toEqual(["gerk24EJ22x", "tEvCRL8r9KW"]);
+            expect(commentIds).toEqual(["tEvCRL8r9KW", "gerk24EJ22x"]);
         });
 
         it('should render actions for a comment if current user is its author', () => {
             commentComponents.forEach(commentComponent => {
-                const showActions = commentComponent.props().showActions;
+                const showManageActions = commentComponent.props().showManageActions;
                 if (commentComponent.props().comment.user.id == currentUser.id) {
-                    expect(showActions).toBe(true);
+                    expect(showManageActions).toBe(true);
                 } else {
-                    expect(showActions).toBe(false);
+                    expect(showManageActions).toBe(false);
                 }
             });
         });
@@ -169,6 +164,22 @@ describe('Interpretations: Interpretations -> InterpretationComments component',
             expect(onDeleteCall[0]).toEqual(expect.objectContaining({
                 id: commentToDelete.id,
             }));
+        });
+    });
+
+    describe('click on reply link', () => {
+        beforeEach(() => {
+            commentComponent = commentComponents.at(1);
+            const commentToReplyTo = commentComponent.props().comment;
+            commentComponent.props().onReply(commentToReplyTo);
+            interpretationComments.update();
+        });
+
+        it('should render a non-cancellable comment text area component', () => {
+            const commentTextarea = interpretationComments.find("CommentTextarea");
+            expect(commentTextarea).toHaveLength(1);
+            expect(commentTextarea.props().comment.text).toEqual("");
+            expect(commentTextarea).not.toHaveProp("onCancel");
         });
     });
 });

--- a/packages/interpretations/src/components/interpretations/__tests__/InterpretationDialog.spec.js
+++ b/packages/interpretations/src/components/interpretations/__tests__/InterpretationDialog.spec.js
@@ -41,16 +41,15 @@ describe('Interpretations: Interpretations -> InterpretationDialog component', (
         interpretationDialog = renderComponent();
     });
 
-    it('should render a multiline text field with the interpretation text', () => {
-        const textField = interpretationDialog.find("TextField");
-        expect(textField).toHaveProp("value", interpretation.text);
-        expect(textField.props().multiLine).toBe(true);
+    it('should render a RichEditor component field with the interpretation as initial text', () => {
+        const textField = interpretationDialog.find("RichEditor");
+        expect(textField).toHaveProp("initialContent", interpretation.text);
     });
 
     describe("when save is clicked with new text", () => {
         beforeEach(() => {
-            interpretationDialog.find("TextField").simulate('change', {}, "new text");
-            interpretationDialog.instance().save();
+            interpretationDialog.find("RichEditor").props().onEditorChange("new text");
+            interpretationDialog.instance()._save();
         });
 
         it("should call onSave with the updated interpretation", () => {
@@ -66,8 +65,8 @@ describe('Interpretations: Interpretations -> InterpretationDialog component', (
 
     describe("when cancel is clicked with new text", () => {
         beforeEach(() => {
-            interpretationDialog.find("TextField").simulate('change', {}, "new text");
-            interpretationDialog.instance().cancel();
+            interpretationDialog.find("RichEditor").props().onEditorChange("new text");
+            interpretationDialog.instance()._cancel();
         });
 
         it("should call onClose", () => {

--- a/packages/interpretations/src/components/interpretations/misc.js
+++ b/packages/interpretations/src/components/interpretations/misc.js
@@ -24,8 +24,16 @@ export const getUserLink = (d2, user) => {
 };
 
 export const Link = (props) => {
-    const { label, ...otherProps } = props;
-    return <a style={styles.interpretationLink} {...otherProps}>{label}</a>;
+    const { label, value, onClick, ...otherProps } = props;
+    return (
+        <a
+            style={styles.interpretationLink}
+            onClick={ev => onClick(value)}
+            {...otherProps}
+        >
+            {label}
+        </a>
+    );
 };
 
 export const ActionSeparator = ({labelText = "·"}) => (

--- a/packages/interpretations/src/models/__tests__/helpers.spec.js
+++ b/packages/interpretations/src/models/__tests__/helpers.spec.js
@@ -1,7 +1,8 @@
 import _ from 'lodash';
 import { getFavoriteWithInterpretations } from '../helpers';
-import Intepretation from '../interpretation';
+import Interpretation from '../interpretation';
 import { getStubContext } from '../../../../../config/inject-theme';
+import * as users from '../users';
 
 const context = getStubContext();
 const map = {id: "1", name: "My favorite", interpretations: [{id: "int1"}]};
@@ -11,6 +12,7 @@ let d2, getApiGetMock, favorite;
 
 const initD2 = () => {
     getApiGetMock = jest.fn(() => Promise.resolve({views: mockedViews}));
+    users.getMentions = jest.fn(() => Promise.resolve({allUsers: [], mostMentionedUsers: []}));
 
     d2 = _.merge(context.d2, {
         models: {
@@ -29,6 +31,7 @@ const initD2 = () => {
 describe("getFavoriteWithInterpretations", () => {
     beforeEach(() => {
         initD2();
+
         return getFavoriteWithInterpretations(d2, "map", "1")
             .then(_favorite => { favorite = _favorite; });
     });
@@ -37,8 +40,8 @@ describe("getFavoriteWithInterpretations", () => {
         it("should call the model D2 get with the required fields", () => {
             const expectedFields = "id,name,href,user[id,displayName],displayName,description," +
                 "created,lastUpdated,access,publicAccess,userGroupAccesses," +
-                "interpretations[id,user[id,displayName],created,likes,likedBy[id,displayName],"
-                + "text,comments[id,text,created,user[id,displayName]]]";
+                "interpretations[id,user[id,displayName,userCredentials[username]],created,likes,likedBy[id,displayName],"
+                + "text,comments[id,text,created,user[id,displayName,userCredentials[username]]]]";
             expect(d2.models.map.get).toBeCalledWith("1", {fields: expectedFields});
         });
 
@@ -60,7 +63,7 @@ describe("getFavoriteWithInterpretations", () => {
         it("should have wrapped interpretations", () => {
             expect(favorite.interpretations).toHaveLength(favorite.interpretations.length);
             _(favorite.interpretations)
-                .every(interpretation => expect(interpretation).toBeInstanceOf(Intepretation));
+                .every(interpretation => expect(interpretation).toBeInstanceOf(Interpretation));
         });
     });
 });

--- a/packages/interpretations/src/models/__tests__/users.spec.js
+++ b/packages/interpretations/src/models/__tests__/users.spec.js
@@ -1,0 +1,166 @@
+import sinon from 'sinon';
+import * as api from '../../util/api';
+import { getMentions } from '../users';
+
+const users = [{
+        id: "oXD88WWSQpR",
+        displayName: "Alain Traore",
+        userCredentials: {
+            username: "traore"
+        }
+    }, {
+        id: "NOOF56dveaZ",
+        displayName: "Bombali District",
+        userCredentials: {
+            username: "bombali"
+        }
+    }, {
+        id: "I9fMsY4pRKk",
+        displayName: "Didier Konan",
+        userCredentials: {
+            username: "konan"
+        }
+    }, {
+        id: "cddnwKV2gm9",
+        displayName: "Donor User",
+        userCredentials: {
+            username: "donor"
+        }
+    }, {
+        id: "rWLrZL8rP3K",
+        displayName: "Guest User",
+        userCredentials: {
+            username: "guest"
+        }
+    },
+];
+
+const interpretations = [
+    {
+        id: "dQPY66FE8R4",
+        mentions: [{
+            created: "2018-06-15T11:19:34.980",
+            username: "donor"
+        }]
+    },
+    {
+        id: "E83OzhfnCCK",
+        mentions: [{
+            created: "2018-06-15T11:19:07.737",
+            username: "donor"
+        },
+        {
+            created: "2018-06-15T11:19:07.737",
+            username: "konan"
+        }]
+    },
+];
+
+const interpretationsWithComments = [
+    {
+        id: "E83OzhfnCCK",
+        comments: [{
+            mentions: [{
+                created: "2018-06-15T10:05:31.731",
+                username: "traore"
+            }]
+        }, {
+            mentions: [{
+                created: "2018-06-15T11:19:19.828",
+                username: "konan"
+            }]
+        }]
+    },
+    {
+        id: "xKwnFILzWxM",
+        comments: [{
+            mentions: [{
+                created: "2018-06-12T10:32:52.484",
+                username: "konan"
+            }, {
+                created: "2018-06-12T10:37:52.484",
+                username: "bombali"
+            }]
+        }]
+    },
+];
+
+const d2 = {
+    currentUser: {
+        id: "oXD88WWSQpR",
+        username: "traore",
+    },
+};
+
+const mockApiFetch = () => {
+    const apiFetchStub = sinon.stub();
+
+    apiFetchStub.withArgs("/users", "GET", {
+        fields: "id,displayName,userCredentials[username]",
+        order: "displayName:asc",
+        paging: false,
+    }).returns(Promise.resolve({users}));
+
+    apiFetchStub.withArgs("/interpretations", "GET", {
+        fields: "id,mentions",
+        filter: [`user.id:eq:${d2.currentUser.id}`, "mentions:!null"],
+        paging: false,
+    }).returns(Promise.resolve({interpretations}));
+
+    apiFetchStub.withArgs("/interpretations", "GET", {
+        fields: "id,comments[mentions]",
+        filter: [`comments.user.id:eq:${d2.currentUser.id}`, "comments.mentions.username:!null"],
+        paging: false,
+    }).returns(Promise.resolve({interpretations: interpretationsWithComments}));
+
+    apiFetchStub.throws();
+
+    api.apiFetch = apiFetchStub;
+};
+
+let mentions, allUsers, mostMentionedUsers;
+
+describe("users helpers", () => {
+    describe("getMentions", () => {
+        beforeEach(() => {
+            mockApiFetch();
+            return getMentions(d2).then(_mentions => mentions = _mentions);
+        });
+
+        describe("property mostMentionedUsers", () => {
+            beforeEach(() => {
+                mostMentionedUsers = mentions ? mentions.mostMentionedUsers : null;
+            });
+
+            it("contains array with most mentioned users (except currentUser), sorted by ocurrences", () => {
+                expect(mostMentionedUsers).toEqual([{
+                    "displayName": "Didier Konan",
+                    "id": "I9fMsY4pRKk",
+                    "username": "konan"
+                }, {
+                    "displayName": "Donor User",
+                    "id": "cddnwKV2gm9",
+                    "username": "donor"
+                }, {
+                    "displayName": "Bombali District",
+                    "id": "NOOF56dveaZ",
+                    "username": "bombali"
+                }]);
+            });
+        });
+
+        describe("property allUsers", () => {
+            beforeEach(() => {
+                allUsers = mentions ? mentions.allUsers : null;
+            });
+
+            it("contains array with users not present in mostMentionedUsers, sorted alphabetically", () => {
+                expect(allUsers).toEqual([{
+                    id: 'rWLrZL8rP3K',
+                    displayName: 'Guest User',
+                    username: 'guest'
+                }]);
+            });
+        });
+    });
+});

--- a/packages/interpretations/src/models/comment.js
+++ b/packages/interpretations/src/models/comment.js
@@ -19,4 +19,20 @@ export default class Comment {
         const url = `/interpretations/${interpretation.id}/comments/${this.id}`;
         return apiFetch(url, "DELETE");
     }
+
+    static getReplyText(d2, user) {
+        const currentUsername = d2.currentUser.username;
+        return user && user.userCredentials && user.userCredentials.username !== currentUsername ?
+            ("@" + user.userCredentials.username + "\xA0") : "";
+    }
+
+    getReply(d2) {
+        const text = Comment.getReplyText(d2, this.user);
+        return new Comment(this._interpretation, { text });
+    }
+
+    static getReplyForInterpretation(d2, interpretation) {
+        const text = Comment.getReplyText(d2, interpretation.user);
+        return new Comment(interpretation, { text });
+    }
 }

--- a/packages/interpretations/src/models/helpers.js
+++ b/packages/interpretations/src/models/helpers.js
@@ -1,15 +1,16 @@
 import Interpretation from './interpretation';
 import pick from 'lodash/fp/pick';
 import { apiFetch } from '../util/api';
+import { getMentions } from './users';
   
 const interpretationsFields = [
     'id',
-    'user[id,displayName]',
+    'user[id,displayName,userCredentials[username]]',
     'created',
     'likes',
     'likedBy[id,displayName]',
     'text',
-    'comments[id,text,created,user[id,displayName]]',
+    'comments[id,text,created,user[id,displayName,userCredentials[username]]]',
 ];
 
 const favoriteFields = [
@@ -30,15 +31,20 @@ const favoriteFields = [
 export const getFavoriteWithInterpretations = (d2, type, id) => {
     const modelClass = d2.models[type];
     const api = d2.Api.getApi();
-    const getModel = modelClass.get(id, {fields: favoriteFields.join(',')})
-    const getViews = api.get(`dataStatistics/favorites/${id}`).then(json => json.views);
+    const model$ = modelClass.get(id, {fields: favoriteFields.join(',')});
+    const views$ = api.get(`dataStatistics/favorites/${id}`).then(json => json.views);
+    const mentions$ = getMentions(d2);
 
-    return Promise.all([getModel, getViews])
-        .then(([model, views]) => {
-            const modelInterpretations = model.interpretations.map(attrs => new Interpretation(model, attrs));
-            model.interpretations = modelInterpretations;
-            model.favoriteViews = views;
-            return model;
+    return Promise.all([model$, views$, mentions$])
+        .then(([model, views, mentions]) => {
+            const modelInterpretations = model.interpretations
+                .map(attrs => new Interpretation(model, attrs));
+
+            return Object.assign(model, {
+                interpretations: modelInterpretations,
+                favoriteViews: views,
+                mentions: mentions,
+            });
         });
 };
 

--- a/packages/interpretations/src/models/users.js
+++ b/packages/interpretations/src/models/users.js
@@ -1,0 +1,60 @@
+import { apiFetch } from '../util/api';
+import { keyBy, filter, map, flatMap, flow, groupBy, without } from 'lodash/fp';
+import { orderBy, concat, toPairs, at, differenceBy, compact } from 'lodash/fp';
+
+export async function getMentions(d2) {
+    const allUsersResponse = await apiFetch("/users", "GET", {
+        fields: "id,displayName,userCredentials[username]",
+        order: "displayName:asc",
+        paging: false,
+    });
+
+    const interpretationsResponse = await apiFetch("/interpretations", "GET", {
+        fields: "id,mentions",
+        filter: [`user.id:eq:${d2.currentUser.id}`, "mentions:!null"],
+        paging: false,
+    });
+
+    const commentsResponse = await apiFetch("/interpretations", "GET", {
+        fields: "id,comments[mentions]",
+        filter: [`comments.user.id:eq:${d2.currentUser.id}`, "comments.mentions.username:!null"],
+        paging: false,
+    });
+
+    const allUsers = allUsersResponse.users.map(user => ({
+        id: user.id,
+        displayName: user.displayName,
+        username: user.userCredentials.username,
+    }));
+
+    const allUsersByUsername = keyBy("username", allUsers);
+
+    const interpretationMentions = flatMap(
+        interpretation => map("username", interpretation.mentions),
+        interpretationsResponse.interpretations);
+
+    const commentMentions = flatMap(
+        interpretation => map("username", flatMap("mentions", interpretation.comments)),
+        commentsResponse.interpretations);
+
+    const sortByFrequency = flow(
+        groupBy(value => value),
+        toPairs,
+        map(([value, group]) => ({value, count: group.length})),
+        orderBy(["count", "value"], ["desc", "asc"]),
+        map("value"),
+    );
+
+    const mostMentionedUsernames = flow(
+        concat(commentMentions),
+        without([d2.currentUser.username]),
+        sortByFrequency,
+    )(interpretationMentions);
+
+    const mostMentionedUsers = compact(at(mostMentionedUsernames, allUsersByUsername));
+
+    const allUsersFiltered = differenceBy("id", allUsers, mostMentionedUsers)
+        .filter(user => d2.currentUser.id !== user.id);
+
+    return {allUsers: allUsersFiltered, mostMentionedUsers};
+}

--- a/packages/interpretations/src/util/api.js
+++ b/packages/interpretations/src/util/api.js
@@ -4,7 +4,7 @@ import { getInstance } from 'd2/lib/d2';
 export const apiFetch = async (urlOrPath, method, body = null) => {
     const d2 = await getInstance();
     const api = d2.Api.getApi();
-    const payload = isObject(body) ? JSON.stringify(body) : body;
+    const payload = isObject(body) && method !== "GET" ? JSON.stringify(body) : body;
     const options = {
         headers: {
             "Content-Type": isObject(body) ? 'application/json' : 'text/plain',

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,6 +107,14 @@
     i18next-conv "^6.0.0"
     i18next-scanner "^2.4.4"
 
+"@dhis2/d2-i18n-extract@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n-extract/-/d2-i18n-extract-1.0.7.tgz#805c92c75f5d3678a047374a551bda5f7571d7f3"
+  dependencies:
+    argparse "^1.0.10"
+    i18next-conv "^6.0.0"
+    i18next-scanner "^2.4.4"
+
 "@dhis2/d2-i18n-generate@^1.0.18":
   version "1.0.18"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n-generate/-/d2-i18n-generate-1.0.18.tgz#e3426d381030856232fbe1e2097b8ca2aebe90f3"
@@ -133,6 +141,12 @@
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
+
+"@sinonjs/formatio@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
+  dependencies:
+    samsam "1.3.0"
 
 "@types/jss@^9.3.0":
   version "9.5.3"
@@ -2490,6 +2504,10 @@ colors@^1.1.2:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.5.tgz#89c7ad9a374bc030df8013241f68136ed8835afc"
 
+colors@~0.6.0-1:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
+
 colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
@@ -2520,6 +2538,10 @@ commander@2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
 
 commander@~2.14.1:
   version "2.14.1"
@@ -2846,6 +2868,14 @@ cosmiconfig@^4.0.0:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
     require-from-string "^2.0.1"
+
+cosmiconfig@^5.0.2:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
 
 create-ecdh@^4.0.0:
   version "4.0.3"
@@ -4585,6 +4615,13 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+findup@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/findup/-/findup-0.1.5.tgz#8ad929a3393bac627957a7e5de4623b06b0e2ceb"
+  dependencies:
+    colors "~0.6.0-1"
+    commander "~2.1.0"
+
 first-chunk-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz#1bdecdb8e083c0664b91945581577a43a9f31d70"
@@ -4864,6 +4901,10 @@ get-port@^3.2.0:
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
 
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
@@ -5529,6 +5570,20 @@ husky@^1.0.0-rc.4:
     run-node "^1.0.0"
     slash "^2.0.0"
 
+husky@^1.0.0-rc.8:
+  version "1.0.0-rc.9"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.0.0-rc.9.tgz#9455788056b003327cff38f5c72285bb3ca485e9"
+  dependencies:
+    cosmiconfig "^5.0.2"
+    execa "^0.9.0"
+    find-up "^2.1.0"
+    get-stdin "^6.0.0"
+    is-ci "^1.1.0"
+    pkg-dir "^2.0.0"
+    read-pkg "^3.0.0"
+    run-node "^1.0.0"
+    slash "^2.0.0"
+
 hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
@@ -5750,26 +5805,6 @@ interpret@^1.0.0, interpret@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-intl-format-cache@^2.0.5:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-2.1.0.tgz#04a369fecbfad6da6005bae1f14333332dcf9316"
-
-intl-messageformat-parser@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.2.0.tgz#5906b7f953ab7470e0dc8549097b648b991892ff"
-
-intl-messageformat@1.3.0, intl-messageformat@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-1.3.0.tgz#f7d926aded7a3ab19b2dc601efd54e99a4bd4eae"
-  dependencies:
-    intl-messageformat-parser "1.2.0"
-
-intl-relativeformat@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-1.3.0.tgz#893dc7076fccd380cf091a2300c380fa57ace45b"
-  dependencies:
-    intl-messageformat "1.3.0"
-
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
@@ -5777,7 +5812,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.0.0, invariant@^2.1.1, invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -7083,6 +7118,10 @@ jsx-ast-utils@^2.0.0, jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
+just-extend@^1.1.27:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+
 keycode@^2.1.8, keycode@^2.1.9:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
@@ -7610,6 +7649,10 @@ loglevelnext@^1.0.1:
   dependencies:
     es6-symbol "^3.1.1"
     object.assign "^4.1.0"
+
+lolex@^2.3.2, lolex@^2.4.2:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.0.tgz#9c087a69ec440e39d3f796767cf1b2cdc43d5ea5"
 
 long@^3.2.0:
   version "3.2.0"
@@ -8272,6 +8315,16 @@ next-tick@1:
 nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
+nise@^1.3.3:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.1.tgz#78bc2b343d5ff1031ea9d1bb2c87a94c26db7250"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    just-extend "^1.1.27"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 no-case@^2.2.0:
   version "2.3.2"
@@ -9196,7 +9249,7 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-path-to-regexp@^1.0.1:
+path-to-regexp@^1.0.1, path-to-regexp@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
@@ -9520,6 +9573,12 @@ postcss-reduce-transforms@^1.0.3:
     postcss "^5.0.8"
     postcss-value-parser "^3.0.1"
 
+postcss-rtl@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-rtl/-/postcss-rtl-1.3.0.tgz#e2b2eb1526758525c10966059b3623005e817c27"
+  dependencies:
+    rtlcss "^2.3.0"
+
 postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90"
@@ -9566,7 +9625,7 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.13:
+postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.13, postcss@^6.0.14:
   version "6.0.22"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
   dependencies:
@@ -9947,15 +10006,6 @@ react-event-listener@^0.5.1:
     prop-types "^15.6.0"
     warning "^3.0.0"
 
-react-intl@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.3.0.tgz#e1df6af5667fdf01cbe4aab20e137251e2ae5142"
-  dependencies:
-    intl-format-cache "^2.0.5"
-    intl-messageformat "^1.3.0"
-    intl-relativeformat "^1.3.0"
-    invariant "^2.1.1"
-
 react-is@^16.3.2:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
@@ -9980,6 +10030,12 @@ react-popper@^0.10.0:
   dependencies:
     popper.js "^1.14.1"
     prop-types "^15.6.1"
+
+react-portal@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.1.5.tgz#6665d4d2a92d47d6f8b07a6529e26fc52d5cccde"
+  dependencies:
+    prop-types "^15.5.8"
 
 react-reconciler@^0.7.0:
   version "0.7.0"
@@ -10707,6 +10763,16 @@ rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
+rtlcss@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/rtlcss/-/rtlcss-2.3.0.tgz#9fffed884f94717b75b3ccffc22ab6044f430c5a"
+  dependencies:
+    chalk "^2.3.0"
+    findup "^0.1.5"
+    mkdirp "^0.5.1"
+    postcss "^6.0.14"
+    strip-json-comments "^2.0.0"
+
 run-async@^2.0.0, run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -10756,6 +10822,10 @@ safe-regex@^1.1.0:
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+
+samsam@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
 
 sane@^2.0.0:
   version "2.5.2"
@@ -11022,6 +11092,18 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
 simple-assign@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/simple-assign/-/simple-assign-0.1.0.tgz#17fd3066a5f3d7738f50321bb0f14ca281cc4baa"
+
+sinon@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-6.0.0.tgz#f26627e4830dc34279661474da2c9e784f166215"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    diff "^3.5.0"
+    lodash.get "^4.4.2"
+    lolex "^2.4.2"
+    nise "^1.3.3"
+    supports-color "^5.4.0"
+    type-detect "^4.0.8"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -11485,7 +11567,7 @@ strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
-strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1, strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -11700,6 +11782,10 @@ test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-extensions@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.7.0.tgz#faaaba2625ed746d568a23e4d0aacd9bf08a8b39"
@@ -11891,6 +11977,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 type-is@~1.6.15, type-is@~1.6.16:
   version "1.6.16"


### PR DESCRIPTION
Fixes https://jira.dhis2.org/browse/DHIS2-3422

Requires https://github.com/dhis2/maps-app/pull/13

Changes proposed in this pull request:

- Textarea for interpretation and interpretation comments use now CKEditor with link/emoji buttons.
- Rich editor supports mentioning (`@username`)
- It uses same markup than analytics east region, will be updated to new markup on next iteration.
