### PR TITLE
Rename argument with appropriate names

### DIFF
--- a/packages/favorites-dialog/src/EnhancedTable.js
+++ b/packages/favorites-dialog/src/EnhancedTable.js
@@ -91,8 +91,8 @@ const EnhancedTable = props => {
         toggleActionsMenu();
     };
 
-    const clickHandler = model => event => {
-        onFavoriteSelect(model);
+    const clickHandler = id => event => {
+        onFavoriteSelect(id);
     };
 
     return (

--- a/packages/favorites-dialog/src/Favorites.js
+++ b/packages/favorites-dialog/src/Favorites.js
@@ -22,8 +22,8 @@ class Favorites extends Component {
     render() {
         const { open, onRequestClose, onFavoriteSelect } = this.props;
 
-        const handleOnFavoriteSelect = model => {
-            onFavoriteSelect(model);
+        const handleOnFavoriteSelect = id => {
+            onFavoriteSelect(id);
             // XXX should this be in the favoriteSelect callback?
             onRequestClose();
         };


### PR DESCRIPTION
Changes proposed in this pull request:

- Use proper name for argument to avoid confusion 

