### PR TITLE
Enable support for initially selected periods in period-selector-component

### DIFF
--- a/examples/create-react-app/src/components/period-selector-dialog.js
+++ b/examples/create-react-app/src/components/period-selector-dialog.js
@@ -8,6 +8,12 @@ import PeriodSelectorDialog from '@dhis2/d2-ui-period-selector-dialog';
 
 class PeriodSelectorDialogExample extends Component {
     state = {
+        // example of initially selected periods
+        periods: [
+            { id: 'TODAY', name: 'Today' },
+            { id: 'YESTERDAY', name: 'Yesterday' },
+            { id: 'LAST_3_DAYS', name: 'Last 3 days' },
+        ],
         dialogOpened: false,
         snackbar: {
             open: false,
@@ -17,6 +23,7 @@ class PeriodSelectorDialogExample extends Component {
 
     onPeriodSelect = (periods) => {
         this.setState({
+            periods,
             dialogOpened: !this.state.dialogOpened,
             snackbar: {
                 open: true,
@@ -53,6 +60,7 @@ class PeriodSelectorDialogExample extends Component {
                     open={this.state.dialogOpened}
                     onClose={this.toggleDialog}
                     onUpdate={this.onPeriodSelect}
+                    periods={this.state.periods}
                     d2={this.props.d2}
                 />
                 <Snackbar

--- a/packages/period-selector-dialog/src/PeriodSelector.js
+++ b/packages/period-selector-dialog/src/PeriodSelector.js
@@ -22,7 +22,12 @@ class PeriodSelector extends Component {
 
 PeriodSelector.propTypes = {
     d2: PropTypes.object.isRequired,
+    periods: PropTypes.array,
     onPeriodsSelect: PropTypes.func.isRequired,
+};
+
+PeriodSelector.defaultProps = {
+    periods: [],
 };
 
 PeriodSelector.childContextTypes = {

--- a/packages/period-selector-dialog/src/PeriodSelectorDialog.js
+++ b/packages/period-selector-dialog/src/PeriodSelectorDialog.js
@@ -43,6 +43,7 @@ class PeriodSelectorDialog extends React.Component {
                 <DialogContent>
                     <PeriodSelector
                         d2={this.props.d2}
+                        periods={this.props.periods}
                         onPeriodsSelect={this.onPeriodsSelect}
                     />
                 </DialogContent>
@@ -63,9 +64,11 @@ PeriodSelectorDialog.defaultProps = {
     maxWidth: 'md',
     fullWidth: true,
     onClose: () => null,
+    periods: [],
 };
 
 PeriodSelectorDialog.propTypes = {
+    periods: PropTypes.array,
     d2: PropTypes.object.isRequired,
     fullWidth: PropTypes.bool,
     maxWidth: PropTypes.string,

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -27,6 +27,10 @@ class Periods extends Component {
         super(props);
 
         this.i18n = context.d2.i18n;
+
+        if (this.props.periods.length > 0) {
+            this.props.setSelectedPeriods(this.props.periods);
+        }
     }
 
     componentWillUpdate(nextProps) {
@@ -120,6 +124,7 @@ class Periods extends Component {
 }
 
 Periods.propTypes = {
+    periods: PropTypes.array.isRequired,
     periodType: PropTypes.string.isRequired,
     offeredPeriods: PropTypes.object.isRequired,
     selectedPeriods: PropTypes.object.isRequired,


### PR DESCRIPTION
As title says enable support for initially selected periods.
Typical use case: periods selected in favorite/Analytic object.