### PR TITLE
Add optional node to render in header for contextmenu

### DIFF
--- a/src/data-table/DataTable.component.js
+++ b/src/data-table/DataTable.component.js
@@ -101,7 +101,9 @@ class DataTable extends Component {
                 <div className="data-table__headers">
                     {this.renderHeaders()}
                     { (this.hasContextMenu() || this.hasSingleAction()) &&
-                        <DataTableHeader />
+                        <DataTableHeader>
+                            {this.props.contextMenuHeader}
+                        </DataTableHeader>
                     }
                 </div>
                 <div className="data-table__rows">
@@ -120,6 +122,7 @@ DataTable.propTypes = {
     contextMenuIcons: PropTypes.object,
     primaryAction: PropTypes.func,
     isContextActionAllowed: PropTypes.func,
+    contextMenuHeader: PropTypes.node,
 };
 
 export default DataTable;

--- a/src/data-table/DataTableHeader.component.js
+++ b/src/data-table/DataTableHeader.component.js
@@ -23,6 +23,7 @@ class DataTableHeader extends Component {
         return (
             <div className={classList}>
                 {this.props.name ? this.getTranslation(camelCaseToUnderscores(this.props.name)) : null}
+                {this.props.children}
             </div>
         );
     }


### PR DESCRIPTION
Related to adding an icon in Maintenance app, so that you can have an optional element in above the context-menu column. This will be a "settings icon" in maintenance.
