### PR TITLE
[interpretations] Use displayInterpretation on details card

### DIFF
--- a/packages/interpretations/src/components/details/DetailsCard.js
+++ b/packages/interpretations/src/components/details/DetailsCard.js
@@ -40,7 +40,7 @@ const EditButton = props => {
 const descriptionMaxLength = 250;
 
 const getDescription = (model) => {
-    const {description} = model;
+    const { displayDescription: description } = model;
 
     if (!description) {
         return (<i>{i18n.t('No description')}</i>)

--- a/packages/interpretations/src/components/details/__tests__/DetailsCard.spec.js
+++ b/packages/interpretations/src/components/details/__tests__/DetailsCard.spec.js
@@ -17,7 +17,7 @@ const favorite = {
     publicAccess: "r-------",
     description: "Some Description",
     externalAccess: false,
-    displayDescription: "Description3",
+    displayDescription: "Some translated Description",
     favorite: false,
     access: {
         read: true,
@@ -81,7 +81,7 @@ describe('Interpretations: Details -> DetailsCard component', () => {
     });
 
     it('should render description as first item', () => {
-        expect(detailsCard.find("ListItem").get(0).props.text).toEqual(favorite.description);
+        expect(detailsCard.find("ListItem").get(0).props.text).toEqual("Some translated Description");
     });
 
     it('should render owner', () => {

--- a/packages/interpretations/src/models/__tests__/helpers.spec.js
+++ b/packages/interpretations/src/models/__tests__/helpers.spec.js
@@ -38,7 +38,7 @@ describe("getFavoriteWithInterpretations", () => {
 
     describe("api calls", () => {
         it("should call the model D2 get with the required fields", () => {
-            const expectedFields = "id,name,href,user[id,displayName],displayName,description," +
+            const expectedFields = "id,name,href,user[id,displayName],displayName,description,displayDescription," +
                 "created,lastUpdated,access,publicAccess,externalAccess,userAccesses,userGroupAccesses," +
                 "interpretations[id,user[id,displayName,userCredentials[username]],created,likes,likedBy[id,displayName],"
                 + "text,comments[id,text,created,user[id,displayName,userCredentials[username]]]]";

--- a/packages/interpretations/src/models/helpers.js
+++ b/packages/interpretations/src/models/helpers.js
@@ -19,6 +19,7 @@ const favoriteFields = [
     'user[id,displayName]',
     'displayName',
     'description',
+    'displayDescription',
     'created',
     'lastUpdated',
     'access',


### PR DESCRIPTION
Fixes DHIS2-3428.

Changes proposed in this pull request:

- Was using object.description, should be object.displayDescription