### PR TITLE
DHIS2-2151-Sharing-UI

### DIFF
--- a/packages/sharing-dialog/src/PermissionOption.component.js
+++ b/packages/sharing-dialog/src/PermissionOption.component.js
@@ -29,7 +29,7 @@ class PermissionOption extends Component {
 
 PermissionOption.propTypes = {
     disabled: PropTypes.bool.isRequired,
-    isSelected: PropTypes.bool.isRequired,
+    isSelected: PropTypes.bool,
     primaryText: PropTypes.string.isRequired,
     value: PropTypes.object.isRequired,
     onClick: PropTypes.func,
@@ -39,6 +39,7 @@ PermissionOption.propTypes = {
 PermissionOption.defaultProps = {
     onClick: undefined,
     focusState: 'none',
+    isSelected: false,
 };
 
 PermissionOption.muiName = 'MenuItem';

--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -29,7 +29,6 @@ class SharingDialog extends React.Component {
 
     constructor(props) {
         super(props);
-
         if (props.d2) {
             props.d2.i18n.addStrings(['share', 'close', 'no_manage_access']);
         } else {
@@ -49,14 +48,17 @@ class SharingDialog extends React.Component {
     }
 
     componentWillReceiveProps(nextProps) {
+        console.warn('Received new props:', nextProps);
         const hasChanged = this.createPropsChecker(nextProps);
-
-        if (hasChanged('id') || hasChanged('type')) {
+        
+        if ((hasChanged('id') || hasChanged('type')) && nextProps.id && nextProps.type) {
+            console.warn('Ready to fetch from API!');
             this.resetState();
             if (nextProps.open) this.loadObjectFromApi(nextProps);
         }
-
-        if (!this.props.open && nextProps.open) {
+        
+        if (!this.props.open && nextProps.open && nextProps.id && nextProps.type) {
+            console.warn('Ready to fetch from API!');
             this.loadObjectFromApi(nextProps);
         }
     }
@@ -199,15 +201,24 @@ SharingDialog.propTypes = {
     onRequestClose: PropTypes.func.isRequired,
 
     /**
-     * Type of the sharable object.
+     * Type of the sharable object. Can be supplied after initial render.
      */
-    type: PropTypes.string.isRequired,
+    type: PropTypes.string,
 
     /**
-     * Id of the sharable object.
+     * Id of the sharable object. Can be supplied after initial render.
      */
-    id: PropTypes.string.isRequired,
+    id: PropTypes.string,
+
+    /**
+     * d2 instance to use.
+     */
     d2: PropTypes.object.isRequired,
+};
+
+SharingDialog.defaultProps = {
+    type: '',
+    id: '',
 };
 
 export default SharingDialog;

--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -1,5 +1,6 @@
 import Dialog from 'material-ui/Dialog/Dialog';
 import FlatButton from 'material-ui/FlatButton/FlatButton';
+import RaisedButton from 'material-ui/RaisedButton';
 import Snackbar from 'material-ui/Snackbar';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -13,7 +14,6 @@ const styles = {
 };
 
 const defaultState = {
-    api: null,
     sharedObject: null,
     errorMessage: '',
 };
@@ -42,29 +42,40 @@ class SharingDialog extends React.Component {
 
     componentDidMount() {
         this.loadDataSharingSettings();
-        if (this.props.open && this.props.type && this.props.id) {
+
+        /* Load object if:
+         *   - Dialog is open
+         *   - Type and ID is supplied
+         *   - User did not supply their own shared object
+         */
+        if (this.props.open && this.isReadyToLoadObject(this.props)) {
             this.loadObjectFromApi(this.props);
         }
     }
 
+    isReadyToLoadObject = (props) => {
+        return props.type && (props.id || props.sharedObject);
+    }
+
     componentWillReceiveProps(nextProps) {
-        console.warn('Received new props:', nextProps);
         const hasChanged = this.createPropsChecker(nextProps);
-        
-        if ((hasChanged('id') || hasChanged('type')) && nextProps.id && nextProps.type) {
-            console.warn('Ready to fetch from API!');
+
+        if ((hasChanged('id') || hasChanged('type') || hasChanged('sharedObject')) && this.isReadyToLoadObject(nextProps)) {
             this.resetState();
-            if (nextProps.open) this.loadObjectFromApi(nextProps);
+
+            if (nextProps.open) {
+                this.loadObjectFromApi(nextProps);
+            }
         }
-        
-        if (!this.props.open && nextProps.open && nextProps.id && nextProps.type) {
-            console.warn('Ready to fetch from API!');
+
+        if (!this.props.open && nextProps.open && this.isReadyToLoadObject(nextProps)) {
             this.loadObjectFromApi(nextProps);
         }
     }
 
     onSearchRequest = key =>
-        this.state.api.get('sharing/search', { key })
+        this.props.d2.Api.getApi()
+            .get('sharing/search', { key })
             .then(searchResult => searchResult);
 
     onSharingChanged = (updatedAttributes, onSuccess) => {
@@ -76,21 +87,22 @@ class SharingDialog extends React.Component {
             },
         };
 
-        this.postChanges(updatedObject, onSuccess);
+        if (this.props.doNotPost) {
+            this.updateSharedObject(updatedObject, onSuccess);
+        } else {
+            this.postChanges(updatedObject, onSuccess);
+        }
     }
 
     createPropsChecker = nextProps => field => nextProps[field] !== this.props[field];
 
     postChanges = (updatedObject, onSuccess) => {
         const url = `sharing?type=${this.props.type}&id=${this.props.id}`;
-        return this.state.api.post(url, updatedObject)
+        return this.props.d2.Api.getApi()
+            .post(url, updatedObject)
             .then(({ httpStatus, message }) => {
                 if (httpStatus === 'OK') {
-                    this.setState({
-                        sharedObject: updatedObject,
-                    }, () => {
-                        if (onSuccess) onSuccess();
-                    });
+                    this.updateSharedObject(updatedObject, onSuccess);
                 }
 
                 return message;
@@ -101,47 +113,64 @@ class SharingDialog extends React.Component {
             });
     }
 
+    updateSharedObject = (updatedObject, onSuccess) => {
+        this.setState({
+            sharedObject: updatedObject,
+        }, () => {
+            if (onSuccess) onSuccess();
+        });
+    }
+
     resetState = () => {
         this.setState(defaultState);
     }
 
     loadDataSharingSettings = () => {
-        const api = this.props.d2.Api.getApi();
+        this.props.d2.Api.getApi()
+            .get('schemas', { fields: ['name', 'dataShareable'] })
+            .then((schemas) => {
+                const dataShareableTypes = schemas.schemas
+                    .filter(item => item.dataShareable)
+                    .map(item => item.name);
 
-        api
-        .get('schemas', { fields: ['name', 'dataShareable'] })
-        .then((schemas) => {
-            const dataShareableTypes = schemas.schemas
-                .filter(item => item.dataShareable)
-                .map(item => item.name);
-
-            this.setState({
-                dataShareableTypes,
+                this.setState({
+                    dataShareableTypes,
+                });
             });
-        });
     }
 
-    loadObjectFromApi = ({ type, id }) => {
-        const api = this.props.d2.Api.getApi();
-
-        api
-        .get('sharing', { type, id })
-        .then((sharedObject) => {
+    loadObjectFromApi = (props) => {
+        const setSharedObject = sharedObject => {
             this.setState({
-                api,
                 sharedObject,
             });
-        })
-        .catch((error) => {
-            this.setState({
-                errorMessage: error.message,
-            });
-        });
+        }
+
+        if (props.sharedObject) {
+            setSharedObject(props.sharedObject);
+        } else {
+            this.props.d2.Api.getApi()
+                .get('sharing', { type: props.type, id: props.id })
+                .then((sharedObject) => setSharedObject(sharedObject))
+                .catch((error) => {
+                    this.setState({
+                        errorMessage: error.message,
+                    });
+                });
+        }
     }
 
-    closeSharingDialog = () => {
-        this.props.onRequestClose(this.state.sharedObject.object);
+    addId = object => ({ ...object, id: this.props.id });
+
+    closeDialog = () => {
+        this.props.onRequestClose(this.addId(this.state.sharedObject.object, this.props.id))
     }
+
+    confirmAndCloseDialog = () => {
+        this.props.onConfirm(this.addId(this.state.sharedObject.object, this.props.id));
+    }
+
+    translate = s => this.props.d2.i18n.getTranslation(s)
 
     render() {
         const dataShareable = this.state.dataShareableTypes.indexOf(this.props.type) !== -1;
@@ -149,10 +178,19 @@ class SharingDialog extends React.Component {
         const isLoading = !this.state.sharedObject && this.props.open && !errorOccurred;
         const sharingDialogActions = [
             <FlatButton
-                label={this.props.d2.i18n.getTranslation('close')}
-                onClick={this.closeSharingDialog}
+                label={this.translate('close')}
+                onClick={this.closeDialog}
             />,
         ];
+
+        if (this.props.doNotPost) sharingDialogActions.push(
+            <RaisedButton
+                primary
+                label={this.translate('apply')}
+                onClick={this.confirmAndCloseDialog}
+            />
+        )
+
         return (
             <div>
                 <Snackbar
@@ -160,32 +198,32 @@ class SharingDialog extends React.Component {
                     message={this.state.errorMessage}
                     autoHideDuration={3000}
                 />
-                { isLoading && <LoadingMask style={styles.loadingMask} size={1} /> }
-                { this.state.sharedObject &&
-                    <Dialog
-                        autoDetectWindowHeight
-                        autoScrollBodyContent
-                        open={this.props.open}
-                        title={this.props.d2.i18n.getTranslation('share')}
-                        actions={sharingDialogActions}
-                        onRequestClose={this.closeSharingDialog}
-                        {...this.props}
-                    >
+                <Dialog
+                    autoDetectWindowHeight
+                    autoScrollBodyContent
+                    open={this.props.open}
+                    title={this.props.d2.i18n.getTranslation('share')}
+                    actions={sharingDialogActions}
+                    onRequestClose={this.closeDialog}
+                    {...this.props}
+                >
+                    { isLoading && <LoadingMask style={styles.loadingMask} size={1} /> }
+                    { this.state.sharedObject &&
                         <Sharing
                             sharedObject={this.state.sharedObject}
                             dataShareable={dataShareable}
                             onChange={this.onSharingChanged}
                             onSearch={this.onSearchRequest}
                         />
-                    </Dialog>
-                }
+                    }
+                </Dialog>
             </div>
         );
     }
 }
 
 SharingDialog.childContextTypes = {
-    d2: PropTypes.object
+    d2: PropTypes.object,
 };
 
 SharingDialog.propTypes = {
@@ -195,10 +233,40 @@ SharingDialog.propTypes = {
     open: PropTypes.bool.isRequired,
 
     /**
+     * Do not post new sharing settings. Rather, let the user save the new
+     * settings returned from onRequestClose.
+     */
+    doNotPost: PropTypes.bool,
+
+    /**
+     * Supply your own shared object, ignore 'id' prop.
+     */
+    sharedObject: PropTypes.shape({
+        object: PropTypes.shape({
+            user: PropTypes.shape({ name: PropTypes.string }).isRequired,
+            displayName: PropTypes.string.isRequired,
+            userAccesses: PropTypes.array.isRequired,
+            userGroupAccesses: PropTypes.array.isRequired,
+            publicAccess: PropTypes.string.isRequired,
+            externalAccess: PropTypes.bool,
+        }),
+        meta: PropTypes.shape({
+            allowPublicAccess: PropTypes.bool.isRequired,
+            allowExternalAccess: PropTypes.bool.isRequired,
+        }),
+    }),
+
+    /**
      * Function to be called when the dialog is closed. The function is called
      * with the updated sharing preferences as the first and only argument.
      */
     onRequestClose: PropTypes.func.isRequired,
+
+    /**
+     * Function to be called when user applies the settings. Is only shown
+     * when doNotPost is true.
+     */
+    onConfirm: PropTypes.func,
 
     /**
      * Type of the sharable object. Can be supplied after initial render.
@@ -219,6 +287,8 @@ SharingDialog.propTypes = {
 SharingDialog.defaultProps = {
     type: '',
     id: '',
+    doNotPost: false,
+    sharedObject: null,
 };
 
 export default SharingDialog;

--- a/packages/sharing-dialog/src/__tests__/SharingDialog.component.spec.js
+++ b/packages/sharing-dialog/src/__tests__/SharingDialog.component.spec.js
@@ -51,8 +51,10 @@ const sharingDialogProps = {
 };
 
 describe('Sharing: SharingDialog component', () => {
-    let sharingDialogComponent;
-    let onRequestClose;
+    let sharingDialogComponent,
+        onRequestClose,
+        onConfirm;
+
     const context = getStubContext();
 
     context.d2.Api.getApi = jest.fn().mockReturnValue({
@@ -66,10 +68,12 @@ describe('Sharing: SharingDialog component', () => {
 
     beforeEach(() => {
         onRequestClose = jest.fn();
+        onConfirm = jest.fn();
         sharingDialogComponent = renderComponent({
             ...sharingDialogProps,
             d2: context.d2,
             onRequestClose,
+            onConfirm,
         });
     });
 
@@ -104,9 +108,14 @@ describe('Sharing: SharingDialog component', () => {
             expect(buttons[0].props.label).toBe('close_translated');
         });
 
-        it('triggers onRequestClose from the props when the closeSharingDialog is called', () => {
-            sharingDialogComponent.instance().closeSharingDialog();
+        it('triggers onRequestClose from the props when the closeDialog is called', () => {
+            sharingDialogComponent.instance().closeDialog();
             expect(onRequestClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('triggers onConfirm from the props when the confirmAndCloseDialog is called', () => {
+            sharingDialogComponent.instance().confirmAndCloseDialog();
+            expect(onConfirm).toHaveBeenCalledTimes(1);
         });
     });
 


### PR DESCRIPTION
Fixes DHIS2-2151-Sharing-UI.

Changes proposed in this pull request:

Add three new props for the new program access UI in the Maintenance app:
- doNotPost: used if the user wants to save the changes themselves. Makes the sharing dialog "lazy", so to say, compared to the elsewise "eager" instant POST-ing of changes.
- sharedObject: used if the user wants to supply their own object to share. Using this prop will skip the GET-request on sharing settings that is normally made by the sharing dialog.
- onConfirm: used to differentiate "cancelling" and "confirming" changes made in the dialog when using the "doNotPost" prop.

- Update tests to accomodate these changes.

