### PR TITLE
Remove API link for maps in FileMenu/GetLink dialog

### DIFF
--- a/packages/file-menu/src/GetLinkDialog.js
+++ b/packages/file-menu/src/GetLinkDialog.js
@@ -47,11 +47,15 @@ const GetLinkDialog = (props, context) => {
                         {getAppUrl(fileType, fileModel.id, context)}
                     </a>
                 </DialogContentText>
-                <DialogContentText>
-                    {i18n.t('Open in web API')}
-                    <br />
-                    <a href={`${fileModel.href}/data.html+css`}>{fileModel.href}/data.html+css</a>
-                </DialogContentText>
+                {fileType !== 'map' && (
+                    <DialogContentText>
+                        {i18n.t('Open in web API')}
+                        <br />
+                        <a href={`${fileModel.href}/data.html+css`}>
+                            {fileModel.href}/data.html+css
+                        </a>
+                    </DialogContentText>
+                )}
             </DialogContent>
             <DialogActions>
                 <Button onClick={onRequestClose} color="primary">


### PR DESCRIPTION
The link does not work at the moment, until the headless browser
solution for downloading maps is in place.

Fixes DHIS2-3935.

Changes proposed in this pull request:

- Remove the open in API link for maps