### PR TITLE
Enable New button by default (DHIS2-3935)

### DIFF
--- a/packages/file-menu/src/FileMenu.js
+++ b/packages/file-menu/src/FileMenu.js
@@ -126,7 +126,7 @@ export class FileMenu extends Component {
                     anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
                     getContentAnchorEl={null}
                 >
-                    <NewMenuItem enabled={Boolean(this.state.fileModel)} onNew={this.onNew} />
+                    <NewMenuItem enabled={true} onNew={this.onNew} />
                     <Divider light />
 
                     <OpenMenuItem

--- a/packages/file-menu/src/__tests__/FileMenu.spec.js
+++ b/packages/file-menu/src/__tests__/FileMenu.spec.js
@@ -57,7 +57,7 @@ describe('File: FileMenu component', () => {
     });
 
     const buttons = [
-        { name: 'New', componentName: 'NewMenuItem', enabled: false },
+        { name: 'New', componentName: 'NewMenuItem', enabled: true },
         { name: 'Open', componentName: 'OpenMenuItem', enabled: true },
         { name: 'Save', componentName: 'SaveMenuItem', enabled: true },
         { name: 'Save as...', componentName: 'SaveAsMenuItem', enabled: false },


### PR DESCRIPTION
Fixes DHIS2-3935.

Changes proposed in this pull request:

- New button in the File menu should be always enabled

The reason is that when an app is launched without a specific analytic object loaded, it should be possible to discard all the unsaved changes and start from scratch.
The New button is also enabled when an existing analytics object is loaded, which allows for resetting the app and starting create a new object.

