### PR TITLE
[interpretations] Use action Save&share on interpretation create and Share on existing

### DIFF
--- a/packages/interpretations/i18n/en.pot
+++ b/packages/interpretations/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-06-28T12:13:29.139Z\n"
-"PO-Revision-Date: 2018-06-28T12:13:29.139Z\n"
+"POT-Creation-Date: 2018-06-28T13:45:47.577Z\n"
+"PO-Revision-Date: 2018-06-28T13:45:47.577Z\n"
 
 msgid "No description"
 msgstr ""
@@ -101,10 +101,10 @@ msgstr ""
 msgid "Create interpretation"
 msgstr ""
 
-msgid "Save"
+msgid "Save & share"
 msgstr ""
 
-msgid "Save & share"
+msgid "Save"
 msgstr ""
 
 msgid "No interpretations"

--- a/packages/interpretations/i18n/en.pot
+++ b/packages/interpretations/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-06-22T11:56:27.059Z\n"
-"PO-Revision-Date: 2018-06-22T11:56:27.059Z\n"
+"POT-Creation-Date: 2018-06-28T12:13:29.139Z\n"
+"PO-Revision-Date: 2018-06-28T12:13:29.139Z\n"
 
 msgid "No description"
 msgstr ""
@@ -77,6 +77,9 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
+msgid "Share"
+msgstr ""
+
 msgid "Delete"
 msgstr ""
 
@@ -98,10 +101,10 @@ msgstr ""
 msgid "Create interpretation"
 msgstr ""
 
-msgid "Share"
+msgid "Save"
 msgstr ""
 
-msgid "Save"
+msgid "Save & share"
 msgstr ""
 
 msgid "No interpretations"

--- a/packages/interpretations/src/components/interpretations/Interpretation.js
+++ b/packages/interpretations/src/components/interpretations/Interpretation.js
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FlatButton from 'material-ui/FlatButton/FlatButton';
 import { SvgIcon } from '@dhis2/d2-ui-core';
+import i18n from '@dhis2/d2-i18n'
+import SharingDialog from '@dhis2/d2-ui-sharing-dialog';
+import some from 'lodash/fp/some';
 import InterpretationComments from './InterpretationComments';
 import InterpretationDialog from './InterpretationDialog';
 import { Link, ActionSeparator, WithAvatar, getUserLink } from './misc';
 import { userCanManage } from '../../util/auth';
-import i18n from '@dhis2/d2-i18n'
 import styles from './InterpretationsStyles.js';
-import some from 'lodash/fp/some';
 import CommentModel from '../../models/comment';
 import { formatDate } from '../../util/i18n';
 
@@ -16,6 +17,7 @@ class Interpretation extends React.Component {
     state = {
         newComment: null,
         interpretationToEdit: null,
+        sharingDialogIsOpen: false,
     };
 
     constructor(props) {
@@ -88,9 +90,13 @@ class Interpretation extends React.Component {
         this.closeInterpretationDialog();
     }
 
+    openSharingDialog = () => { this.setState({ sharingDialogIsOpen: true }); }
+
+    closeSharingDialog = () => { this.setState({ sharingDialogIsOpen: false }); }
+
     render() {
         const { interpretation, extended, mentions } = this.props;
-        const { interpretationToEdit, newComment } = this.state;
+        const { interpretationToEdit, newComment, sharingDialogIsOpen } = this.state;
         const { d2 } = this.context;
         const showActions = extended;
         const showComments = extended;
@@ -106,6 +112,15 @@ class Interpretation extends React.Component {
                         onSave={this.saveInterpretationAndClose}
                         onClose={this.closeInterpretationDialog}
                         mentions={mentions}
+                    />
+                }
+                {sharingDialogIsOpen &&
+                    <SharingDialog
+                        open={true}
+                        onRequestClose={this.closeSharingDialog}
+                        d2={d2}
+                        id={interpretation.id}
+                        type={"interpretation"}
                     />
                 }
 
@@ -142,6 +157,8 @@ class Interpretation extends React.Component {
                                     <span className="owner-actions">
                                         <ActionSeparator />
                                         <Link label={i18n.t('Edit')} onClick={this.openInterpretationDialog} />
+                                        <ActionSeparator />
+                                        <Link label={i18n.t('Share')} onClick={this.openSharingDialog} />
                                         <ActionSeparator />
                                         <Link label={i18n.t('Delete')} onClick={this.deleteInterpretation} />
                                     </span>}

--- a/packages/interpretations/src/components/interpretations/InterpretationDialog.js
+++ b/packages/interpretations/src/components/interpretations/InterpretationDialog.js
@@ -41,21 +41,27 @@ class InterpretationDialog extends Component {
         this.props.onClose();
     }
 
-    _save() {
+    _saveInterpretation() {
         const { interpretation, onSave } = this.props;
         const { value } = this.state;
         interpretation.text = value;
-        return interpretation.save().then(() => {
-            onSave(interpretation);
-            return interpretation;
+        return interpretation.save();
+    }
+
+    _save() {
+        return this._saveInterpretation().then(savedInterpretation => {
+            this.props.onSave(savedInterpretation);
+            this.props.onClose();
         });
     }
 
     onChange = (newValue) => { this.setState({ value: newValue }); }
 
     _saveAndShare = () => {
-        this._save().then(savedInterpretation =>
-            this.setState({ savedInterpretation, sharingDialogIsOpen: true }));
+        return this._saveInterpretation().then(savedInterpretation => {
+            this.props.onSave(savedInterpretation);
+            this.setState({ savedInterpretation, sharingDialogIsOpen: true });
+        });
     }
 
     render() {
@@ -69,9 +75,9 @@ class InterpretationDialog extends Component {
         const buttonProps = {color: "primary", disabled: !value};
         const actions = compact([
             <Button color="primary" onClick={this.cancel}>{i18n.t('Cancel')}</Button>,
-            isActionEdit
-                ? <Button {...buttonProps} onClick={this.save}>{i18n.t('Save')}</Button>
-                : <Button {...buttonProps} onClick={this.saveAndShare}>{i18n.t('Save & share')}</Button>,
+            !isActionEdit &&
+                <Button {...buttonProps} onClick={this.saveAndShare}>{i18n.t('Save & share')}</Button>,
+            <Button {...buttonProps} onClick={this.save}>{i18n.t('Save')}</Button>,
         ]);
 
         if (sharingDialogIsOpen) {

--- a/packages/interpretations/src/components/interpretations/InterpretationDialog.js
+++ b/packages/interpretations/src/components/interpretations/InterpretationDialog.js
@@ -22,8 +22,10 @@ class InterpretationDialog extends Component {
             value: props.interpretation.text,
             showEditor: true,
             sharingDialogIsOpen: false,
+            savedInterpretation: null,
         };
         this.save = this.hideEditorAndThen(this._save.bind(this));
+        this.saveAndShare = this.hideEditorAndThen(this._saveAndShare.bind(this));
         this.cancel = this.hideEditorAndThen(this._cancel.bind(this));
     }
 
@@ -43,60 +45,66 @@ class InterpretationDialog extends Component {
         const { interpretation, onSave } = this.props;
         const { value } = this.state;
         interpretation.text = value;
-        onSave(interpretation);
+        return interpretation.save().then(() => {
+            onSave(interpretation);
+            return interpretation;
+        });
     }
 
     onChange = (newValue) => { this.setState({ value: newValue }); }
 
-    openSharingDialog = () => { this.setState({ sharingDialogIsOpen: true }); }
-
-    closeSharingDialog = () => { this.setState({ sharingDialogIsOpen: false }); }
+    _saveAndShare = () => {
+        this._save().then(savedInterpretation =>
+            this.setState({ savedInterpretation, sharingDialogIsOpen: true }));
+    }
 
     render() {
         const { d2 } = this.context;
         const { interpretation, mentions } = this.props;
-        const { value, showEditor, sharingDialogIsOpen } = this.state;
-        const renderSharingDialog = interpretation && interpretation.id;
-        const title = interpretation && interpretation.id
+        const { value, showEditor, sharingDialogIsOpen, savedInterpretation } = this.state;
+        const isActionEdit = !!interpretation.id;
+        const title = isActionEdit
             ? i18n.t('Edit interpretation')
             : i18n.t('Create interpretation');
+        const buttonProps = {color: "primary", disabled: !value};
         const actions = compact([
             <Button color="primary" onClick={this.cancel}>{i18n.t('Cancel')}</Button>,
-            interpretation.id
-                ? <Button color="primary" onClick={this.openSharingDialog}>{i18n.t('Share')}</Button>
-                : null,
-            <Button color="primary" disabled={!value} onClick={this.save}>{i18n.t('Save')}</Button>,
+            isActionEdit
+                ? <Button {...buttonProps} onClick={this.save}>{i18n.t('Save')}</Button>
+                : <Button {...buttonProps} onClick={this.saveAndShare}>{i18n.t('Save & share')}</Button>,
         ]);
 
-        return (
-            <Dialog
-                title={title}
-                open={true}
-                onRequestClose={this.cancel}
-                actions={actions}
-                contentStyle={styles.dialog}
-                repositionOnUpdate={false}
-            >
-                {showEditor &&
-                    <RichEditor
-                        options={{height: 150}}
-                        initialContent={value}
-                        onEditorChange={this.onChange}
-                        mentions={mentions}
-                    />
-                }
-
-                {renderSharingDialog &&
-                    <SharingDialog
-                        open={sharingDialogIsOpen}
-                        onRequestClose={this.closeSharingDialog}
-                        d2={d2}
-                        id={interpretation.id}
-                        type={"interpretation"}
-                    />
-                }
-            </Dialog>
-        );
+        if (sharingDialogIsOpen) {
+            return (
+                <SharingDialog
+                    open={true}
+                    onRequestClose={this.cancel}
+                    d2={d2}
+                    id={savedInterpretation.id}
+                    type={"interpretation"}
+                />
+            );
+        } else {
+            return (
+                <Dialog
+                    title={title}
+                    open={true}
+                    onRequestClose={this.cancel}
+                    actions={actions}
+                    contentStyle={styles.dialog}
+                    repositionOnUpdate={false}
+                >
+                    {showEditor &&
+                        <RichEditor
+                            options={{height: 150}}
+                            initialContent={value}
+                            onEditorChange={this.onChange}
+                            mentions={mentions}
+                        />
+                    }
+                </Dialog>
+            );
+        }
     }
 }
 

--- a/packages/interpretations/src/components/interpretations/InterpretationsCard.js
+++ b/packages/interpretations/src/components/interpretations/InterpretationsCard.js
@@ -100,7 +100,6 @@ class InterpretationsCard extends React.Component {
         this.toggleExpand = this.toggleExpand.bind(this);
         this.openNewInterpretationDialog = this.openNewInterpretationDialog.bind(this);
         this.closeInterpretationDialog = this.closeInterpretationDialog.bind(this);
-        this.saveInterpretationAndClose = this.saveInterpretationAndClose.bind(this);
         this.setCurrentInterpretation = this.setCurrentInterpretation.bind(this);
         this.isControlledComponent = !!props.onCurrentInterpretationChange;
     }
@@ -122,11 +121,7 @@ class InterpretationsCard extends React.Component {
     }
 
     notifyChange(interpretation) {
-        this.setCurrentInterpretation(interpretation ? interpretation.id : null);
-
-        if (this.props.onChange) {
-            this.props.onChange();
-        }
+        this.props.onChange();
     }
 
     toggleExpand() {
@@ -142,10 +137,6 @@ class InterpretationsCard extends React.Component {
         this.setState({ interpretationToEdit: null });
     }
 
-    saveInterpretation(interpretation) {
-        interpretation.save().then(this.notifyChange);
-    }
-
     setCurrentInterpretation(interpretationId) {
         const { model, onCurrentInterpretationChange } = this.props;
 
@@ -157,11 +148,6 @@ class InterpretationsCard extends React.Component {
         } else {
             this.setState({ currentInterpretationId: interpretationId });
         }
-    }
-
-    saveInterpretationAndClose(interpretation) {
-        this.saveInterpretation(interpretation);
-        this.closeInterpretationDialog();
     }
 
     getCurrentInterpretation() {
@@ -190,7 +176,7 @@ class InterpretationsCard extends React.Component {
                     <InterpretationDialog
                         model={model}
                         interpretation={interpretationToEdit}
-                        onSave={this.saveInterpretationAndClose}
+                        onSave={this.notifyChange}
                         onClose={this.closeInterpretationDialog}
                         mentions={model.mentions}
                     />

--- a/packages/interpretations/src/components/interpretations/__tests__/InterpretationDialog.spec.js
+++ b/packages/interpretations/src/components/interpretations/__tests__/InterpretationDialog.spec.js
@@ -20,7 +20,8 @@ const interpretation = {
             id: "xE7jOejl9FI",
             displayName: "John Traore"
         }
-    }]
+    }],
+    save: jest.fn(() => Promise.resolve(interpretation)),
 };
 
 const renderComponent = (partialProps = {}) => {
@@ -49,7 +50,7 @@ describe('Interpretations: Interpretations -> InterpretationDialog component', (
     describe("when save is clicked with new text", () => {
         beforeEach(() => {
             interpretationDialog.find("RichEditor").props().onEditorChange("new text");
-            interpretationDialog.instance()._save();
+            return interpretationDialog.instance()._save();
         });
 
         it("should call onSave with the updated interpretation", () => {

--- a/packages/interpretations/src/components/interpretations/__tests__/InterpretationsCard.spec.js
+++ b/packages/interpretations/src/components/interpretations/__tests__/InterpretationsCard.spec.js
@@ -104,7 +104,7 @@ describe('Interpretations: Interpretations -> InterpretationsCard component', ()
                     expect(interpretationsCard.find("InterpretationDialog")).toExist();
                 });
 
-                describe("when dialog close", () => {
+                describe("when click on close", () => {
                     beforeEach(() => {
                         interpretationsCard.find("InterpretationDialog").props().onClose();
                         interpretationsCard.update()
@@ -115,22 +115,13 @@ describe('Interpretations: Interpretations -> InterpretationsCard component', ()
                     });
                 });
 
-                describe("when dialog save", () => {
+                describe("when click on save", () => {
                     beforeEach(() => {
                         newInterpretation = {
                             text: "New text",
                             save: jest.fn(() => Promise.resolve()),
                         };
-                        interpretationsCard.find("InterpretationDialog").props().onSave(newInterpretation);
-                        interpretationsCard.update()
-                    });
-
-                    it("closes the dialog", () => {
-                        expect(interpretationsCard.find("InterpretationDialog")).not.toExist();
-                    });
-
-                    it("should save the interpretation", () => {
-                        expect(newInterpretation.save).toHaveBeenCalled();
+                        return interpretationsCard.find("InterpretationDialog").props().onSave(newInterpretation);
                     });
 
                     it("should notify change", () => {

--- a/packages/interpretations/src/models/interpretation.js
+++ b/packages/interpretations/src/models/interpretation.js
@@ -31,11 +31,13 @@ export default class Interpretation {
 
             return apiFetchWithResponse(`/interpretations/${modelName}/${modelId}`, "POST", this.text)
                 .then(getInterpretationIdFromResponse)
-                .then(interpretationId =>
-                    apiFetch(`/sharing?type=interpretation&id=${interpretationId}`, "PUT", sharingPayload)
-                );
+                .then(interpretationId => {
+                    this.id = interpretationId;
+                    const sharingUrl = `/sharing?type=interpretation&id=${interpretationId}`;
+                    return apiFetch(sharingUrl, "PUT", sharingPayload).then(() => this);
+                });
         } else {
-            return apiFetch(`/interpretations/${this.id}`, "PUT", this.text);
+            return apiFetch(`/interpretations/${this.id}`, "PUT", this.text).then(() => this);
         }
     }
 


### PR DESCRIPTION
Fixes DHIS2-3428

Changes proposed in this pull request:

- On interpretation create: show action "Save & share". It saves the interpretation and then opens the sharing dialog of this new interpretation. Note that the interpretation starts with the same sharing the parent object has.
- On interpretation edit: action "Save" (and does not open sharing dialog)
- Add action "Share" to interpretation on detail.

![screenshot from 2018-06-28 14-18-36](https://user-images.githubusercontent.com/24643/42033983-dee4611a-7ade-11e8-9344-0fca126127a2.png)
![screenshot from 2018-06-28 14-19-01](https://user-images.githubusercontent.com/24643/42033984-df05bff4-7ade-11e8-8c21-f6b8b579e950.png)