### PR TITLE
Feature/interpretation sharings

### DIFF
--- a/packages/interpretations/i18n/en.pot
+++ b/packages/interpretations/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-06-15T10:55:59.533Z\n"
-"PO-Revision-Date: 2018-06-15T10:55:59.533Z\n"
+"POT-Creation-Date: 2018-06-22T11:56:27.059Z\n"
+"PO-Revision-Date: 2018-06-22T11:56:27.059Z\n"
 
 msgid "No description"
 msgstr ""
@@ -96,6 +96,9 @@ msgid "Edit interpretation"
 msgstr ""
 
 msgid "Create interpretation"
+msgstr ""
+
+msgid "Share"
 msgstr ""
 
 msgid "Save"

--- a/packages/interpretations/src/components/interpretations/InterpretationDialog.js
+++ b/packages/interpretations/src/components/interpretations/InterpretationDialog.js
@@ -2,12 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Dialog from 'material-ui/Dialog';
 import { Button } from '@dhis2/d2-ui-core';
-import TextField from 'material-ui/TextField';
-import RichEditor from '../html-editor/RichEditor';
 import defer from 'lodash/fp/defer';
 import i18n from '@dhis2/d2-i18n'
 import { compact } from 'lodash/fp';
 import SharingDialog from '@dhis2/d2-ui-sharing-dialog';
+import RichEditor from '../html-editor/RichEditor';
 
 const styles = {
     dialog: {
@@ -20,15 +19,12 @@ class InterpretationDialog extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            value: props.interpretation ? props.interpretation.text : "",
+            value: props.interpretation.text,
             showEditor: true,
             sharingDialogIsOpen: false,
         };
         this.save = this.hideEditorAndThen(this._save.bind(this));
         this.cancel = this.hideEditorAndThen(this._cancel.bind(this));
-        this.onChange = this.onChange.bind(this);
-        this.openSharingDialog = this.openSharingDialog.bind(this);
-        this.closeSharingDialog = this.closeSharingDialog.bind(this);
     }
 
     hideEditorAndThen(fn) {
@@ -50,21 +46,15 @@ class InterpretationDialog extends Component {
         onSave(interpretation);
     }
 
-    onChange(newValue) {
-        this.setState({ value: newValue });
-    }
+    onChange = (newValue) => { this.setState({ value: newValue }); }
 
-    openSharingDialog() {
-        this.setState({ sharingDialogIsOpen: true });
-    }
+    openSharingDialog = () => { this.setState({ sharingDialogIsOpen: true }); }
 
-    closeSharingDialog() {
-        this.setState({ sharingDialogIsOpen: false });
-    }
+    closeSharingDialog = () => { this.setState({ sharingDialogIsOpen: false }); }
 
     render() {
         const { d2 } = this.context;
-        const { interpretation, onSave, mentions } = this.props;
+        const { interpretation, mentions } = this.props;
         const { value, showEditor, sharingDialogIsOpen } = this.state;
         const renderSharingDialog = interpretation && interpretation.id;
         const title = interpretation && interpretation.id
@@ -75,7 +65,7 @@ class InterpretationDialog extends Component {
             interpretation.id
                 ? <Button color="primary" onClick={this.openSharingDialog}>{i18n.t('Share')}</Button>
                 : null,
-            <Button color="primary" disabled={!value}  onClick={this.save}>{i18n.t('Save')}</Button>,
+            <Button color="primary" disabled={!value} onClick={this.save}>{i18n.t('Save')}</Button>,
         ]);
 
         return (
@@ -114,6 +104,7 @@ InterpretationDialog.propTypes = {
     interpretation: PropTypes.object.isRequired,
     onSave: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
+    mentions: RichEditor.propTypes.mentions,
 };
 
 InterpretationDialog.contextTypes = {

--- a/packages/interpretations/src/models/__tests__/helpers.spec.js
+++ b/packages/interpretations/src/models/__tests__/helpers.spec.js
@@ -39,7 +39,7 @@ describe("getFavoriteWithInterpretations", () => {
     describe("api calls", () => {
         it("should call the model D2 get with the required fields", () => {
             const expectedFields = "id,name,href,user[id,displayName],displayName,description," +
-                "created,lastUpdated,access,publicAccess,userGroupAccesses," +
+                "created,lastUpdated,access,publicAccess,externalAccess,userAccesses,userGroupAccesses," +
                 "interpretations[id,user[id,displayName,userCredentials[username]],created,likes,likedBy[id,displayName],"
                 + "text,comments[id,text,created,user[id,displayName,userCredentials[username]]]]";
             expect(d2.models.map.get).toBeCalledWith("1", {fields: expectedFields});

--- a/packages/interpretations/src/models/helpers.js
+++ b/packages/interpretations/src/models/helpers.js
@@ -24,6 +24,8 @@ const favoriteFields = [
     'lastUpdated',
     'access',
     'publicAccess',
+    'externalAccess',
+    'userAccesses',
     'userGroupAccesses',
     `interpretations[${interpretationsFields.join(',')}]`,
 ];

--- a/packages/interpretations/src/models/interpretation.js
+++ b/packages/interpretations/src/models/interpretation.js
@@ -1,7 +1,19 @@
-import { apiFetch } from '../util/api';
+import { pick, last } from 'lodash/fp';
+import { apiFetch, apiFetchWithResponse } from '../util/api';
 import Comment from './comment';
 
+function getInterpretationIdFromResponse(response)  {
+    const location = response.headers.get('location');
+    if (location) {
+        return last(location.split('/'));
+    } else {
+        throw new Error("Could not get interpretation ID");
+    }
+}
+
 export default class Interpretation {
+    static sharingFields = ["publicAccess", "externalAccess", "userGroupAccesses", "userAccesses"];
+
     constructor(parent, attributes) {
         this._parent = parent;
         Object.assign(this, attributes);
@@ -11,10 +23,20 @@ export default class Interpretation {
     save() {
         const modelId = this._parent.id;
         const modelName = this._parent.modelDefinition.name;
-        const [method, url] = this.id
-            ? ['PUT',  `/interpretations/${this.id}`]
-            : ['POST', `/interpretations/${modelName}/${modelId}`];
-        return apiFetch(url, method, this.text);
+        const isNewInterpretation = !this.id;
+
+        if (isNewInterpretation) {
+            // Set initial sharing of interpretation from the parent object
+            const sharingPayload = { object: pick(Interpretation.sharingFields, this._parent) };
+
+            return apiFetchWithResponse(`/interpretations/${modelName}/${modelId}`, "POST", this.text)
+                .then(getInterpretationIdFromResponse)
+                .then(interpretationId =>
+                    apiFetch(`/sharing?type=interpretation&id=${interpretationId}`, "PUT", sharingPayload)
+                );
+        } else {
+            return apiFetch(`/interpretations/${this.id}`, "PUT", this.text);
+        }
     }
 
     delete() {

--- a/packages/interpretations/src/util/api.js
+++ b/packages/interpretations/src/util/api.js
@@ -14,3 +14,18 @@ export const apiFetch = async (urlOrPath, method, body = null) => {
 
     return api.request(method, url, payload, options);
 };
+
+export const apiFetchWithResponse = async (urlOrPath, method, body = null) => {
+    const d2 = await getInstance();
+    const api = d2.Api.getApi();
+    const url = urlOrPath.startsWith("/") ? (api.baseUrl + urlOrPath) : urlOrPath;
+    const options = {
+        method,
+        body,
+        mode: 'cors',
+        credentials: 'include',
+        cache: 'default',
+    };
+
+    return fetch(url, options);
+};


### PR DESCRIPTION
DHIS2-3428

Changes proposed in this pull request:

- Add sharing action to interpretation dialog (request from @turban). Simple UX, let me know if we need this action somewhere else, and not as an action of the dialog.
- Set interpretations sharing on creation from parent

![screenshot from 2018-06-22 14-03-55](https://user-images.githubusercontent.com/24643/41775695-49556b34-7625-11e8-9083-dcd360690baf.png)
![screenshot from 2018-06-22 14-04-05](https://user-images.githubusercontent.com/24643/41775696-497e216e-7625-11e8-88b6-a6b0f7fa1e09.png)


