### PR TITLE
Make sure that dialog opens vertically centred

### DIFF
--- a/packages/translation-dialog/src/TranslationForm.component.js
+++ b/packages/translation-dialog/src/TranslationForm.component.js
@@ -54,7 +54,7 @@ class TranslationForm extends Component {
 
     getLoadingdataElement() {
         return (
-            <div style={{ textAlign: 'center' }}>
+            <div style={{ textAlign: 'center', minHeight: 350 }}>
                 <CircularProgress mode="indeterminate" />
             </div>
         );
@@ -80,16 +80,18 @@ class TranslationForm extends Component {
         return (
             <div>
                 {this.renderFieldsToTranslate()}
-                <RaisedButton
-                    label={this.getTranslation('save')}
-                    primary
-                    onClick={this.saveTranslations}
-                />
-                <RaisedButton
-                    style={{ marginLeft: '1rem' }}
-                    label={this.getTranslation('cancel')}
-                    onClick={this.props.onCancel}
-                />
+                <div style={{ paddingTop: '1rem' }}>
+                    <RaisedButton
+                        label={this.getTranslation('save')}
+                        primary
+                        onClick={this.saveTranslations}
+                    />
+                    <RaisedButton
+                        style={{ marginLeft: '1rem' }}
+                        label={this.getTranslation('cancel')}
+                        onClick={this.props.onCancel}
+                    />
+                </div>
             </div>
         );
     }
@@ -108,7 +110,7 @@ class TranslationForm extends Component {
         }
 
         return (
-            <div style={{ minHeight: 250 }}>
+            <div style={{ minHeight: 350 }}>
                 <LocaleSelector locales={this.props.locales} onChange={this.setCurrentLocale} />
                 {this.state.currentSelectedLocale ? this.renderForm() : this.renderHelpText()}
             </div>


### PR DESCRIPTION
Fixes DHIS2-4183

Changes proposed in this pull request:
- The loader div and the form now have an equal min-height so that the dialog-content's dimensions are more accurate when the dialog opens and its position is computed
- Increased the min width value from 250 to 350 because the loaded form's normal height is around 360
- Added some padding above the buttons

