### PR TITLE
Add forceReload parameter to children.load call so they are actually re-fetched

### DIFF
--- a/packages/org-unit-tree/src/OrgUnitTree.component.js
+++ b/packages/org-unit-tree/src/OrgUnitTree.component.js
@@ -102,7 +102,9 @@ class OrgUnitTree extends React.Component {
             this.setState({ loading: true });
 
             const root = this.props.root;
-            root.children.load({ fields: 'id,displayName,children::isNotEmpty,path,parent' }).then((children) => {
+            // d2.ModelCollectionProperty.load takes a second parameter `forceReload` and will just return
+            // the current valueMap unless either `this.hasUnloadedData` or `forceReload` are true
+            root.children.load({ fields: 'id,displayName,children::isNotEmpty,path,parent' }, true).then((children) => {
                 this.setChildState(children);
             });
         }

--- a/packages/org-unit-tree/src/OrgUnitTree.component.js
+++ b/packages/org-unit-tree/src/OrgUnitTree.component.js
@@ -104,7 +104,10 @@ class OrgUnitTree extends React.Component {
             const root = this.props.root;
             // d2.ModelCollectionProperty.load takes a second parameter `forceReload` and will just return
             // the current valueMap unless either `this.hasUnloadedData` or `forceReload` are true
-            root.children.load({ fields: 'id,displayName,children::isNotEmpty,path,parent' }, true).then((children) => {
+            root.children.load(
+                { fields: 'id,displayName,children::isNotEmpty,path,parent' },
+                this.props.foreceReloadChildren,
+            ).then((children) => {
                 this.setChildState(children);
             });
         }
@@ -143,6 +146,7 @@ class OrgUnitTree extends React.Component {
                     onChildrenLoaded={this.props.onChildrenLoaded}
                     hideMemberCount={this.props.hideMemberCount}
                     orgUnitsPathsToInclude={this.props.orgUnitsPathsToInclude}
+                    foreceReloadChildren={this.props.foreceReloadChildren}
                 />
             );
         }
@@ -355,6 +359,12 @@ OrgUnitTree.propTypes = {
      * Array of paths of Organisation Units to include on tree. If not defined or empty, all children from root to leafs will be shown
      */
     orgUnitsPathsToInclude: PropTypes.array,
+
+    /**
+     * If true `root.children.load` (a method on d2.ModelCollectionProperty) will be called with forceReload set to true, which is required
+     * for dynamic OrgUnitTrees, i.e. in cases where parent-child relations are updated
+     */
+    foreceReloadChildren: PropTypes.bool,
 };
 
 OrgUnitTree.defaultProps = {
@@ -371,6 +381,7 @@ OrgUnitTree.defaultProps = {
     hideCheckboxes: false,
     hideMemberCount: false,
     orgUnitsPathsToInclude: null,
+    foreceReloadChildren: false,
 };
 
 export default OrgUnitTree;


### PR DESCRIPTION
**UPDATE**: Please ignore this for now. It seems this fix just masks an underlying problem.

Fixes DHIS2-966

This doesn't fully fix DHIS2-966 but will do so partly. At least the UI is updated after an OrgUnit is moved

Changes proposed in this pull request:
- Add a second `forceReload` parameter with value `true` to the call to `root.children.load`.
- By adding this parameter d2 will actually fetch new data, instead of just returning the existing collection. See the [relevant code in d2 here](https://github.com/dhis2/d2/blob/master/src/model/ModelCollectionProperty.js#L165-L167).

