### PR TITLE
Adjust styling for new logo

### DIFF
--- a/packages/header-bar/src/InnerHeader.js
+++ b/packages/header-bar/src/InnerHeader.js
@@ -113,8 +113,10 @@ class InnerHeader extends Component {
 
     render() {
         const headerBannerWrapperStyle = {
-            width: 155,
-            height: 44,
+            minWidth: 48,
+            height: 48,
+            marginRight: 8,
+            borderRight: '1px solid rgba(0,0,0,0.1)',
             verticalAlign: 'middle',
             textAlign: 'center',
             flexDirection: 'row',
@@ -125,7 +127,7 @@ class InnerHeader extends Component {
 
         const headerBannerStyle = {
             maxWidth: 175,
-            maxHeight: 44,
+            maxHeight: 25,
         };
 
         const linkWrapStyle = {
@@ -153,7 +155,7 @@ class InnerHeader extends Component {
         };
 
         const logoHref = {
-            minWidth: 175,
+            minWidth: 48,
         };
 
         const linkHref = [this.getBaseUrl(), 'dhis-web-commons-about/redirect.action'].join('/');


### PR DESCRIPTION
Fixes DHIS2-4516.

Changes proposed in this pull request:
- Adjust style to go with the much smaller new logo
- header-banner-wrapper now occupies the full height because it has a side border

NOTE 1:
This PR will only make sense once the PR on dhis2-core is merged that actually replaces the icons: https://github.com/dhis2/dhis2-core/pull/2282

NOTE 2:
I could do with some advice on how to release this..... It should show for all apps really.... But will now be tied to an API version... Not sure if this is the way to go... Maybe we need to force the v2.31 version of the HeaderBar to reach out to the endpoint v31 version of the endpoint.
