### PR TITLE
DHIS2-4079: first implementation of rich text editor and parser

### DIFF
--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -1,0 +1,18 @@
+# D2-ui: Rich text
+
+The rich text library contains a rich text editor and parser for handling rich text in input fields in dhis2 applications.
+
+## Installation
+
+```
+yarn add @dhis2/d2-ui-rich-text
+```
+
+## Usage
+
+Importing components
+
+```
+import { Editor } from "@dhis2/d2-ui-rich-text";
+import { Parser } from "@dhis2/d2-ui-rich-text";
+```

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "@dhis2/d2-ui-rich-text",
+    "version": "1.0.0",
+    "description": "Rich text components for DHIS2 in d2-ui",
+    "main": "./build/cjs/index.js",
+    "module": "./build/es/index.js",
+    "files": ["build"],
+    "license": "BSD-3-Clause",
+    "author": "Edoardo Sabadelli <edoardo@dhis2.org>",
+    "scripts": {
+        "coverage": "jest --coverage",
+        "test-ci": "jest --config=../../jest.config.js packages/rich-text",
+        "lint": "eslint src/",
+        "prebuild": "rimraf ./build/*",
+        "build": "yarn build:commonjs && yarn build:es",
+        "build:commonjs":
+            "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
+        "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
+        "build:umd": "cross-env && webpack -p",
+        "watch": "yarn build:es --  --watch"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/dhis2/d2-ui.git"
+    },
+    "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "lodash": "^4.17.10",
+        "markdown-it": "^8.4.2",
+        "material-ui": "^0.20.0",
+        "prop-types": "^15.6.2"
+    },
+    "peerDependencies": {
+        "react": "^16.4.0",
+        "react-dom": "^16.4.0"
+    },
+    "pre-commit": ["validate", "test"],
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/rich-text/src/editor/Editor.js
+++ b/packages/rich-text/src/editor/Editor.js
@@ -1,0 +1,93 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class Editor extends Component {
+    constructor(props) {
+        super(props);
+
+        this.defaultState = {
+            boldMode: false,
+            italicMode: false,
+        };
+
+        this.state = {
+            ...this.defaultState,
+            element: null,
+        };
+    }
+
+    onKeyDown = event => {
+        const { key, ctrlKey, metaKey } = event;
+        const element = event.target;
+
+        this.setState({ element });
+
+        // bold
+        if (key === 'b' && (ctrlKey || metaKey)) {
+            this.insertMarkers('bold');
+            // italic
+        } else if (key === 'i' && (ctrlKey || metaKey)) {
+            this.insertMarkers('italic');
+        }
+    };
+
+    toggleMode = mode => {
+        const prop = `${mode}Mode`;
+
+        this.setState({ [prop]: !this.state[prop] });
+    };
+
+    insertMarkers = mode => {
+        const element = this.state.element;
+        const { selectionStart, selectionEnd, value } = element;
+
+        this.toggleMode(mode);
+
+        let marker;
+
+        switch (mode) {
+            case 'italic':
+                marker = '_';
+                break;
+            case 'bold':
+                marker = '*';
+                break;
+            default:
+                return;
+        }
+
+        let newValue;
+
+        if (selectionStart >= 0 && selectionStart === selectionEnd) {
+            newValue = `${value}${marker}`;
+        } else if (selectionStart >= 0) {
+            newValue = [
+                value.slice(0, selectionStart),
+                value.slice(selectionStart, selectionEnd),
+                value.slice(selectionEnd),
+            ].join(marker);
+
+            this.toggleMode(mode);
+        }
+
+        if (this.props.onEdit) {
+            this.props.onEdit(newValue);
+        }
+    };
+
+    render() {
+        const { children } = this.props;
+
+        return <div onKeyDown={this.onKeyDown}>{children}</div>;
+    }
+}
+
+Editor.defaultProps = {
+    onEdit: null,
+};
+
+Editor.propTypes = {
+    onEdit: PropTypes.func,
+};
+
+export default Editor;

--- a/packages/rich-text/src/editor/__tests__/Editor.spec.js
+++ b/packages/rich-text/src/editor/__tests__/Editor.spec.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Editor from '../Editor';
+
+describe('RichText: Editor component', () => {
+    let richTextEditor;
+    const props = {
+        onEdit: jest.fn(),
+    };
+
+    const renderComponent = props => {
+        return shallow(
+            <Editor {...props}>
+                <input />
+            </Editor>
+        );
+    };
+
+    it('should have rendered a result', () => {
+        richTextEditor = renderComponent();
+
+        expect(richTextEditor).toHaveLength(1);
+    });
+});

--- a/packages/rich-text/src/index.js
+++ b/packages/rich-text/src/index.js
@@ -1,0 +1,2 @@
+export { default as Editor } from './editor/Editor';
+export { default as Parser } from './parser/Parser';

--- a/packages/rich-text/src/parser/Parser.js
+++ b/packages/rich-text/src/parser/Parser.js
@@ -1,0 +1,161 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import MarkdownIt from 'markdown-it';
+
+const initParser = () => {
+    // disable all rules, enable autolink for URLs and email addresses
+    const md = new MarkdownIt('zero', { linkify: true });
+
+    // *bold* -> <strong>bold</strong>
+    md.inline.ruler.push('strong', (state, silent) => {
+        if (silent) return false;
+
+        const start = state.pos;
+        const marker = state.src.charCodeAt(start);
+
+        // marker character: "*"
+        if (marker !== 0x2a) {
+            return false;
+        }
+
+        const BOLD_RE = /^\*([^*]+)\*/;
+
+        const token = state.src.slice(start);
+
+        if (BOLD_RE.test(token)) {
+            const boldMatch = token.match(BOLD_RE);
+
+            const text = boldMatch[0].slice(1, -1);
+
+            state.push('strong_open', 'strong', 1);
+
+            const t = state.push('text', '', 0);
+            t.content = text;
+
+            state.push('strong_close', 'strong', -1);
+
+            state.pos += boldMatch[0].length;
+
+            return true;
+        }
+
+        return false;
+    });
+
+    // _italic_ -> <em>italic</em>
+    md.inline.ruler.push('italic', (state, silent) => {
+        if (silent) return false;
+
+        const start = state.pos;
+        const marker = state.src.charCodeAt(start);
+
+        // marker character: "_"
+        if (marker !== 0x5f) {
+            return false;
+        }
+
+        const ITALIC_RE = /^_([^_]+)_/;
+
+        const token = state.src.slice(start);
+
+        if (ITALIC_RE.test(token)) {
+            const italicMatch = token.match(ITALIC_RE);
+
+            const text = italicMatch[0].slice(1, -1);
+
+            state.push('em_open', 'em', 1);
+
+            const t = state.push('text', '', 0);
+            t.content = text;
+
+            state.push('em_close', 'em', -1);
+
+            state.pos += italicMatch[0].length;
+
+            return true;
+        }
+
+        return false;
+    });
+
+    // :-) :) :-( :( :+1 :-1 -> <span>[unicode]</span>
+    md.inline.ruler.push('emoji', (state, silent) => {
+        if (silent) return false;
+
+        const start = state.pos;
+        const marker = state.src.charCodeAt(start);
+
+        // marker character: ":"
+        if (marker !== 0x3a) {
+            return false;
+        }
+
+        const emojiDb = {
+            ':-)': '\u{1F642}',
+            ':)': '\u{1F642}',
+            ':-(': '\u{1F641}',
+            ':(': '\u{1F641}',
+            ':+1': '\u{1F44D}',
+            ':-1': '\u{1F44E}',
+        };
+
+        const EMOJI_RE = /^(:-\)|:\)|:\(|:-\(|:\+1|:-1)/;
+
+        const token = state.src.slice(start);
+
+        if (EMOJI_RE.test(token)) {
+            const emojiMatch = token.match(EMOJI_RE);
+
+            const emoji = emojiMatch[0];
+
+            state.push('emoji_open', 'span', 1);
+
+            const t = state.push('text', '', 0);
+            t.content = emojiDb[emoji];
+
+            state.push('emoji_close', 'span', -1);
+
+            state.pos += emojiMatch[0].length;
+
+            return true;
+        }
+
+        return false;
+    });
+
+    md.enable(['linkify', 'strong', 'italic', 'emoji']);
+
+    return md;
+};
+
+class Parser extends Component {
+    constructor(props) {
+        super(props);
+
+        this.parser = initParser();
+    }
+
+    render() {
+        const { children, style } = this.props;
+
+        return (
+            <p
+                style={style}
+                dangerouslySetInnerHTML={{
+                    __html: this.parser.renderInline(children),
+                }}
+            />
+        );
+    }
+}
+
+Parser.defaultProps = {
+    style: null,
+};
+
+Parser.propTypes = {
+    style: PropTypes.object,
+};
+
+export default Parser;

--- a/packages/rich-text/src/parser/__tests__/Parser.spec.js
+++ b/packages/rich-text/src/parser/__tests__/Parser.spec.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Parser from '../Parser';
+
+describe('RichText: Parser component', () => {
+    let richTextParser;
+    const props = {
+        style: { color: 'blue' },
+    };
+
+    const renderComponent = (props, text) => {
+        return shallow(<Parser {...props}>{text}</Parser>);
+    };
+
+    it('should have rendered a result', () => {
+        richTextParser = renderComponent({}, 'test');
+
+        expect(richTextParser).toHaveLength(1);
+    });
+
+    it('should have rendered a result with the style prop', () => {
+        richTextParser = renderComponent(props, 'test prop');
+
+        expect(richTextParser.props().style).toEqual(props.style);
+    });
+
+    it('should have rendered a plain text content', () => {
+        richTextParser = renderComponent({}, 'plain text');
+
+        expect(richTextParser.html()).toEqual('<p>plain text</p>');
+    });
+
+    it('should have rendered markdown converted into HTML', () => {
+        const tests = [
+            ['_italic_', '<em>italic</em>'],
+            ['*bold*', '<strong>bold</strong>'],
+            [':-)', '<span>\u{1F642}</span>'],
+            [':)', '<span>\u{1F642}</span>'],
+            [':-(', '<span>\u{1F641}</span>'],
+            [':(', '<span>\u{1F641}</span>'],
+            [':+1', '<span>\u{1F44D}</span>'],
+            [':-1', '<span>\u{1F44E}</span>'],
+            [
+                'mixed _italic_ *bold* and :+1',
+                'mixed <em>italic</em> <strong>bold</strong> and <span>\u{1F44D}</span>',
+            ],
+            // _ inside italic not allowed, it closes the <em>
+            ['_italic with _ inside_', '<em>italic with </em> inside_'],
+            ['_italic with * inside_', '<em>italic with * inside</em>'],
+            // * inside bold not allowed, it closes the <strong>
+            ['*bold with * inside*', '<strong>bold with </strong> inside*'],
+            ['*bold with _ inside*', '<strong>bold with _ inside</strong>'],
+            // nested italic/bold combinations not allowed
+            ['_italic with *bold* inside_', '<em>italic with *bold* inside</em>'],
+            ['*bold with _italic_ inside*', '<strong>bold with _italic_ inside</strong>'],
+            ['text with : and :)', 'text with : and <span>\u{1F642}</span>'],
+            ['(parenthesis and :))', '(parenthesis and <span>\u{1F642}</span>)'],
+            [':((parenthesis:))', '<span>\u{1F641}</span>(parenthesis<span>\u{1F642}</span>)'],
+            [':+1+1', '<span>\u{1F44D}</span>+1'],
+            ['-1:-1', '-1<span>\u{1F44E}</span>'],
+        ];
+
+        tests.forEach(test => {
+            richTextParser = renderComponent({}, test[0]);
+
+            expect(richTextParser.html()).toEqual(`<p>${test[1]}</p>`);
+        });
+    });
+});

--- a/packages/rich-text/webpack.config.js
+++ b/packages/rich-text/webpack.config.js
@@ -1,0 +1,36 @@
+const webpack = require('webpack');
+const path = require('path');
+
+module.exports = {
+    entry: './src/index.js',
+    output: {
+        path: path.resolve(__dirname, 'build'),
+        filename: 'index.js',
+        library: 'RichText',
+        libraryTarget: 'umd',
+    },
+    module: {
+        rules: [
+            { test: /\.js$/, loader: 'babel-loader', exclude: /node_modules/ },
+            { test: /\.jsx$/, loader: 'babel-loader', exclude: /node_modules/ },
+        ],
+    },
+    devtool: 'source-map',
+    externals: {
+        react: {
+            root: 'React',
+            amd: 'react',
+            commonjs2: 'react',
+            commonjs: 'react',
+        },
+        'react-dom': {
+            root: 'ReactDOM',
+            commonjs2: 'react-dom',
+            commonjs: 'react-dom',
+            amd: 'react-dom',
+            umd: 'react-dom',
+        },
+    },
+
+    plugins: [new webpack.optimize.ModuleConcatenationPlugin()],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7305,6 +7305,12 @@ libnpx@^10.2.0:
     y18n "^4.0.0"
     yargs "^11.0.0"
 
+linkify-it@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.0.3.tgz#d94a4648f9b1c179d64fa97291268bdb6ce9434f"
+  dependencies:
+    uc.micro "^1.0.1"
+
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
@@ -7776,6 +7782,16 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 marked@~0.3.6:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
@@ -7903,6 +7919,10 @@ md5.js@^1.3.4:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
 meant@~1.0.1:
   version "1.0.1"
@@ -12003,6 +12023,10 @@ typedarray@^0.0.6:
 ua-parser-js@^0.7.9:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.5.tgz#0c65f15f815aa08b560a61ce8b4db7ffc3f45376"
 
 uglify-es@^3.3.4:
   version "3.3.10"


### PR DESCRIPTION
Fixes DHIS2-4079.

Changes proposed in this pull request:

- parser: the implementation uses MarkdownIt library, where all the default rules
are disabled.
Instead a couple of custom rules are implemented end enabled.
The supported syntax is italic, bold and a few emojis.
The linkify feature is enabled, which automatically converts URLs or
email addresses into links ( tags).
- editor: simple rich text editor for italic and bold, only keyboard shortcuts for now, no UI)

