### PR TITLE
DHIS2-2151-Sharing-UI: Add margin between 'close' and 'apply'

### DIFF
--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -186,6 +186,7 @@ class SharingDialog extends React.Component {
         if (this.props.doNotPost) sharingDialogActions.push(
             <RaisedButton
                 primary
+                style={{ marginLeft: '8px' }}
                 label={this.translate('apply')}
                 onClick={this.confirmAndCloseDialog}
             />


### PR DESCRIPTION
Fixes DHIS2-2151-Sharing-UI.

Changes proposed in this pull request:

- Add margin between 'close' and 'apply' buttons in the sharing dialog.

