### PR TITLE
task/Upgrade translation dialog to material-ui 1.5

### DIFF
--- a/examples/create-react-app/src/components/translation.js
+++ b/examples/create-react-app/src/components/translation.js
@@ -62,8 +62,9 @@ export default class TranslationDialogExample extends React.Component {
                 <TranslationDialog
                     d2={this.props.d2}
                     open={this.state.translationDialog.open}
+                    onClose={()=> console.log('dialog closed')}
                     objectToTranslate={dataElement}
-                    onTranslationSaved={() => console.log('saved')}
+                    onTranslationSaved={(val) => console.log('saved', val)}
                     onTranslationError={() => console.error('error')}
                     onRequestClose={this.toggleDialog()}
                 />

--- a/packages/translation-dialog/package.json
+++ b/packages/translation-dialog/package.json
@@ -10,8 +10,8 @@
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "d2": "^29.1.1",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
   },
   "author": "Mark Polak",
   "contributors": [

--- a/packages/translation-dialog/package.json
+++ b/packages/translation-dialog/package.json
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@dhis2/d2-ui-core": "^1.3.2",
+    "@material-ui/core": "^1.5.1",
     "babel-runtime": "^6.26.0",
     "d2-utilizr": "^0.2.15",
-    "material-ui": "^0.19.3",
     "prop-types": "^15.5.10",
     "recompose": "^0.26.0",
     "rxjs": "^5.5.7"

--- a/packages/translation-dialog/src/LocaleSelector.component.js
+++ b/packages/translation-dialog/src/LocaleSelector.component.js
@@ -1,7 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import SelectField from 'material-ui/SelectField/SelectField';
-import MenuItem from 'material-ui/MenuItem/MenuItem';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormControl from '@material-ui/core/FormControl';
+import InputLabel from '@material-ui/core/InputLabel';
+
 
 class LocaleSelector extends Component {
     constructor(props, context) {
@@ -9,10 +12,14 @@ class LocaleSelector extends Component {
 
         const i18n = this.context.d2.i18n;
         this.getTranslation = i18n.getTranslation.bind(i18n);
-        this.state = {};
+        this.state = {
+            locale: '',
+        };
     }
 
-    onLocaleChange = (event, index, locale) => {
+    onLocaleChange = (event) => {
+        const locale = event.target.value;
+
         this.setState({
             locale,
         });
@@ -24,19 +31,24 @@ class LocaleSelector extends Component {
         const localeMenuItems = [{ payload: '', text: '' }]
             .concat(this.props.locales)
             .map((locale, index) => (
-                <MenuItem key={index} primaryText={locale.name} value={locale.locale} />
+                <MenuItem key={`${locale.name}-${ index}`} value={locale.locale}>{locale.name}</MenuItem>
             ));
 
         return (
-            <SelectField
-                fullWidth
-                {...this.props}
-                value={this.state && this.state.locale}
-                hintText={this.getTranslation('select_locale')}
-                onChange={this.onLocaleChange}
-            >
-                {localeMenuItems}
-            </SelectField>
+            <FormControl fullWidth>
+                <InputLabel htmlFor="locale-selector">{this.getTranslation('select_locale')}</InputLabel>
+                <Select
+                    {...this.props}
+                    value={this.state.locale}
+                    onChange={this.onLocaleChange}
+                    inputProps={{
+                        name: 'locale',
+                        id: 'locale-selector',
+                    }}
+                >
+                    {localeMenuItems}
+                </Select>
+            </FormControl>
         );
     }
 }

--- a/packages/translation-dialog/src/LocaleSelector.component.js
+++ b/packages/translation-dialog/src/LocaleSelector.component.js
@@ -5,41 +5,31 @@ import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 
-
 class LocaleSelector extends Component {
     constructor(props, context) {
         super(props, context);
 
         const i18n = this.context.d2.i18n;
         this.getTranslation = i18n.getTranslation.bind(i18n);
-        this.state = {
-            locale: '',
-        };
     }
 
     onLocaleChange = (event) => {
-        const locale = event.target.value;
-
-        this.setState({
-            locale,
-        });
-
-        this.props.onChange(locale, event);
+        this.props.onChange(event.target.value);
     }
 
     render() {
-        const localeMenuItems = [{ payload: '', text: '' }]
+        const localeMenuItems = [{ dummy: '', item: '' }]
             .concat(this.props.locales)
-            .map((locale, index) => (
-                <MenuItem key={`${locale.name}-${ index}`} value={locale.locale}>{locale.name}</MenuItem>
-            ));
+            .map((locale, i) => {
+                const k = `${locale.name}-${i}`;
+                return <MenuItem key={k} value={locale.locale}>{locale.name}</MenuItem>;
+            });
 
         return (
-            <FormControl fullWidth>
+            <FormControl fullWidth style={{ marginBottom: '10px' }}>
                 <InputLabel htmlFor="locale-selector">{this.getTranslation('select_locale')}</InputLabel>
                 <Select
-                    {...this.props}
-                    value={this.state.locale}
+                    value={this.props.currentLocale}
                     onChange={this.onLocaleChange}
                     inputProps={{
                         name: 'locale',
@@ -61,6 +51,7 @@ LocaleSelector.propTypes = {
             locale: PropTypes.string.isRequired,
         })
     ).isRequired,
+    currentLocale: PropTypes.string,
     onChange: PropTypes.func.isRequired,
 };
 

--- a/packages/translation-dialog/src/TranslationDialog.component.js
+++ b/packages/translation-dialog/src/TranslationDialog.component.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+
+
 import { getTranslationFormFor } from './TranslationForm.component';
 
 class TranslationDialog extends Component {
@@ -12,32 +15,10 @@ class TranslationDialog extends Component {
         this.state = {
             TranslationForm: getTranslationFormFor(props.objectToTranslate),
         };
-
-        this.translationSaved = this.translationSaved.bind(this);
-        this.translationError = this.translationError.bind(this);
-        this.closeTranslationDialog = this.closeTranslationDialog.bind(this);
     }
 
     getChildContext() {
         return { d2: this.props.d2 };
-    }
-
-    render() {
-        return (
-            <Dialog
-                title={this.i18n.getTranslation('translation_dialog_title')}
-                autoDetectWindowHeight
-                autoScrollBodyContent
-                {...this.props}
-            >
-                <this.state.TranslationForm
-                    onTranslationSaved={this.translationSaved}
-                    onTranslationError={this.translationError}
-                    onCancel={this.closeTranslationDialog}
-                    fieldsToTranslate={this.props.fieldsToTranslate}
-                />
-            </Dialog>
-        );
     }
 
     componentWillReceiveProps(newProps) {
@@ -48,17 +29,31 @@ class TranslationDialog extends Component {
         }
     }
 
-    closeTranslationDialog() {
+    closeTranslationDialog = () => {
         this.props.onRequestClose();
     }
 
-    translationSaved(args) {
+    translationSaved = (args) => {
         this.props.onTranslationSaved(args);
         this.closeTranslationDialog();
     }
 
-    translationError(err) {
+    translationError = (err) => {
         this.props.onTranslationError(err);
+    }
+
+    render() {
+        return (
+            <Dialog {...this.props}>
+                <DialogTitle id="form-dialog-title">{this.i18n.getTranslation('translation_dialog_title')}</DialogTitle>
+                <this.state.TranslationForm
+                    onTranslationSaved={this.translationSaved}
+                    onTranslationError={this.translationError}
+                    onCancel={this.closeTranslationDialog}
+                    fieldsToTranslate={this.props.fieldsToTranslate}
+                />
+            </Dialog>
+        );
     }
 }
 

--- a/packages/translation-dialog/src/TranslationDialog.component.js
+++ b/packages/translation-dialog/src/TranslationDialog.component.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Dialog from 'material-ui/Dialog/Dialog';
+import Dialog from '@material-ui/core/Dialog';
 import { getTranslationFormFor } from './TranslationForm.component';
 
 class TranslationDialog extends Component {

--- a/packages/translation-dialog/src/TranslationDialog.component.js
+++ b/packages/translation-dialog/src/TranslationDialog.component.js
@@ -42,9 +42,26 @@ class TranslationDialog extends Component {
         this.props.onTranslationError(err);
     }
 
+    muiDialogProps = () => {
+        const pick = ({
+            open,
+            onClose,
+            onEnter,
+            onExit,
+            onExited }) => ({
+            open,
+            onClose,
+            onEnter,
+            onExit,
+            onExited,
+        });
+
+        return pick(this.props);
+    }
+
     render() {
         return (
-            <Dialog PaperProps={{ style: { width: '75%', maxWidth: '768px' } }} {...this.props}>
+            <Dialog PaperProps={{ style: { width: '75%', maxWidth: '768px' } }} {...this.muiDialogProps()}>
                 <DialogTitle id="form-dialog-title">{this.i18n.getTranslation('translation_dialog_title')}</DialogTitle>
                 <this.state.TranslationForm
                     onTranslationSaved={this.translationSaved}
@@ -63,7 +80,7 @@ TranslationDialog.propTypes = {
     }).isRequired,
     onTranslationSaved: PropTypes.func.isRequired,
     onTranslationError: PropTypes.func.isRequired,
-    open: PropTypes.bool,
+    open: PropTypes.bool.isRequired,
     onRequestClose: PropTypes.func.isRequired,
     fieldsToTranslate: PropTypes.array,
     d2: PropTypes.object.isRequired,
@@ -72,5 +89,6 @@ TranslationDialog.propTypes = {
 TranslationDialog.childContextTypes = {
     d2: PropTypes.object,
 };
+
 
 export default TranslationDialog;

--- a/packages/translation-dialog/src/TranslationDialog.component.js
+++ b/packages/translation-dialog/src/TranslationDialog.component.js
@@ -44,7 +44,7 @@ class TranslationDialog extends Component {
 
     render() {
         return (
-            <Dialog {...this.props}>
+            <Dialog PaperProps={{ style: { width: '75%', maxWidth: '768px' } }} {...this.props}>
                 <DialogTitle id="form-dialog-title">{this.i18n.getTranslation('translation_dialog_title')}</DialogTitle>
                 <this.state.TranslationForm
                     onTranslationSaved={this.translationSaved}

--- a/packages/translation-dialog/src/TranslationForm.component.js
+++ b/packages/translation-dialog/src/TranslationForm.component.js
@@ -81,17 +81,9 @@ class TranslationForm extends Component {
                         onChange={this.setValue.bind(this, fieldName)}
                         margin="normal"
                     />
-                    <div>{this.props.objectToTranslate[fieldName]}</div>
+                    <div style={{ ƒfontSize: '16px', color: 'rgba(0,0,0,0.6)' }}>{this.props.objectToTranslate[fieldName]}</div>
                 </div>
             ));
-    }
-
-    renderForm() {
-        return (
-            <DialogContent>
-                {this.renderFieldsToTranslate()}
-            </DialogContent>
-        );
     }
 
     renderActionButtons() {
@@ -99,13 +91,13 @@ class TranslationForm extends Component {
             <DialogActions>
                 <Button
                     variant="contained"
+                    onClick={this.props.onCancel}
+                >{this.getTranslation('cancel')}</Button>
+                <Button
+                    variant="contained"
                     color="primary"
                     onClick={this.saveTranslations}
                 >{this.getTranslation('save')}</Button>
-                <Button
-                    variant="contained"
-                    onClick={this.props.onCancel}
-                >{this.getTranslation('cancel')}</Button>
             </DialogActions>
         )
     }
@@ -128,7 +120,7 @@ class TranslationForm extends Component {
                 <DialogContent>
                     <div style={{ minHeight: 350 }}>
                         <LocaleSelector locales={this.props.locales} onChange={this.setCurrentLocale} />
-                        {this.state.currentSelectedLocale ? this.renderForm() : this.renderHelpText()}
+                        {this.state.currentSelectedLocale ? this.renderFieldsToTranslate() : this.renderHelpText()}
                     </div>
                 </DialogContent>
                 {this.state.currentSelectedLocale && this.renderActionButtons()}

--- a/packages/translation-dialog/src/TranslationForm.component.js
+++ b/packages/translation-dialog/src/TranslationForm.component.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import TextField from 'material-ui/TextField/TextField';
+import TextField from '@material-ui/core/TextField';
+import Button from '@material-ui/core/Button';
 import camelCaseToUnderscores from 'd2-utilizr/lib/camelCaseToUnderscores';
-import RaisedButton from 'material-ui/RaisedButton/RaisedButton';
 import { Observable } from 'rxjs';
 import LocaleSelector from './LocaleSelector.component';
 import { getLocales, getTranslationsForModel, saveTranslations } from './translationForm.actions';
@@ -81,12 +81,14 @@ class TranslationForm extends Component {
             <div>
                 {this.renderFieldsToTranslate()}
                 <div style={{ paddingTop: '1rem' }}>
-                    <RaisedButton
+                    <Button
+                        variant="contained"
                         label={this.getTranslation('save')}
                         primary
                         onClick={this.saveTranslations}
                     />
-                    <RaisedButton
+                    <Button
+                        variant="contained"
                         style={{ marginLeft: '1rem' }}
                         label={this.getTranslation('cancel')}
                         onClick={this.props.onCancel}

--- a/packages/translation-dialog/src/TranslationForm.component.js
+++ b/packages/translation-dialog/src/TranslationForm.component.js
@@ -83,16 +83,14 @@ class TranslationForm extends Component {
                 <div style={{ paddingTop: '1rem' }}>
                     <Button
                         variant="contained"
-                        label={this.getTranslation('save')}
                         primary
                         onClick={this.saveTranslations}
-                    />
+                    >{this.getTranslation('save')}</Button>
                     <Button
                         variant="contained"
                         style={{ marginLeft: '1rem' }}
-                        label={this.getTranslation('cancel')}
                         onClick={this.props.onCancel}
-                    />
+                    >{this.getTranslation('cancel')}</Button>
                 </div>
             </div>
         );

--- a/packages/translation-dialog/src/TranslationForm.component.js
+++ b/packages/translation-dialog/src/TranslationForm.component.js
@@ -68,22 +68,27 @@ class TranslationForm extends Component {
     renderFieldsToTranslate() {
         return this.props.fieldsToTranslate
             .filter(fieldName => fieldName)
-            .map(fieldName => (
-                <div key={fieldName}>
-                    <TextField
-                        placeholder={this.getTranslation(camelCaseToUnderscores(fieldName))}
-                        label={this.getTranslationValueFor(fieldName)}
-                        value={this.getTranslationValueFor(fieldName)}
-                        InputLabelProps={{
-                            shrink: true,
-                        }}
-                        fullWidth
-                        onChange={this.setValue.bind(this, fieldName)}
-                        margin="normal"
-                    />
-                    <div style={{ ƒfontSize: '16px', color: 'rgba(0,0,0,0.6)' }}>{this.props.objectToTranslate[fieldName]}</div>
-                </div>
-            ));
+            .map((fieldName) => {
+                const labelPlaceholder = this.getTranslation(camelCaseToUnderscores(fieldName));
+                const val = this.getTranslationValueFor(fieldName) || '';
+
+                return (
+                    <div key={fieldName}>
+                        <TextField
+                            placeholder={labelPlaceholder}
+                            label={labelPlaceholder}
+                            value={val}
+                            InputLabelProps={{
+                                shrink: true,
+                            }}
+                            fullWidth
+                            onChange={this.setValue.bind(this, fieldName)}
+                            margin="normal"
+                        />
+                        <div style={{ color: 'rgba(0,0,0,0.6)' }}>{this.props.objectToTranslate[fieldName]}</div>
+                    </div>
+                );
+            });
     }
 
     renderActionButtons() {
@@ -99,7 +104,7 @@ class TranslationForm extends Component {
                     onClick={this.saveTranslations}
                 >{this.getTranslation('save')}</Button>
             </DialogActions>
-        )
+        );
     }
 
     renderHelpText() {
@@ -119,7 +124,11 @@ class TranslationForm extends Component {
             <Fragment>
                 <DialogContent>
                     <div style={{ minHeight: 350 }}>
-                        <LocaleSelector locales={this.props.locales} onChange={this.setCurrentLocale} />
+                        <LocaleSelector
+                            currentLocale={this.state.currentSelectedLocale}
+                            locales={this.props.locales}
+                            onChange={this.setCurrentLocale}
+                        />
                         {this.state.currentSelectedLocale ? this.renderFieldsToTranslate() : this.renderHelpText()}
                     </div>
                 </DialogContent>
@@ -175,14 +184,18 @@ class TranslationForm extends Component {
 TranslationForm.propTypes = {
     onTranslationSaved: PropTypes.func.isRequired,
     onTranslationError: PropTypes.func.isRequired,
+    onCancel: PropTypes.func,
     objectToTranslate: PropTypes.shape({
         id: PropTypes.string.isRequired,
     }),
+    locales: PropTypes.array,
+    translations: PropTypes.array,
     fieldsToTranslate: PropTypes.arrayOf(PropTypes.string),
 };
 
 TranslationForm.defaultProps = {
     fieldsToTranslate: ['name', 'shortName', 'description'],
+    locales: [],
 };
 
 TranslationForm.contextTypes = {

--- a/packages/translation-dialog/src/__tests__/LocaleSelector.component.spec.js
+++ b/packages/translation-dialog/src/__tests__/LocaleSelector.component.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import MuiSelectField from 'material-ui/SelectField/SelectField';
-import MenuItem from 'material-ui/MenuItem';
+import MuiSelectField from '@material-ui/core/SelectField';
+import MenuItem from '@material-ui/core/MenuItem';
 
 import LocaleSelector from '../LocaleSelector.component';
 import { getStubContext } from '../../../../config/inject-theme';

--- a/packages/translation-dialog/src/__tests__/LocaleSelector.component.spec.js
+++ b/packages/translation-dialog/src/__tests__/LocaleSelector.component.spec.js
@@ -1,47 +1,49 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import MuiSelectField from '@material-ui/core/SelectField';
+import { createShallow } from '@material-ui/core/test-utils';
+import MuiFormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
+import renderer from 'react-test-renderer';
 
 import LocaleSelector from '../LocaleSelector.component';
 import { getStubContext } from '../../../../config/inject-theme';
 
 describe('LocaleSelector component', () => {
+    let shallow;
     let Component;
     let onChangeLocaleSpy;
+    let SelectComponent;
     const locales = [{ locale: 'elf', name: 'Elfish' }, { locale: 'noren', name: 'Norglish' }];
+
+    beforeAll(() => {
+        shallow = createShallow();
+    });
 
     beforeEach(() => {
         onChangeLocaleSpy = jest.fn();
         Component = shallow(<LocaleSelector locales={locales} onChange={onChangeLocaleSpy} />, {
             context: getStubContext(),
         });
+        SelectComponent = Component.find(Select).first();
     });
 
-    it('should render a MuiSelectField component', () => {
-        expect(Component.type()).toBe(MuiSelectField);
+    it('should render a MuiFormControl component', () => {
+        expect(Component.type()).toBe(MuiFormControl);
     });
 
     it('should render items array as menu items', () => {
-        expect(Component.contains(<MenuItem value="elf" primaryText="Elfish" />)).toBe(true);
+        const firstItem = SelectComponent.find(MenuItem).children().first();
+        expect(firstItem.text()).toBe('Elfish');
     });
 
     it('should render list of items with length 1 greater than the passed in list', () => {
-        expect(Component.children()).toHaveLength(locales.length + 1);
+        expect(SelectComponent.children()).toHaveLength(locales.length + 1);
     });
 
     it('should call onChange function when field content is changed', () => {
-        Component.simulate('change', {}, 2, 'noren');
+        SelectComponent.simulate('change', { target: { value: 'noren' } });
 
         expect(onChangeLocaleSpy).toHaveBeenCalled();
         expect(onChangeLocaleSpy.mock.calls[0][0]).toBe('noren');
-    });
-
-    it('should change the local state when field content is changed', () => {
-        expect(Component.state()).toEqual({});
-
-        Component.simulate('change', {}, 2, 'noren');
-
-        expect(Component.state().locale).toEqual('noren');
     });
 });


### PR DESCRIPTION
Fixes DHIS2-4639

Breaking change:
- upgrade to material-ui 1.5.1
- limit properties that are spread to the mui Dialog component
- fixed console warnings
- fixed error where switching languages caused controls to not get data correctly set (related to the React warnings)
- updated tests
