### PR TITLE
DHIS2-4253: always use absolute URL for copy paste

### DIFF
--- a/packages/file-menu/src/GetLinkDialog.js
+++ b/packages/file-menu/src/GetLinkDialog.js
@@ -31,7 +31,10 @@ const getAppUrl = (fileType, fileId, context) => {
             appName = '';
     }
 
-    return `${baseUrl}/${appName}/index.html?id=${fileId}`;
+    // DHIS2-4253: force URL to be absolute
+    const url = new URL(`${baseUrl}/${appName}/index.html?id=${fileId}`, window.location.origin);
+
+    return url.href;
 };
 
 const GetLinkDialog = (props, context) => {


### PR DESCRIPTION
Fixes DHIS2-4253.

Changes proposed in this pull request:

- always use absolute URL for the links to an app.
This is to allow use of a copy pasted URL
