### PR TITLE
Add subscription icon to details card

### DIFF
--- a/packages/interpretations/i18n/en.pot
+++ b/packages/interpretations/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-07-02T12:32:53.634Z\n"
-"PO-Revision-Date: 2018-07-02T12:32:53.634Z\n"
+"POT-Creation-Date: 2018-07-04T08:51:47.874Z\n"
+"PO-Revision-Date: 2018-07-04T08:51:47.874Z\n"
 
 msgid "No description"
 msgstr ""
@@ -27,6 +27,12 @@ msgid "Public"
 msgstr ""
 
 msgid "user groups"
+msgstr ""
+
+msgid "Unsubscribe from this {{object}} and stop receiving notifications"
+msgstr ""
+
+msgid "Subscribe to this {{object}} and start receiving notifications"
 msgstr ""
 
 msgid "Details"
@@ -111,4 +117,22 @@ msgid "Write new interpretation"
 msgstr ""
 
 msgid "Interpretations"
+msgstr ""
+
+msgid "chart"
+msgstr ""
+
+msgid "pivot table"
+msgstr ""
+
+msgid "map"
+msgstr ""
+
+msgid "event chart"
+msgstr ""
+
+msgid "event report"
+msgstr ""
+
+msgid "object"
 msgstr ""

--- a/packages/interpretations/i18n/en.pot
+++ b/packages/interpretations/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-06-28T13:45:47.577Z\n"
-"PO-Revision-Date: 2018-06-28T13:45:47.577Z\n"
+"POT-Creation-Date: 2018-07-02T12:32:53.634Z\n"
+"PO-Revision-Date: 2018-07-02T12:32:53.634Z\n"
 
 msgid "No description"
 msgstr ""
@@ -45,12 +45,6 @@ msgid "Views"
 msgstr ""
 
 msgid "Sharing"
-msgstr ""
-
-msgid "Most common users matching"
-msgstr ""
-
-msgid "Other users matching"
 msgstr ""
 
 msgid "OK"

--- a/packages/interpretations/src/components/Interpretations.js
+++ b/packages/interpretations/src/components/Interpretations.js
@@ -66,6 +66,7 @@ class Interpretations extends React.Component {
             <div>
                 <DetailsCard
                     model={model}
+                    onChange={this.onChange}
                 />
 
                 <InterpretationsCard

--- a/packages/interpretations/src/components/details/DetailsCard.js
+++ b/packages/interpretations/src/components/details/DetailsCard.js
@@ -4,11 +4,13 @@ import { Card, CardHeader, CardText } from 'material-ui/Card';
 import IconButton from 'material-ui/IconButton';
 import { SvgIcon } from '@dhis2/d2-ui-core';
 import { grey600 } from 'material-ui/styles/colors';
+import SubscriberIconEnabled from 'material-ui/svg-icons/social/notifications';
+import SubscriberIconDisabled from 'material-ui/svg-icons/alert/add-alert';
 import i18n from '@dhis2/d2-i18n'
 
 import styles from './DetailsCardStyles.js';
-import { patch } from '../../models/helpers';
-import { formatDate } from '../../util/i18n';
+import { setSubscription } from '../../models/helpers';
+import { formatDate, translateModelName } from '../../util/i18n';
 
 const List = ({children}) => (
     <div style={styles.detailsCardList}>{children}</div>
@@ -74,13 +76,33 @@ class DetailsCard extends React.Component {
         isExpanded: true,
     };
 
-    constructor(props) {
-        super(props);
-        this.toggleDetailsExpand = this.toggleDetailsExpand.bind(this);
+    toggleDetailsExpand = () => {
+        this.setState({isExpanded: !this.state.isExpanded});
     }
 
-    toggleDetailsExpand() {
-        this.setState({isExpanded: !this.state.isExpanded});
+    toggleSubscription = () => {
+        const { model, onChange } = this.props;
+        return setSubscription(model, !model.subscribed).then(onChange);
+    }
+
+    renderSubscriptionButton(model) {
+        const tOpts = { object: translateModelName(model.modelName) };
+        const [SubscriberIcon, subscriptionTooltip] = model.subscribed
+            ? [SubscriberIconEnabled,
+                i18n.t("Unsubscribe from this {{object}} and stop receiving notifications", tOpts)]
+            : [SubscriberIconDisabled,
+                i18n.t("Subscribe to this {{object}} and start receiving notifications", tOpts)];
+
+        return (
+            <IconButton
+                style={styles.subscriberIcon}
+                tooltip={subscriptionTooltip}
+                tooltipPosition="bottom-left"
+                onClick={this.toggleSubscription}
+            >
+                <SubscriberIcon />
+            </IconButton>
+        );
     }
 
     render() {
@@ -104,6 +126,8 @@ class DetailsCard extends React.Component {
                 </CardHeader>
 
                 <CardText expandable={true} style={styles.body}>
+                    {this.renderSubscriptionButton(model)}
+
                     <List>
                         <ListItem text={getDescription(model)} />
                         <ListItem label={i18n.t('Owner')} text={owner} />
@@ -120,6 +144,7 @@ class DetailsCard extends React.Component {
 
 DetailsCard.propTypes = {
     model: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
 };
 
 export default DetailsCard;

--- a/packages/interpretations/src/components/details/DetailsCardStyles.js
+++ b/packages/interpretations/src/components/details/DetailsCardStyles.js
@@ -12,6 +12,7 @@ export default {
         zIndex: 1010,
         margin: "8px 4px 8px 4px",
         color: "red",
+        paddingBottom: 7,
     },
 
     detailsCardHeader: {

--- a/packages/interpretations/src/components/details/DetailsCardStyles.js
+++ b/packages/interpretations/src/components/details/DetailsCardStyles.js
@@ -38,4 +38,10 @@ export default {
         transform: 'translateY(-50%)',
         paddingRight: 0,
     },
+
+    subscriberIcon: {
+        position: "absolute",
+        top: 30,
+        right: 10,
+    },
 };

--- a/packages/interpretations/src/components/details/__tests__/DetailsCard.spec.js
+++ b/packages/interpretations/src/components/details/__tests__/DetailsCard.spec.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import PropTypes from 'prop-types';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
+import SubscriberIconEnabled from 'material-ui/svg-icons/social/notifications';
+import SubscriberIconDisabled from 'material-ui/svg-icons/alert/add-alert';
 
 import * as helpers from '../../../models/helpers';
 import DetailsCard from '../DetailsCard';
@@ -10,6 +12,7 @@ import { getStubContext } from '../../../../../../config/inject-theme';
 const favorite = {
     lastUpdated: "2018-05-21T12:57:25.365",
     id: "zDP78aJU8nX",
+    modelName: "map",
     href: "http://localhost:8029/api/maps/zDP78aJU8nX",
     created: "2018-05-17T11:53:17.999",
     name: "ANC: 1st visit coverage (%) by district last year",
@@ -62,6 +65,7 @@ const childContextTypes = {muiTheme: PropTypes.object, d2: PropTypes.object};
 
 const baseProps = {
     model: favorite,
+    onChange: jest.fn(),
 };
 
 const renderComponent = (partialProps = {}) => {
@@ -103,5 +107,61 @@ describe('Interpretations: Details -> DetailsCard component', () => {
     it('should render sharing info', () => {
         expect(getListItem(detailsCard, "Sharing").props().text)
             .toEqual("Public: Read + Administrators");
+    });
+
+    describe("subscription icon", () => {
+        describe('on non subscribed favorite', () => {
+            beforeEach(() => {
+                favorite.subscribed = false;
+                detailsCard = renderComponent();
+            });
+
+            it("should render a disabled subscription icon button", () => {
+                expect(detailsCard.find("IconButton").find(SubscriberIconDisabled)).toExist();
+            });
+
+            describe('when icon clicked', () => {
+                beforeEach(() => {
+                    helpers.setSubscription = jest.fn(() => Promise.resolve({}));
+                    detailsCard.find("IconButton").simulate("click");
+                    detailsCard.update();
+                });
+
+                it("should call the toggle function to be subscribed", () => {
+                    expect(helpers.setSubscription).toBeCalledWith(favorite, true);
+                });
+
+                it("should call prop onChange", () => {
+                    expect(detailsCard.instance().props.onChange).toBeCalled();
+                });
+            });
+        });
+
+        describe('on subscribed favorite', () => {
+            beforeEach(() => {
+                favorite.subscribed = true;
+                detailsCard = renderComponent();
+            });
+
+            it("should render an enabled subscription icon button", () => {
+                expect(detailsCard.find("IconButton").find(SubscriberIconEnabled)).toExist();
+            });
+
+            describe('when icon clicked', () => {
+                beforeEach(() => {
+                    helpers.setSubscription = jest.fn(() => Promise.resolve({}));
+                    detailsCard.find("IconButton").simulate("click");
+                    detailsCard.update();
+                });
+
+                it("should call the toggle function to be unsubscribed", () => {
+                    expect(helpers.setSubscription).toBeCalledWith(favorite, false);
+                });
+
+                it("should call prop onChange", () => {
+                    expect(detailsCard.instance().props.onChange).toBeCalled();
+                });
+            });
+        });
     });
 });

--- a/packages/interpretations/src/components/interpretations/InterpretationDialog.js
+++ b/packages/interpretations/src/components/interpretations/InterpretationDialog.js
@@ -21,7 +21,6 @@ const styles = {
 class InterpretationDialog extends Component {
     state = {
         value: this.props.interpretation.text,
-        showEditor: true,
         sharingDialogIsOpen: false,
         savedInterpretation: null,
     };
@@ -56,7 +55,7 @@ class InterpretationDialog extends Component {
     render() {
         const { d2 } = this.context;
         const { interpretation } = this.props;
-        const { value, showEditor, sharingDialogIsOpen, savedInterpretation } = this.state;
+        const { value, sharingDialogIsOpen, savedInterpretation } = this.state;
         const isActionEdit = !!interpretation.id;
         const title = isActionEdit ? i18n.t('Edit interpretation') : i18n.t('Create interpretation');
         const buttonProps = {color: "primary", disabled: !value};

--- a/packages/interpretations/src/models/__tests__/helpers.spec.js
+++ b/packages/interpretations/src/models/__tests__/helpers.spec.js
@@ -38,10 +38,10 @@ describe("getFavoriteWithInterpretations", () => {
 
     describe("api calls", () => {
         it("should call the model D2 get with the required fields", () => {
-            const expectedFields = "id,name,href,user[id,displayName],displayName,description,displayDescription," +
+            const expectedFields = "id,name,href,subscribed,user[id,displayName],displayName,description,displayDescription," +
                 "created,lastUpdated,access,publicAccess,externalAccess,userAccesses,userGroupAccesses," +
-                "interpretations[id,user[id,displayName,userCredentials[username]],created,likes,likedBy[id,displayName],"
-                + "text,comments[id,text,created,user[id,displayName,userCredentials[username]]]]";
+                "interpretations[id,user[id,displayName,userCredentials[username]],created,likes,likedBy[id,displayName]," +
+                "text,comments[id,text,created,user[id,displayName,userCredentials[username]]]]";
             expect(d2.models.map.get).toBeCalledWith("1", {fields: expectedFields});
         });
 
@@ -56,7 +56,12 @@ describe("getFavoriteWithInterpretations", () => {
             expect(favorite.name).toEqual("My favorite");
         });
 
-        it("should have favoriteViews", () => {
+        it("should have new field modelName", () => {
+            expect(favorite.modelName).toEqual("map");
+        });
+
+
+        it("should have new field favoriteViews", () => {
             expect(favorite.favoriteViews).toEqual(mockedViews);
         });
 

--- a/packages/interpretations/src/models/helpers.js
+++ b/packages/interpretations/src/models/helpers.js
@@ -16,6 +16,7 @@ const favoriteFields = [
     'id',
     'name',
     'href',
+    'subscribed',
     'user[id,displayName]',
     'displayName',
     'description',
@@ -44,11 +45,18 @@ export const getFavoriteWithInterpretations = (d2, type, id) => {
             return Object.assign(model, {
                 interpretations: modelInterpretations,
                 favoriteViews: views,
+                modelName: type,
             });
         });
 };
 
-export const patch = (model, attributeNames) => {
-    const attributes = pick(attributeNames, model);
-    return apiFetch(model.href, "PATCH", attributes);
+export const setSubscription = (model, newSubscriptionValue) => {
+    if (!model || !model.href) {
+        return Promise.reject(new Error(`Attribute href not found in model`));
+    } else {
+        var path = model.href + "/" + "subscriber";
+        var method = newSubscriptionValue ? "POST" : "DELETE";
+        return apiFetch(path, method);
+    }
 };
+

--- a/packages/interpretations/src/util/i18n.js
+++ b/packages/interpretations/src/util/i18n.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import i18n from '@dhis2/d2-i18n';
 
 export function formatDate(dateString) {
     const isoformat = dateString.split(".")[0];
@@ -10,3 +11,21 @@ export function formatRelative(dateString) {
     const isoformat = dateString.split(".")[0];
     return moment(dateString, moment.ISO_8601).fromNow();
 }
+
+export function translateModelName(modelName) {
+    switch (modelName) {
+    case 'chart':
+        return i18n.t('chart');
+    case 'reportTable':
+        return i18n.t('pivot table');
+    case 'map':
+        return i18n.t('map');
+    case 'eventChart':
+        return i18n.t('event chart');
+    case 'eventReport':
+        return i18n.t('event report');
+    default:
+        return i18n.t('object');
+    }
+ }
+ 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-3428

- Add subscription icon button to details card.
- Note: Icons are the same type we have in d2a, but built-in material-ui icons use the "filled" theme, while in d2a we used "outlined". 
- Check screenshot to validate the position of the icon within the card.

![screenshot from 2018-07-04 11-07-14](https://user-images.githubusercontent.com/24643/42267964-aa5a1d40-7f7a-11e8-931b-3e116cced27d.png)
