### PR TITLE
Prevents long app names without spaces from overflowing horizontally

### DIFF
--- a/packages/header-bar/src/header-bar-styles.js
+++ b/packages/header-bar/src/header-bar-styles.js
@@ -237,6 +237,7 @@ styles = {
         flex: '1 1 auto',
         maxWidth: '100%',
         textAlign: 'center',
+        wordWrap: 'break-word',
     },
 
     moreAppsButton: {


### PR DESCRIPTION
Fixes: TECH-107 

Changes proposed in this pull request:
- Added word-wrap: break-word to menuItem styles so long app names without spaces will also be broken into multiple lines instead of overflowing horizontally

