### PR TITLE
[interpretations] Replace user link by a text span

### DIFF
--- a/packages/interpretations/src/components/interpretations/InterpretationsStyles.js
+++ b/packages/interpretations/src/components/interpretations/InterpretationsStyles.js
@@ -161,7 +161,7 @@ export default {
     },
 
     userLink: {
-        "color": "#3162c5",
+        "color": "#3d4245",
         "fontWeight": "bold",
         "textDecoration": "none",
     },

--- a/packages/interpretations/src/components/interpretations/__tests__/Interpretation.spec.js
+++ b/packages/interpretations/src/components/interpretations/__tests__/Interpretation.spec.js
@@ -67,9 +67,8 @@ let currentUser;
 
 const commonExpectations = () => {
     it('should show the author with a link', () => {
-        const link = interpretationComponent.find("a.author");
+        const link = interpretationComponent.find(".author");
         expect(link.text()).toMatch(interpretation.user.displayName);
-        expect(link.prop("href")).toMatch(interpretation.user.id);
     });
 
     it('should show the creation date', () => {

--- a/packages/interpretations/src/components/interpretations/misc.js
+++ b/packages/interpretations/src/components/interpretations/misc.js
@@ -18,9 +18,12 @@ export const EditButton = props => {
 };
 
 export const getUserLink = (d2, user) => {
-    const baseurl = d2.system.systemInfo.contextPath;
-    const userUrl =`${baseurl}/dhis-web-messaging/profile.action?id=${user.id}`;
-    return (<a href={userUrl} style={styles.userLink} className="author" target="_blank">{user.displayName}</a>);
+    // Currently there is no public page for users (DHIS2-691), just use a <span> for now
+    return (
+        <span style={styles.userLink} className="author">
+            {user.displayName}
+        </span>
+    );
 };
 
 export const Link = (props) => {


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-3428

The 2.29 user page in messaging went away, and there is currently no public user page to link to (https://jira.dhis2.org/browse/DHIS2-691)

I've changed the text color to a grey one, blue suggests a link.

![screenshot from 2018-07-04 12-30-41](https://user-images.githubusercontent.com/24643/42272408-4a23a0d4-7f86-11e8-9f03-47e1dcf23d3a.png)


