### PR TITLE
remove PeriodSelectorDialog's  onPeriodsSelect prop, replaced by onSelect / onDeselect

### DIFF
--- a/examples/create-react-app/src/components/period-selector-dialog.js
+++ b/examples/create-react-app/src/components/period-selector-dialog.js
@@ -21,7 +21,6 @@ class PeriodSelectorDialogExample extends Component {
         },
     };
 
-
     onSnackbarClose = () => {
         this.setState({
             snackbar: {
@@ -34,7 +33,7 @@ class PeriodSelectorDialogExample extends Component {
     onUpdate = (periods) => {
         this.setState({
             periods,
-            dialogOpened: !this.state.dialogOpened,
+            dialogOpened: false,
             snackbar: {
                 open: true,
                 message: `Selected periods: ${periods.map(period => period.id).join(', ')}`,
@@ -42,8 +41,14 @@ class PeriodSelectorDialogExample extends Component {
         });
     };
 
-    onClose = (periods) => {
-        this.onUpdate(periods);
+    onClose = () => {
+        this.setState({
+            dialogOpened: false,
+            snackbar: {
+                open: true,
+                message: `Selected periods: ${this.state.periods.map(period => period.id).join(', ')}`,
+            },
+        });
     };
 
     toggleDialog = () => {

--- a/examples/create-react-app/src/components/period-selector-dialog.js
+++ b/examples/create-react-app/src/components/period-selector-dialog.js
@@ -9,7 +9,7 @@ import PeriodSelectorDialog from '@dhis2/d2-ui-period-selector-dialog';
 class PeriodSelectorDialogExample extends Component {
     state = {
         // example of initially selected periods
-        periods: [
+        selectedPeriods: [
             { id: 'TODAY', name: 'Today' },
             { id: 'YESTERDAY', name: 'Yesterday' },
             { id: 'LAST_3_DAYS', name: 'Last 3 days' },
@@ -30,13 +30,13 @@ class PeriodSelectorDialogExample extends Component {
         });
     };
 
-    onUpdate = (periods) => {
+    onUpdate = (selectedPeriods) => {
         this.setState({
-            periods,
+            selectedPeriods,
             dialogOpened: false,
             snackbar: {
                 open: true,
-                message: `Selected periods: ${periods.map(period => period.id).join(', ')}`,
+                message: `Selected periods: ${selectedPeriods.map(period => period.id).join(', ')}`,
             },
         });
     };
@@ -46,7 +46,7 @@ class PeriodSelectorDialogExample extends Component {
             dialogOpened: false,
             snackbar: {
                 open: true,
-                message: `Selected periods: ${this.state.periods.map(period => period.id).join(', ')}`,
+                message: `Selected periods: ${this.state.selectedPeriods.map(period => period.id).join(', ')}`,
             },
         });
     };
@@ -71,7 +71,7 @@ class PeriodSelectorDialogExample extends Component {
                     open={this.state.dialogOpened}
                     onClose={this.onClose}
                     onUpdate={this.onUpdate}
-                    periods={this.state.periods}
+                    selectedItems={this.state.selectedPeriods}
                 />
                 <Snackbar
                     open={this.state.snackbar.open}

--- a/examples/create-react-app/src/components/period-selector-dialog.js
+++ b/examples/create-react-app/src/components/period-selector-dialog.js
@@ -36,7 +36,7 @@ class PeriodSelectorDialogExample extends Component {
             dialogOpened: false,
             snackbar: {
                 open: true,
-                message: `Selected periods: ${selectedPeriods.map(period => period.id).join(', ')}`,
+                message: `Selected periods: ${selectedPeriods.map(period => period.name).join(', ')}`,
             },
         });
     };
@@ -46,7 +46,7 @@ class PeriodSelectorDialogExample extends Component {
             dialogOpened: false,
             snackbar: {
                 open: true,
-                message: `Selected periods: ${this.state.selectedPeriods.map(period => period.id).join(', ')}`,
+                message: `Selected periods: ${this.state.selectedPeriods.map(period => period.name).join(', ')}`,
             },
         });
     };

--- a/examples/create-react-app/src/components/period-selector.js
+++ b/examples/create-react-app/src/components/period-selector.js
@@ -10,7 +10,7 @@ class PeriodSelectorExample extends Component {
         super(props);
 
         this.state = {
-            periods: [],
+            selectedPeriods: [],
             snackbar: {
                 open: false,
                 message: '',
@@ -27,16 +27,16 @@ class PeriodSelectorExample extends Component {
         });
     };
 
-    selectPeriods = (periods) => {
-        this.setState({ periods });
+    selectPeriods = (selectedPeriods) => {
+        this.setState({ selectedPeriods });
     };
 
-    deselectPeriods = (periods) => {
-        const filteredItems = this.state.periods.filter(periodRange =>
-            !periods.includes(periodRange) && periodRange,
+    deselectPeriods = (removedPeriods) => {
+        const selectedPeriods = this.state.selectedPeriods.filter(period =>
+            !removedPeriods.includes(period) && period,
         );
 
-        this.setState({ periods: filteredItems });
+        this.setState({ selectedPeriods });
     };
 
     render() {
@@ -47,7 +47,7 @@ class PeriodSelectorExample extends Component {
                         d2={this.props.d2}
                         onSelect={this.selectPeriods}
                         onDeselect={this.deselectPeriods}
-                        periods={this.state.periods}
+                        selectedItems={this.state.selectedPeriods}
                     />
                     <Snackbar
                         open={this.state.snackbar.open}

--- a/examples/create-react-app/src/components/period-selector.js
+++ b/examples/create-react-app/src/components/period-selector.js
@@ -27,22 +27,16 @@ class PeriodSelectorExample extends Component {
         });
     };
 
-    onPeriodsSelect = (periods) => {
-        this.setState({
-            ...this.state,
-            snackbar: {
-                open: true,
-                message: `Selected periods: ${periods.map(period => period.name).join(', ')}`,
-            },
-        });
-    };
-
     selectPeriods = (periods) => {
-        console.log('selected period:', periods);
+        this.setState({ periods });
     };
 
     deselectPeriods = (periods) => {
-        console.log('de-selected period: ', periods);
+        const filteredItems = this.state.periods.filter(periodRange =>
+            !periods.includes(periodRange) && periodRange,
+        );
+
+        this.setState({ periods: filteredItems });
     };
 
     render() {
@@ -51,7 +45,6 @@ class PeriodSelectorExample extends Component {
                 <Fragment>
                     <PeriodSelector
                         d2={this.props.d2}
-                        onPeriodsSelect={this.onPeriodsSelect}
                         onSelect={this.selectPeriods}
                         onDeselect={this.deselectPeriods}
                         periods={this.state.periods}

--- a/packages/period-selector-dialog/css/PeriodSelector.css
+++ b/packages/period-selector-dialog/css/PeriodSelector.css
@@ -5,11 +5,12 @@
 
 button.nav-button {
     padding: 5px 13px 3px;
-    border-radius: 0;
+    border: 1px solid #ECEFF1;
+    border-radius: 2px 0 0 2px;
 }
 
 .nav-button.active, .nav-button.active:hover {
-    background: #117ad4;
+    background-color: #00796B;
     color: #fff;
 }
 
@@ -124,7 +125,7 @@ button.nav-button {
 }
 
 .selected-icon {
-    background-color: blue;
+    background-color: #1976D2;
     position: relative;
     top: 40%;
     height: 6px;
@@ -145,7 +146,7 @@ button.nav-button {
 .list-text { margin-top: 4px; }
 
 .selector-area .form-control.period-type { width: 65%; padding-right: 10px; }
-.selector-area .form-control.year { width: 30%; border-bottom: 1px solid #e8e8e8; }
+.selector-area .form-control.year { width: 32%; }
 .selector-area .period-li { padding: 5px 5px 2px; }
 .selector-area .period-li.selected { background: #42a0ff !important; }
 .selected-periods .period-li { background: #BBDEFB !important; }

--- a/packages/period-selector-dialog/css/PeriodSelector.css
+++ b/packages/period-selector-dialog/css/PeriodSelector.css
@@ -57,37 +57,33 @@ button.nav-button {
 }
 
 .periods-list-selected { 
-    height: 366px;
-    padding-left: 10px;
-    padding-right: 10px;
-    margin-top: 5px;
-    margin-bottom: 10px;
-    list-style: none;
     overflow: auto;
+    list-style: none;
+    height: 382px;
+    padding-left: 0px;
+    margin: 0px;
 }
 
 .period-dimension-item {
     display: flex;
-    min-height: 24px;
-    padding: 2px;
+    margin: 5px;
 }
 
-.period-selected-label {
+.period-selected-label {  
     display: flex;
-    width: fit-content;
-    border-radius: 4px;   
-    background: #BBDEFB;
-    padding-right: 5px;
-    padding-left: 5px;
     outline: none;
+    border-radius: 4px;
+    background-color: rgb(187, 222, 251);
+    padding: 2px;
+
 }
 
 .periods-list-offered {
-    height: 395px;
-    padding-left: 10px;
-    padding-right: 10px;
     list-style: none;
     overflow: auto;
+    height: 406px;
+    margin: 0px;
+    padding-left: 0px;
 }
 
 .period-offered-label {
@@ -98,12 +94,20 @@ button.nav-button {
     padding-right: 5px;
 }
 
-.selected-periods .title {
-    margin: 0;
-    padding: 10px;
+.subtitle-container {
+    border-bottom: 1px solid #E0E0E0;
+    height: 42px;
+}
+
+.selected-periods .subtitle {
+    position: relative;
+    color: black;
+    font-family: Roboto;
+    height: 20px;
+    font-size: 15px;
     font-weight: 500;
-    color: #4b4b4b;
-    border-bottom: 1px solid #e8e8e8;
+    top: 12px;
+    left: 8px;
 }
 
 .selector-area {
@@ -118,7 +122,7 @@ button.nav-button {
 .unselected-icon {
     background-color: grey;
     position: relative;
-    top: 40%;
+    top: 35%;
     height: 6px;
     width: 6px;
     margin-right: 5px;
@@ -127,23 +131,32 @@ button.nav-button {
 .selected-icon {
     background-color: #1976D2;
     position: relative;
-    top: 40%;
+    top: 35%;
     height: 6px;
     width: 6px;
     margin-right: 5px;
+    margin-left: 5px;
 }
 
 .remove-item-button {
     border: none;
     background: none;
     padding: 0px;
-    padding-top: 5px;
+    padding-top: 3px;
     padding-left: 1px;
     margin-left: 5px;
+    margin-right: 3px;
     width: 10px;
 }
 
-.list-text { margin-top: 4px; }
+.list-text { 
+    font-family: Roboto;
+    font-size: 14px;
+    margin-top: 2px;
+    margin-bottom: 1px;
+    padding-left: 2px;
+    padding-right: 2px;
+ }
 
 .selector-area .form-control.period-type { width: 65%; padding-right: 10px; }
 .selector-area .form-control.year { width: 32%; }

--- a/packages/period-selector-dialog/src/FixedPeriods.js
+++ b/packages/period-selector-dialog/src/FixedPeriods.js
@@ -7,8 +7,18 @@ import PropTypes from 'prop-types';
 import FixedPeriodsGenerator from './utils/FixedPeriodsGenerator';
 import PeriodsList from './PeriodsList';
 
+
+const styles = {
+    inputLabel: {
+        color: '#616161', // color
+        fontSize: 13,
+        paddingBottom: 15,
+        fontWeight: 300,
+    },
+};
+
 export const defaultState = {
-    periodType: '',
+    periodType: 'Weekly',
     year: (new Date()).getFullYear(),
 };
 
@@ -60,10 +70,14 @@ class FixedPeriods extends Component {
         });
     };
 
+    componentDidMount = () => {
+        this.props.setOfferedPeriods(this.generatePeriods(this.state.periodType, this.state.year));
+    };
+
     renderOptions = () => (
         <div className="options-area">
             <FormControl className="form-control period-type">
-                <InputLabel htmlFor="period-type">
+                <InputLabel className="input-label" htmlFor="period-type">
                     {this.i18n.getTranslation('Period type')}
                 </InputLabel>
                 <Select
@@ -78,7 +92,7 @@ class FixedPeriods extends Component {
                 </Select>
             </FormControl>
             <FormControl className="form-control year">
-                <InputLabel htmlFor="year">
+                <InputLabel className="input-label" htmlFor="year">
                     {this.i18n.getTranslation('Year')}
                 </InputLabel>
                 <Select
@@ -86,7 +100,6 @@ class FixedPeriods extends Component {
                     value={this.state.year}
                     inputProps={{ name: 'year', id: 'year' }}
                     disableUnderline
-                    variant="filled"
                 >
                     {this.years.sort().map(year => <MenuItem value={year} key={year}>{year}</MenuItem>)}
                 </Select>
@@ -94,23 +107,27 @@ class FixedPeriods extends Component {
         </div>
     );
 
-    render = () => (
-        <div className="selector-area">
-            {this.renderOptions()}
-            <PeriodsList
-                periods={this.props.periods}
-                onDoubleClick={this.props.onDoubleClick}
-                onPeriodClick={this.props.onPeriodClick}
-                listClassName={'periods-list-offered'}
-            />
-        </div>
-    )
+    render = () => {
+        const Options = this.renderOptions();
+
+        return (
+            <div className="selector-area">
+                {Options}
+                <PeriodsList
+                    items={this.props.items}
+                    onDoubleClick={this.props.onDoubleClick}
+                    onPeriodClick={this.props.onPeriodClick}
+                    listClassName={'periods-list-offered'}
+                />
+            </div>
+        );
+    };
 }
 
 FixedPeriods.propTypes = {
-    periods: PropTypes.array.isRequired,
-    onPeriodClick: PropTypes.func.isRequired,
+    items: PropTypes.array.isRequired,
     onDoubleClick: PropTypes.func.isRequired,
+    onPeriodClick: PropTypes.func.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
 };
 

--- a/packages/period-selector-dialog/src/FixedPeriods.js
+++ b/packages/period-selector-dialog/src/FixedPeriods.js
@@ -7,16 +7,6 @@ import PropTypes from 'prop-types';
 import FixedPeriodsGenerator from './utils/FixedPeriodsGenerator';
 import PeriodsList from './PeriodsList';
 
-
-const styles = {
-    inputLabel: {
-        color: '#616161', // color
-        fontSize: 13,
-        paddingBottom: 15,
-        fontWeight: 300,
-    },
-};
-
 export const defaultState = {
     periodType: 'Weekly',
     year: (new Date()).getFullYear(),

--- a/packages/period-selector-dialog/src/OfferedPeriods.js
+++ b/packages/period-selector-dialog/src/OfferedPeriods.js
@@ -23,7 +23,7 @@ export const OfferedPeriods = (props) => {
 
 OfferedPeriods.propTypes = {
     periodType: PropTypes.string.isRequired,
-    periods: PropTypes.array.isRequired,
+    items: PropTypes.array.isRequired,
     onDoubleClick: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,

--- a/packages/period-selector-dialog/src/PeriodListItem.js
+++ b/packages/period-selector-dialog/src/PeriodListItem.js
@@ -10,7 +10,7 @@ const SelectedIcon = () => <div className="selected-icon" />;
 const RemoveItemButton = ({ action }) => (
     <button className="remove-item-button" onClick={action} tabIndex={0}>
         <Close style={{
-            fill: 'blue',
+            fill: '#1976D2',
             outline: 'none',
             height: 13,
             width: 10 }}
@@ -19,20 +19,30 @@ const RemoveItemButton = ({ action }) => (
 );
 
 class PeriodListItem extends Component {
+    state = { isHovering: false };
+
+    highlightItem = () => {
+        this.setState({ isHovering: true });
+    };
+
+    removeHighlight = () => {
+        this.setState({ isHovering: false });
+    };
+
+    isOfferedList = () => this.props.listClassName === OFFERED_LIST;
+
     onPeriodClick = (event) => {
         this.props.onPeriodClick(this.props.period, this.props.index, event.shiftKey, event.metaKey);
     };
 
     onDoubleClick = () => {
         this.props.onDoubleClick(this.props.period);
-    }
+    };
 
     onRemovePeriodClick = (event) => {
         event.stopPropagation();
         this.props.onRemovePeriodClick(this.props.period);
     };
-
-    isOfferedList = () => this.props.listClassName === OFFERED_LIST;
 
     renderIcon = () => (
         this.isOfferedList()
@@ -40,12 +50,26 @@ class PeriodListItem extends Component {
             : <SelectedIcon />
     );
 
+    renderRemoveButton = () => (
+        this.isOfferedList()
+            ? null
+            : <RemoveItemButton action={this.onRemovePeriodClick} />
+    );
+
+    renderLabelStyle = () => {
+        if (this.state.isHovering && !this.props.period.selected) {
+            return { backgroundColor: '#92C9F7' };
+        } else if (this.props.period.selected) {
+            return { backgroundColor: '#7EBFF5' };
+        }
+        return {};
+    };
+
     render = () => {
         const className = this.isOfferedList() ? 'period-offered-label' : 'period-selected-label';
+        const labelStyle = this.renderLabelStyle();
         const Icon = this.renderIcon();
-        const RemoveButton = this.isOfferedList()
-            ? null
-            : <RemoveItemButton action={this.onRemovePeriodClick} />;
+        const RemoveButton = this.renderRemoveButton();
 
         return (
             <li
@@ -55,7 +79,9 @@ class PeriodListItem extends Component {
                 <div
                     role="button"
                     tabIndex={0}
-                    style={this.props.period.selected ? { backgroundColor: '#7EBFF5' } : {}}
+                    style={labelStyle}
+                    onMouseEnter={this.highlightItem}
+                    onMouseLeave={this.removeHighlight}
                     onClick={this.onPeriodClick}
                     onDoubleClick={this.onDoubleClick}
                     className={className}
@@ -66,15 +92,15 @@ class PeriodListItem extends Component {
                 </div>
             </li>
         );
-    }
+    };
 }
 
 PeriodListItem.propTypes = {
+    period: PropTypes.object.isRequired,
     index: PropTypes.number.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
     onDoubleClick: PropTypes.func.isRequired,
     onRemovePeriodClick: PropTypes.func.isRequired,
-    period: PropTypes.object.isRequired,
     listClassName: PropTypes.string.isRequired,
 };
 

--- a/packages/period-selector-dialog/src/PeriodSelector.js
+++ b/packages/period-selector-dialog/src/PeriodSelector.js
@@ -20,13 +20,13 @@ PeriodSelector.propTypes = {
     d2: PropTypes.object.isRequired,
     onSelect: PropTypes.func,
     onDeselect: PropTypes.func,
-    periods: PropTypes.array,
+    selectedItems: PropTypes.array,
 };
 
 PeriodSelector.defaultProps = {
-    periods: [],
     onSelect: () => null,
     onDeselect: () => null,
+    selectedItems: [],
 };
 
 PeriodSelector.childContextTypes = {

--- a/packages/period-selector-dialog/src/PeriodSelector.js
+++ b/packages/period-selector-dialog/src/PeriodSelector.js
@@ -18,7 +18,6 @@ class PeriodSelector extends Component {
 
 PeriodSelector.propTypes = {
     d2: PropTypes.object.isRequired,
-    onPeriodsSelect: PropTypes.func.isRequired,
     onSelect: PropTypes.func,
     onDeselect: PropTypes.func,
     periods: PropTypes.array,

--- a/packages/period-selector-dialog/src/PeriodSelectorDialog.js
+++ b/packages/period-selector-dialog/src/PeriodSelectorDialog.js
@@ -19,26 +19,26 @@ class PeriodSelectorDialog extends React.Component {
         this.i18n = this.props.d2.i18n;
     }
 
-    onPeriodsSelect = (periods) => {
-        this.setState({
-            periods,
-        });
+    onCloseClick = () => {
+        this.props.onClose();
     };
 
     onUpdateClick = () => {
         this.props.onUpdate(this.state.periods);
     };
 
-    onCloseClick = () => {
-        this.props.onClose(this.state.periods);
-    };
-
-    onSelect = () => {
+    onSelect = (periods) => {
+        this.setState({ periods });
         this.props.onSelect(this.state.periods);
     };
 
-    onDeselect = () => {
-        this.props.onDeselect(this.state.periods);
+    onDeselect = (periods) => {
+        const filteredItems = this.state.periods.filter(periodRange =>
+            !periods.includes(periodRange) && periodRange,
+        );
+
+        this.setState({ periods: filteredItems });
+        this.props.onDeselect(filteredItems);
     };
 
     render = () => {
@@ -53,10 +53,7 @@ class PeriodSelectorDialog extends React.Component {
             >
                 <DialogTitle>{this.i18n.getTranslation('Period')}</DialogTitle>
                 <DialogContent>
-                    <PeriodSelector
-                        onPeriodsSelect={this.onPeriodsSelect}
-                        {...remaindingProps}
-                    />
+                    <PeriodSelector {...remaindingProps} />
                 </DialogContent>
                 <DialogActions style={{ padding: '24px' }}>
                     <Button onClick={this.onCloseClick}>

--- a/packages/period-selector-dialog/src/PeriodSelectorDialog.js
+++ b/packages/period-selector-dialog/src/PeriodSelectorDialog.js
@@ -7,15 +7,24 @@ import DialogActions from '@material-ui/core/DialogActions';
 import Button from '@material-ui/core/Button';
 import PeriodSelector from './PeriodSelector';
 
-export const defaultState = {
-    periods: [],
+const styles = {
+    dialogContent: {
+        paddingBottom: 0,
+        paddingTop: 0,
+        overflow: 'hidden',
+    },
+    dialogActions: {
+        padding: '24px',
+        marginTop: 0,
+        borderTop: '1px solid #E0E0E0',
+
+    },
 };
 
 class PeriodSelectorDialog extends React.Component {
     constructor(props) {
         super(props);
 
-        this.state = defaultState;
         this.i18n = this.props.d2.i18n;
     }
 
@@ -24,21 +33,19 @@ class PeriodSelectorDialog extends React.Component {
     };
 
     onUpdateClick = () => {
-        this.props.onUpdate(this.state.periods);
+        this.props.onUpdate(this.props.selectedItems);
     };
 
-    onSelect = (periods) => {
-        this.setState({ periods });
-        this.props.onSelect(this.state.periods);
+    onSelect = (selectedPeriods) => {
+        this.props.onSelect(selectedPeriods);
     };
 
-    onDeselect = (periods) => {
-        const filteredItems = this.state.periods.filter(periodRange =>
-            !periods.includes(periodRange) && periodRange,
+    onDeselect = (removedPeriods) => {
+        const selectedPeriods = this.props.selectedItems.filter(period =>
+            !removedPeriods.includes(period) && period,
         );
 
-        this.setState({ periods: filteredItems });
-        this.props.onDeselect(filteredItems);
+        this.props.onDeselect(selectedPeriods);
     };
 
     render = () => {
@@ -52,14 +59,14 @@ class PeriodSelectorDialog extends React.Component {
                 maxWidth={maxWidth}
             >
                 <DialogTitle>{this.i18n.getTranslation('Period')}</DialogTitle>
-                <DialogContent>
+                <DialogContent style={styles.dialogContent}>
                     <PeriodSelector {...remaindingProps} />
                 </DialogContent>
-                <DialogActions style={{ padding: '24px' }}>
+                <DialogActions style={styles.dialogActions}>
                     <Button onClick={this.onCloseClick}>
                         {this.i18n.getTranslation('Hide')}
                     </Button>
-                    <Button onClick={this.onUpdateClick} variant="contained" color="primary">
+                    <Button style={{ backgroundColor: '#004BA0', color: 'white' }} onClick={this.onUpdateClick}>
                         {this.i18n.getTranslation('Update')}
                     </Button>
                 </DialogActions>
@@ -71,10 +78,9 @@ class PeriodSelectorDialog extends React.Component {
 PeriodSelectorDialog.defaultProps = {
     maxWidth: 'md',
     fullWidth: true,
-    onClose: () => null,
     onSelect: () => null,
     onDeselect: () => null,
-    periods: [],
+    selectedItems: [],
 };
 
 PeriodSelectorDialog.propTypes = {
@@ -82,11 +88,11 @@ PeriodSelectorDialog.propTypes = {
     open: PropTypes.bool.isRequired,
     fullWidth: PropTypes.bool,
     maxWidth: PropTypes.string,
-    onClose: PropTypes.func,
+    onClose: PropTypes.func.isRequired,
     onUpdate: PropTypes.func.isRequired,
     onSelect: PropTypes.func,
     onDeselect: PropTypes.func,
-    periods: PropTypes.array,
+    selectedItems: PropTypes.array,
 };
 
 export default PeriodSelectorDialog;

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -45,10 +45,7 @@ class Periods extends Component {
         super(props);
 
         this.i18n = context.d2.i18n;
-
-        if (this.props.periods.length > 0) {
-            this.props.setSelectedPeriods(this.props.periods);
-        }
+        this.props.setSelectedPeriods(this.props.selectedItems);
     }
 
     onPeriodTypeClick = (periodType) => {
@@ -59,43 +56,47 @@ class Periods extends Component {
     };
 
     onSelectPeriods = () => {
-        const selectedOfferedPeriods = this.props
+        const itemsToAdd = this.props
             .offeredPeriods
             .periods
             .filter(period => period.selected === true);
 
-        this.props.onSelect(selectedOfferedPeriods);
-        this.props.addSelectedPeriods(selectedOfferedPeriods);
-        this.props.removeOfferedPeriods(selectedOfferedPeriods);
+        this.props.onSelect(itemsToAdd);
+        this.props.addSelectedPeriods(itemsToAdd);
+        this.props.removeOfferedPeriods(itemsToAdd);
     };
 
     onDeselectPeriods = () => {
-        const periods = this.props
+        const removedPeriods = this.props
             .selectedPeriods
             .periods
             .filter(period => period.selected === true);
 
-        this.props.onDeselect(periods);
-        this.props.removeSelectedPeriods(periods);
-        this.props.addOfferedPeriods(periods);
+        this.props.onDeselect(removedPeriods);
+        this.props.removeSelectedPeriods(removedPeriods);
+        this.props.addOfferedPeriods(removedPeriods);
     };
 
-    onDoubleClick = (period) => {
-        const itemToAdd = [period];
+    onDoubleClick = (selectedPeriod) => {
+        const itemToAdd = [selectedPeriod];
+
         this.props.onSelect(itemToAdd);
         this.props.addSelectedPeriods(itemToAdd);
         this.props.removeOfferedPeriods(itemToAdd);
     }
 
-    onRemovePeriod = (period) => {
-        const itemToRemove = [period];
+    onRemovePeriod = (removedPeriod) => {
+        const itemToRemove = [removedPeriod];
+
         this.props.onDeselect(itemToRemove);
         this.props.removeSelectedPeriods(itemToRemove);
         this.props.addOfferedPeriods(itemToRemove);
     };
 
-    onClearAll = (periods) => {
-        this.props.onDeselect(periods);
+    onClearAll = (removedPeriods) => {
+        this.props.onDeselect(removedPeriods);
+        this.props.addOfferedPeriods(removedPeriods);
+        this.props.setSelectedPeriods([]);
     };
 
     renderPeriodTypeButtons = () => (
@@ -122,47 +123,50 @@ class Periods extends Component {
         </Fragment>
     );
 
-    render = () => (
-        <div>
-            {this.renderPeriodTypeButtons()}
-            <div className="periods-container">
-                <div className="block options">
-                    <OfferedPeriods
-                        periodType={this.props.periodType}
-                        periods={this.props.offeredPeriods.periods}
-                        setOfferedPeriods={this.props.setOfferedPeriods}
-                        onDoubleClick={this.onDoubleClick}
-                        onPeriodClick={this.props.toggleOfferedPeriod}
-                    />
-                </div>
-                <div className="block buttons">
-                    {this.renderSelectButtons()}
-                </div>
-                <div className="block selected-periods">
-                    <SelectedPeriods
-                        periods={this.props.selectedPeriods.periods}
-                        onClearAll={this.onClearAll}
-                        onPeriodClick={this.props.toggleSelectedPeriod}
-                        onRemovePeriodClick={this.onRemovePeriod}
-                        setSelectedPeriods={this.props.setSelectedPeriods}
-                        addOfferedPeriods={this.props.addOfferedPeriods}
-                    />
+    render = () => {
+        const PeriodTypeButtons = this.renderPeriodTypeButtons();
+        const SelectButtons = this.renderSelectButtons();
+
+        return (
+            <div>
+                {PeriodTypeButtons}
+                <div className="periods-container">
+                    <div className="block options">
+                        <OfferedPeriods
+                            periodType={this.props.periodType}
+                            items={this.props.offeredPeriods.periods}
+                            onDoubleClick={this.onDoubleClick}
+                            onPeriodClick={this.props.toggleOfferedPeriod}
+                            setOfferedPeriods={this.props.setOfferedPeriods}
+                        />
+                    </div>
+                    <div className="block buttons">
+                        {SelectButtons}
+                    </div>
+                    <div className="block selected-periods">
+                        <SelectedPeriods
+                            items={this.props.selectedPeriods.periods}
+                            onClearAll={this.onClearAll}
+                            onPeriodClick={this.props.toggleSelectedPeriod}
+                            onRemovePeriodClick={this.onRemovePeriod}
+                        />
+                    </div>
                 </div>
             </div>
-        </div>
-    )
+        );
+    };
 }
 
 Periods.propTypes = {
-    periods: PropTypes.array.isRequired,
+    onSelect: PropTypes.func.isRequired,
+    onDeselect: PropTypes.func.isRequired,
+    selectedItems: PropTypes.array.isRequired,
     periodType: PropTypes.string.isRequired,
     offeredPeriods: PropTypes.object.isRequired,
     selectedPeriods: PropTypes.object.isRequired,
     setPeriodType: PropTypes.func.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
     setSelectedPeriods: PropTypes.func.isRequired,
-    onSelect: PropTypes.func.isRequired,
-    onDeselect: PropTypes.func.isRequired,
     addSelectedPeriods: PropTypes.func.isRequired,
     addOfferedPeriods: PropTypes.func.isRequired,
     removeOfferedPeriods: PropTypes.func.isRequired,

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -51,13 +51,6 @@ class Periods extends Component {
         }
     }
 
-    componentWillUpdate = (nextProps) => {
-        // based on periods array length fire on periods select event
-        if (nextProps.selectedPeriods.periods.length !== this.props.selectedPeriods.periods.length) {
-            this.props.onPeriodsSelect(nextProps.selectedPeriods.periods);
-        }
-    }
-
     onPeriodTypeClick = (periodType) => {
         if (this.props.periodType !== periodType) {
             this.props.setPeriodType(periodType);
@@ -89,7 +82,7 @@ class Periods extends Component {
 
     onDoubleClick = (period) => {
         const itemToAdd = [period];
-        this.props.onSelect(period);
+        this.props.onSelect(itemToAdd);
         this.props.addSelectedPeriods(itemToAdd);
         this.props.removeOfferedPeriods(itemToAdd);
     }
@@ -168,7 +161,6 @@ Periods.propTypes = {
     setPeriodType: PropTypes.func.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
     setSelectedPeriods: PropTypes.func.isRequired,
-    onPeriodsSelect: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired,
     onDeselect: PropTypes.func.isRequired,
     addSelectedPeriods: PropTypes.func.isRequired,

--- a/packages/period-selector-dialog/src/PeriodsList.js
+++ b/packages/period-selector-dialog/src/PeriodsList.js
@@ -3,24 +3,22 @@ import PropTypes from 'prop-types';
 import PeriodListItem from './PeriodListItem';
 
 const PeriodsList = (props) => {
-    const { periods, ...remaindingProps } = props;
-    return (<ul
-        className={remaindingProps.listClassName}
-    >
-        {props.periods.map((period, index) =>
-            (<PeriodListItem
-                period={period}
-                index={index}
-                key={period.id}
-                {...remaindingProps}
-            />),
-        )}
-    </ul>
+    const { items, ...remaindingProps } = props;
+
+    const ListItems = props.items.map((period, index) =>
+        (<PeriodListItem
+            period={period}
+            index={index}
+            key={period.id}
+            {...remaindingProps}
+        />),
     );
+
+    return <ul className={remaindingProps.listClassName}> {ListItems} </ul>;
 };
 
 PeriodsList.propTypes = {
-    periods: PropTypes.array.isRequired,
+    items: PropTypes.array.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
     onDoubleClick: PropTypes.func,
     onRemovePeriodClick: PropTypes.func,

--- a/packages/period-selector-dialog/src/RelativePeriods.js
+++ b/packages/period-selector-dialog/src/RelativePeriods.js
@@ -7,8 +7,17 @@ import MenuItem from '@material-ui/core/MenuItem';
 import RelativePeriodsGenerator from './utils/RelativePeriodsGenerator';
 import PeriodsList from './PeriodsList';
 
+const styles = {
+    inputLabel: {
+        color: '#616161', // color
+        fontSize: 13,
+        paddingBottom: 15,
+        fontWeight: 300,
+    },
+};
+
 export const defaultState = {
-    periodType: '',
+    periodType: 'Weeks',
 };
 
 class RelativePeriods extends Component {
@@ -19,6 +28,10 @@ class RelativePeriods extends Component {
         this.i18n = context.d2.i18n;
         this.periodsGenerator = new RelativePeriodsGenerator();
     }
+
+    componentDidMount = () => {
+        this.props.setOfferedPeriods(this.generatePeriods(this.state.periodType));
+    };
 
     onPeriodTypeChange = (event) => {
         this.setState({
@@ -36,7 +49,7 @@ class RelativePeriods extends Component {
     renderOptions = () => (
         <div className="options-area">
             <FormControl className="form-control period-type">
-                <InputLabel htmlFor="period-type">
+                <InputLabel className="input-label" htmlFor="period-type">
                     {this.i18n.getTranslation('Period type')}
                 </InputLabel>
                 <Select
@@ -54,21 +67,25 @@ class RelativePeriods extends Component {
         </div>
     );
 
-    render = () => (
-        <div className="selector-area">
-            {this.renderOptions()}
-            <PeriodsList
-                periods={this.props.periods}
-                onPeriodClick={this.props.onPeriodClick}
-                onDoubleClick={this.props.onDoubleClick}
-                listClassName={'periods-list-offered'}
-            />
-        </div>
-    )
+    render = () => {
+        const Options = this.renderOptions();
+
+        return (
+            <div className="selector-area">
+                {Options}
+                <PeriodsList
+                    items={this.props.items}
+                    onPeriodClick={this.props.onPeriodClick}
+                    onDoubleClick={this.props.onDoubleClick}
+                    listClassName={'periods-list-offered'}
+                />
+            </div>
+        );
+    };
 }
 
 RelativePeriods.propTypes = {
-    periods: PropTypes.array.isRequired,
+    items: PropTypes.array.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
     onDoubleClick: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,

--- a/packages/period-selector-dialog/src/RelativePeriods.js
+++ b/packages/period-selector-dialog/src/RelativePeriods.js
@@ -7,15 +7,6 @@ import MenuItem from '@material-ui/core/MenuItem';
 import RelativePeriodsGenerator from './utils/RelativePeriodsGenerator';
 import PeriodsList from './PeriodsList';
 
-const styles = {
-    inputLabel: {
-        color: '#616161', // color
-        fontSize: 13,
-        paddingBottom: 15,
-        fontWeight: 300,
-    },
-};
-
 export const defaultState = {
     periodType: 'Weeks',
 };

--- a/packages/period-selector-dialog/src/SelectedPeriods.js
+++ b/packages/period-selector-dialog/src/SelectedPeriods.js
@@ -15,7 +15,9 @@ class SelectedPeriods extends React.Component {
 
     render = () => (
         <div className="selector-area">
-            <h3 className="title"> {this.i18n.getTranslation('Selected periods')} </h3>
+            <div className="subtitle-container">
+                <span className="subtitle"> {this.i18n.getTranslation('Selected periods')} </span>
+            </div>
             <PeriodsList
                 items={this.props.items}
                 onPeriodClick={this.props.onPeriodClick}

--- a/packages/period-selector-dialog/src/SelectedPeriods.js
+++ b/packages/period-selector-dialog/src/SelectedPeriods.js
@@ -6,21 +6,18 @@ import PeriodsList from './PeriodsList';
 class SelectedPeriods extends React.Component {
     constructor(props, context) {
         super(props);
-
         this.i18n = context.d2.i18n;
     }
 
     clearPeriods = () => {
-        this.props.onClearAll(this.props.periods);
-        this.props.addOfferedPeriods(this.props.periods);
-        this.props.setSelectedPeriods([]);
+        this.props.onClearAll(this.props.items);
     };
 
     render = () => (
         <div className="selector-area">
             <h3 className="title"> {this.i18n.getTranslation('Selected periods')} </h3>
             <PeriodsList
-                periods={this.props.periods}
+                items={this.props.items}
                 onPeriodClick={this.props.onPeriodClick}
                 onRemovePeriodClick={this.props.onRemovePeriodClick}
                 listClassName={'periods-list-selected'}
@@ -35,12 +32,10 @@ class SelectedPeriods extends React.Component {
 }
 
 SelectedPeriods.propTypes = {
-    periods: PropTypes.array.isRequired,
+    items: PropTypes.array.isRequired,
     onClearAll: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
     onRemovePeriodClick: PropTypes.func.isRequired,
-    setSelectedPeriods: PropTypes.func.isRequired,
-    addOfferedPeriods: PropTypes.func.isRequired,
 };
 
 SelectedPeriods.contextTypes = {

--- a/packages/period-selector-dialog/src/reducers/periods.js
+++ b/packages/period-selector-dialog/src/reducers/periods.js
@@ -52,6 +52,20 @@ export default (periodType = 'offered') => (state = defaultState, action) => {
     case actionTypes[`TOGGLE_${periodType.toUpperCase()}_PERIOD`]: {
         const { index, isShiftPressed, isCtrlPressed } = action;
 
+        if (action.period.selected) {
+            const periods = state.periods.map(period => (
+                period.id === action.period.id
+                    ? { ...period, selected: false }
+                    : period
+            ));
+
+            return {
+                ...state,
+                lastClickedIndex: null,
+                periods,
+            };
+        }
+
         // If control was not pressed, then only select
         // current period and unselect all others
         if (isCtrlPressed === false && isShiftPressed === false) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6867,6 +6867,7 @@ husky@^1.0.0-rc.4, husky@^1.0.0-rc.8:
 husky@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/husky/-/husky-1.1.2.tgz#574c2bb16958db8a8120b63306efaff110525c23"
+  integrity sha512-9TdkUpBeEOjz0AnFdUN4i3w8kEbOsVs9/WSeJqWLq2OO6bcKQhVW64Zi+pVd/AMRLpN3QTINb6ZXiELczvdmqQ==
   dependencies:
     cosmiconfig "^5.0.6"
     execa "^0.9.0"
@@ -11661,6 +11662,7 @@ prettier@^1.12.1:
 prettier@^1.14.3:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
+  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
 
 pretty-bytes@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
This PR Includes:
- Removing prop onPeriodsSelect

- adding two new prop functions onSelect / onDeselect
onSelect: Passes period ranges to parent component when a period range is selected (fired on doubleclick or selecting items through arrowButton)

onDeselect: Passes period ranges to parent component when a period range is deselected (fired onClick on <RemoveItemButton /> for selected periods, and on deselect through arrowButton).

- Additional styling according to [design document](https://projects.invisionapp.com/d/main#/console/12702965/266159910/preview)  and Data Visualizer's Data Dimension is added.

- 1 Additional if-test on the reducer's toggling function which enables deToggling of already selected items

prop periods have been changed to selectedItems (reflecting Data Dimension component in DV).