### PR TITLE
Implement RichTextWrapper component for rendering markdown/links/emojis

### DIFF
--- a/packages/rich-text-wrapper/README.md
+++ b/packages/rich-text-wrapper/README.md
@@ -1,0 +1,58 @@
+# Rich text wrapper D2-UI component
+
+# Usage
+
+## Build
+
+```
+$ pwd
+/path/to/d2-ui/packages/rich-text-wrapper
+
+$ yarn build
+```
+
+## Publish
+
+```
+$ pwd
+/path/to/d2-ui/packages/rich-text-wrapper
+$ yarn version
+
+$ cd build # always publish from the build dir!
+$ npm login
+$ npm publish
+```
+
+## Install
+
+```sh
+yarn add d2-ui-rich-text-wrapper
+```
+
+## Import
+
+```js
+import RichTextWrapper from 'd2-ui-rich-text-wrapper';
+
+<RichTextWrapper>Some text _with_ *markdown* syntax and emoji :)</RichTextWrapper>;
+```
+
+# Local development
+
+```sh
+$ pwd
+/path/to/d2-ui/packages/rich-text-wrapper
+
+$ yarn build
+
+$ cd build
+$ yarn link
+```
+
+In the integrating project:
+
+```sh
+$ yarn link d2-ui-rich-text-wrapper
+$ ls node_modules/d2-ui-rich-text-wrapper/ # if there are more files here than below you did not link from the build dir!
+    index.js    package.json
+```

--- a/packages/rich-text-wrapper/package.json
+++ b/packages/rich-text-wrapper/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "@dhis2/d2-ui-rich-text-wrapper",
+    "version": "1.0.0",
+    "description": "Rich text wrapper component for DHIS2",
+    "main": "./build/cjs/index.js",
+    "module": "./build/es/index.js",
+    "files": ["build"],
+    "license": "BSD-3-Clause",
+    "author": "Edoardo Sabadelli <edoardo@dhis2.org>",
+    "peerDependencies": {
+        "react": "^16.4.0",
+        "react-dom": "^16.4.0"
+    },
+    "scripts": {
+        "prebuild": "rimraf ./build/*",
+        "build": "yarn build:commonjs && yarn build:es",
+        "build:commonjs":
+            "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
+        "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
+        "build:umd": "cross-env && webpack -p",
+        "watch": "yarn build:es -- --watch",
+        "test-ci": "jest --config=../../jest.config.js packages/rich-text-wrapper",
+        "prettify": "prettier \"src/**/*.{js,jsx,json,css}\" --write"
+    },
+    "dependencies": {
+        "markdown-it": "^8.4.1",
+        "prop-types": "^15.6.2"
+    },
+    "jest": {
+        "transformIgnorePatterns": ["node_modules/(?!react-native|react-navigation)/"]
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "devDependencies": {
+        "prettier": "^1.12.1"
+    }
+}

--- a/packages/rich-text-wrapper/src/RichTextWrapper.js
+++ b/packages/rich-text-wrapper/src/RichTextWrapper.js
@@ -1,0 +1,161 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import MarkdownIt from 'markdown-it';
+
+const initRichTextParser = () => {
+    // disable all rules, enable autolink for URLs and email addresses
+    const md = new MarkdownIt('zero', { linkify: true });
+
+    // *bold* -> <strong>bold</strong>
+    md.inline.ruler.push('strong', (state, silent) => {
+        if (silent) return false;
+
+        const start = state.pos;
+        const marker = state.src.charCodeAt(start);
+
+        // marker character: "*"
+        if (marker !== 0x2a) {
+            return false;
+        }
+
+        const BOLD_RE = /^\*([^*]+)\*/;
+
+        const token = state.src.slice(start);
+
+        if (BOLD_RE.test(token)) {
+            const boldMatch = token.match(BOLD_RE);
+
+            const text = boldMatch[0].slice(1, -1);
+
+            state.push('strong_open', 'strong', 1);
+
+            const t = state.push('text', '', 0);
+            t.content = text;
+
+            state.push('strong_close', 'strong', -1);
+
+            state.pos += boldMatch[0].length;
+
+            return true;
+        }
+
+        return false;
+    });
+
+    // _italic_ -> <em>italic</em>
+    md.inline.ruler.push('italic', (state, silent) => {
+        if (silent) return false;
+
+        const start = state.pos;
+        const marker = state.src.charCodeAt(start);
+
+        // marker character: "_"
+        if (marker !== 0x5f) {
+            return false;
+        }
+
+        const ITALIC_RE = /^_([^_]+)_/;
+
+        const token = state.src.slice(start);
+
+        if (ITALIC_RE.test(token)) {
+            const italicMatch = token.match(ITALIC_RE);
+
+            const text = italicMatch[0].slice(1, -1);
+
+            state.push('em_open', 'em', 1);
+
+            const t = state.push('text', '', 0);
+            t.content = text;
+
+            state.push('em_close', 'em', -1);
+
+            state.pos += italicMatch[0].length;
+
+            return true;
+        }
+
+        return false;
+    });
+
+    // :-) :) :-( :( :+1 :-1 -> <span>[unicode]</span>
+    md.inline.ruler.push('emoji', (state, silent) => {
+        if (silent) return false;
+
+        const start = state.pos;
+        const marker = state.src.charCodeAt(start);
+
+        // marker character: ":"
+        if (marker !== 0x3a) {
+            return false;
+        }
+
+        const emojiDb = {
+            ':-)': '\u{1F642}',
+            ':)': '\u{1F642}',
+            ':-(': '\u{1F641}',
+            ':(': '\u{1F641}',
+            ':+1': '\u{1F44D}',
+            ':-1': '\u{1F44E}',
+        };
+
+        const EMOJI_RE = /^(:-\)|:\)|:\(|:-\(|:\+1|:-1)/;
+
+        const token = state.src.slice(start);
+
+        if (EMOJI_RE.test(token)) {
+            const emojiMatch = token.match(EMOJI_RE);
+
+            const emoji = emojiMatch[0];
+
+            state.push('emoji_open', 'span', 1);
+
+            const t = state.push('text', '', 0);
+            t.content = emojiDb[emoji];
+
+            state.push('emoji_close', 'span', -1);
+
+            state.pos += emojiMatch[0].length;
+
+            return true;
+        }
+
+        return false;
+    });
+
+    md.enable(['linkify', 'strong', 'italic', 'emoji']);
+
+    return md;
+};
+
+class RichTextWrapper extends Component {
+    constructor(props) {
+        super(props);
+
+        this.parser = initRichTextParser();
+    }
+
+    render() {
+        const { children, style } = this.props;
+
+        return (
+            <p
+                style={style}
+                dangerouslySetInnerHTML={{
+                    __html: this.parser.renderInline(children),
+                }}
+            />
+        );
+    }
+}
+
+RichTextWrapper.defaultProps = {
+    style: null,
+};
+
+RichTextWrapper.propTypes = {
+    style: PropTypes.object,
+};
+
+export default RichTextWrapper;

--- a/packages/rich-text-wrapper/src/__tests__/RichTextWrapper.spec.js
+++ b/packages/rich-text-wrapper/src/__tests__/RichTextWrapper.spec.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import RichTextWrapper from '../RichTextWrapper';
+
+describe('RichText: RichTextWrapper component', () => {
+    let richTextWrapper;
+    const props = {
+        style: { color: 'blue' },
+    };
+
+    const renderComponent = (props, text) => {
+        return shallow(<RichTextWrapper {...props}>{text}</RichTextWrapper>);
+    };
+
+    it('should have rendered a result', () => {
+        richTextWrapper = renderComponent({}, 'test');
+
+        expect(richTextWrapper).toHaveLength(1);
+    });
+
+    it('should have rendered a result with the style prop', () => {
+        richTextWrapper = renderComponent(props, 'test prop');
+
+        expect(richTextWrapper.props().style).toEqual(props.style);
+    });
+
+    it('should have rendered a plain text content', () => {
+        richTextWrapper = renderComponent({}, 'plain text');
+
+        expect(richTextWrapper.html()).toEqual('<p>plain text</p>');
+    });
+
+    it('should have rendered markdown converted into HTML', () => {
+        const tests = [
+            ['_italic_', '<em>italic</em>'],
+            ['*bold*', '<strong>bold</strong>'],
+            [':-)', '<span>\u{1F642}</span>'],
+            [':)', '<span>\u{1F642}</span>'],
+            [':-(', '<span>\u{1F641}</span>'],
+            [':(', '<span>\u{1F641}</span>'],
+            [':+1', '<span>\u{1F44D}</span>'],
+            [':-1', '<span>\u{1F44E}</span>'],
+            [
+                'mixed _italic_ *bold* and :+1',
+                'mixed <em>italic</em> <strong>bold</strong> and <span>\u{1F44D}</span>',
+            ],
+            // _ inside italic not allowed, it closes the <em>
+            ['_italic with _ inside_', '<em>italic with </em> inside_'],
+            ['_italic with * inside_', '<em>italic with * inside</em>'],
+            // * inside bold not allowed, it closes the <strong>
+            ['*bold with * inside*', '<strong>bold with </strong> inside*'],
+            ['*bold with _ inside*', '<strong>bold with _ inside</strong>'],
+            // nested italic/bold combinations not allowed
+            ['_italic with *bold* inside_', '<em>italic with *bold* inside</em>'],
+            ['*bold with _italic_ inside*', '<strong>bold with _italic_ inside</strong>'],
+            ['text with : and :)', 'text with : and <span>\u{1F642}</span>'],
+            ['(parenthesis and :))', '(parenthesis and <span>\u{1F642}</span>)'],
+            [':((parenthesis:))', '<span>\u{1F641}</span>(parenthesis<span>\u{1F642}</span>)'],
+            [':+1+1', '<span>\u{1F44D}</span>+1'],
+            ['-1:-1', '-1<span>\u{1F44E}</span>'],
+        ];
+
+        tests.forEach(test => {
+            richTextWrapper = renderComponent({}, test[0]);
+
+            expect(richTextWrapper.html()).toEqual(`<p>${test[1]}</p>`);
+        });
+    });
+});

--- a/packages/rich-text-wrapper/src/index.js
+++ b/packages/rich-text-wrapper/src/index.js
@@ -1,0 +1,3 @@
+import RichTextWrapper from './RichTextWrapper';
+
+export default RichTextWrapper;

--- a/packages/rich-text-wrapper/webpack.config.js
+++ b/packages/rich-text-wrapper/webpack.config.js
@@ -1,0 +1,36 @@
+const webpack = require('webpack');
+const path = require('path');
+
+module.exports = {
+    entry: './src/index.js',
+    output: {
+        path: path.resolve(__dirname, 'build'),
+        filename: 'index.js',
+        library: 'RichTextWrapper',
+        libraryTarget: 'umd',
+    },
+    module: {
+        rules: [
+            { test: /\.js$/, loader: 'babel-loader', exclude: /node_modules/ },
+            { test: /\.jsx$/, loader: 'babel-loader', exclude: /node_modules/ },
+        ],
+    },
+    devtool: 'source-map',
+    externals: {
+        react: {
+            root: 'React',
+            amd: 'react',
+            commonjs2: 'react',
+            commonjs: 'react',
+        },
+        'react-dom': {
+            root: 'ReactDOM',
+            commonjs2: 'react-dom',
+            commonjs: 'react-dom',
+            amd: 'react-dom',
+            umd: 'react-dom',
+        },
+    },
+
+    plugins: [new webpack.optimize.ModuleConcatenationPlugin()],
+};


### PR DESCRIPTION
Fixes DHIS2-4079.

Changes proposed in this pull request:

This implementation uses MarkdownIt library, where all the default rules
are disabled.
Instead a couple of custom rules are implemented end enabled.
The supported syntax is _italic_, *bold* and a few emojis.
The linkify feature is enabled, which automatically converts URLs or
email addresses into links (<a> tags).