### PR TITLE
Fix console errors in examples/create-react-app and OrgUnitTree

### DIFF
--- a/examples/create-react-app/src/components/list-select.js
+++ b/examples/create-react-app/src/components/list-select.js
@@ -22,14 +22,14 @@ export default function Buttons() {
                 <h3>List Select</h3>
                 <ListSelect
                     source={[
-                        {label: 'foo', value: 'bar'},
-                        {label: 'foo', value: 'bar'},
-                        {label: 'foo', value: 'bar'},
-                        {label: 'foo', value: 'bar'},
-                        {label: 'foo', value: 'bar'},
-                        {label: 'foo', value: 'bar'},
-                        {label: 'foo', value: 'bar'},
-                        {label: 'foo', value: 'bar'},
+                        {label: 'foo', value: 'bar0'},
+                        {label: 'foo', value: 'bar1'},
+                        {label: 'foo', value: 'bar2'},
+                        {label: 'foo', value: 'bar3'},
+                        {label: 'foo', value: 'bar4'},
+                        {label: 'foo', value: 'bar5'},
+                        {label: 'foo', value: 'bar6'},
+                        {label: 'foo', value: 'bar7'},
                     ]}
                     onItemDoubleClick={() => {}}
                 />
@@ -46,14 +46,14 @@ export default function Buttons() {
                 <h3>List Select With Local Search</h3>
                 <ListSelectWithLocalSearch
                     source={[
-                        {label: 'foo', value: 'bar'},
-                        {label: 'fuz', value: 'bar'},
-                        {label: 'faz', value: 'bar'},
-                        {label: 'foo', value: 'bar'},
-                        {label: 'foo', value: 'bar'},
-                        {label: 'foo', value: 'bar'},
-                        {label: 'foo', value: 'bar'},
-                        {label: 'foo', value: 'bar'},
+                        {label: 'foo', value: 'bar0'},
+                        {label: 'fuz', value: 'bar1'},
+                        {label: 'faz', value: 'bar2'},
+                        {label: 'foo', value: 'bar3'},
+                        {label: 'foo', value: 'bar4'},
+                        {label: 'foo', value: 'bar5'},
+                        {label: 'foo', value: 'bar6'},
+                        {label: 'foo', value: 'bar7'},
                     ]}
                     onItemDoubleClick={() => {}}
                 />

--- a/examples/create-react-app/src/components/period-selector.js
+++ b/examples/create-react-app/src/components/period-selector.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import Snackbar from 'material-ui/Snackbar';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
@@ -39,16 +39,18 @@ class PeriodSelectorExample extends Component {
     render() {
         return (
             <MuiThemeProvider muiTheme={getMuiTheme()}>
-                <PeriodSelector
-                    onPeriodsSelect={this.onPeriodsSelect}
-                    d2={this.props.d2}
-                />
-                <Snackbar
-                    open={this.state.snackbar.open}
-                    message={this.state.snackbar.message}
-                    autoHideDuration={4000}
-                    onClose={this.onSnackbarClose}
-                />
+                <Fragment>
+                    <PeriodSelector
+                        onPeriodsSelect={this.onPeriodsSelect}
+                        d2={this.props.d2}
+                    />
+                    <Snackbar
+                        open={this.state.snackbar.open}
+                        message={this.state.snackbar.message}
+                        autoHideDuration={4000}
+                        onClose={this.onSnackbarClose}
+                    />
+                </Fragment>
             </MuiThemeProvider>
         );
     }

--- a/packages/org-unit-tree/src/OrgUnitTree.component.js
+++ b/packages/org-unit-tree/src/OrgUnitTree.component.js
@@ -209,7 +209,7 @@ class OrgUnitTree extends React.Component {
         const label = (
             <div
                 style={labelStyle}
-                onClick={(canBecomeCurrentRoot && setCurrentRoot) || (isSelectable && this.handleSelectClick)}
+                onClick={canBecomeCurrentRoot ? setCurrentRoot : (isSelectable ? this.handleSelectClick : undefined)}
                 role="button"
                 tabIndex={0}
             >
@@ -247,7 +247,7 @@ class OrgUnitTree extends React.Component {
 
         return (
             <div
-                onClick={isSelectable && this.handleSelectClick}
+                onClick={isSelectable ? this.handleSelectClick : undefined}
                 className="orgunit without-children"
                 style={ouContainerStyle}
                 role="button"


### PR DESCRIPTION
There were dozens of console errors along the lines of "duplicate key" and "onClick={false}" (screenshot below), so I quickly fixed them.  This reduces create-react-app example app console chattiness significantly.  The OrgUnitTree.js fix also applies outside the example app.

![screen shot 2018-10-04 at 10 47 40 am](https://user-images.githubusercontent.com/947888/46472984-23611700-c7df-11e8-93a5-e880c3146255.png)
