### PR TITLE
Task/remove cjs build from all packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,10 +29,6 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },
-  "pre-commit": [
-    "validate",
-    "test"
-  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-core",
   "version": "1.4.0",
   "description": "Core components for DHIS2 in d2-ui",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "author": "",
   "scripts": {
@@ -11,9 +10,8 @@
     "test-ci": "jest --config=../../jest.config.js packages/core",
     "lint": "eslint src/",
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es && npm run build:sass",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
+    "build": "npm run build:es && npm run build:sass",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
     "build:sass": "node-sass ./scss --output ./build/css",
     "watch": "npm run build:sass && npm run build:es --  --watch"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,13 +7,13 @@
   "author": "",
   "scripts": {
     "coverage": "jest --coverage",
-    "test-ci": "jest --config=../../jest.config.js packages/core",
     "lint": "eslint src/",
     "prebuild": "rimraf ./build/*",
     "build": "npm run build:es && npm run build:sass",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
     "build:sass": "node-sass ./scss --output ./build/css",
-    "watch": "npm run build:sass && npm run build:es --  --watch"
+    "watch": "npm run build --  --watch",
+    "test-ci": "jest --config=../../jest.config.js packages/core"
   },
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-core",
   "version": "1.4.0",
   "description": "Core components for DHIS2 in d2-ui",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "author": "",

--- a/packages/expression-manager/package.json
+++ b/packages/expression-manager/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-expression-manager",
   "version": "2.0.0",
   "description": "Expression manager component for DHIS2 apps",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "author": "",

--- a/packages/expression-manager/package.json
+++ b/packages/expression-manager/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-expression-manager",
   "version": "2.0.0",
   "description": "Expression manager component for DHIS2 apps",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "author": "",
   "scripts": {
@@ -11,9 +10,8 @@
     "test-ci": "jest --config=../../jest.config.js packages/expression-manager",
     "lint": "eslint src/",
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
+    "build": "npm run build:es && npm run build:sass",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
     "watch": "npm run build:es --  --watch"
   },
   "repository": {

--- a/packages/expression-manager/package.json
+++ b/packages/expression-manager/package.json
@@ -33,10 +33,6 @@
     "react": "^16.3.0",
     "react-dom": "^16.3.0"
   },
-  "pre-commit": [
-    "validate",
-    "test"
-  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/expression-manager/package.json
+++ b/packages/expression-manager/package.json
@@ -7,12 +7,11 @@
   "author": "",
   "scripts": {
     "coverage": "jest --coverage",
-    "test-ci": "jest --config=../../jest.config.js packages/expression-manager",
     "lint": "eslint src/",
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:es && npm run build:sass",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "watch": "npm run build:es --  --watch"
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "watch": "npm run build --  --watch",
+    "test-ci": "jest --config=../../jest.config.js packages/expression-manager"
   },
   "repository": {
     "type": "git",

--- a/packages/favorites-dialog/package.json
+++ b/packages/favorites-dialog/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-favorites-dialog",
   "version": "4.0.0",
   "description": "Favorite Dialog component for DHIS2",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "author": "Edoardo Sabadelli <edoardo@dhis2.org>",

--- a/packages/favorites-dialog/package.json
+++ b/packages/favorites-dialog/package.json
@@ -15,9 +15,8 @@
   },
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:es && npm run build:sass",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "watch": "npm run build:es --  --watch",
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/favorites-dialog"
   },
   "dependencies": {

--- a/packages/favorites-dialog/package.json
+++ b/packages/favorites-dialog/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-favorites-dialog",
   "version": "4.0.0",
   "description": "Favorite Dialog component for DHIS2",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "author": "Edoardo Sabadelli <edoardo@dhis2.org>",
   "contributors": [
@@ -16,9 +15,8 @@
   },
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
+    "build": "npm run build:es && npm run build:sass",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
     "watch": "npm run build:es --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/favorites-dialog"
   },

--- a/packages/file-menu/package.json
+++ b/packages/file-menu/package.json
@@ -13,8 +13,8 @@
     },
     "scripts": {
         "prebuild": "rimraf ./build/*",
-        "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-        "watch": "npm run localize && npm run build -- --watch",
+        "build": "npm run localize && cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+        "watch": "npm run build -- --watch",
         "test-ci": "jest --config=../../jest.config.js packages/file-menu",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
         "prettify": "prettier \"src/**/*.{js,jsx,json,css}\" --write",

--- a/packages/file-menu/package.json
+++ b/packages/file-menu/package.json
@@ -2,8 +2,7 @@
     "name": "@dhis2/d2-ui-file-menu",
     "version": "4.0.0",
     "description": "File menu component for DHIS2",
-    "main": "./build/cjs/index.js",
-    "module": "./build/es/index.js",
+    "module": "./build/index.js",
     "license": "BSD-3-Clause",
     "author": "Edoardo Sabadelli <edoardo@dhis2.org>",
     "peerDependencies": {
@@ -13,9 +12,8 @@
     },
     "scripts": {
         "prebuild": "rimraf ./build/*",
-        "build": "npm run localize && npm run build:commonjs && npm run build:es",
-        "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-        "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
+        "build": "npm run localize && npm run build:es",
+        "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
         "watch": "npm run build:es -- --watch",
         "test-ci": "jest --config=../../jest.config.js packages/file-menu",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",

--- a/packages/file-menu/package.json
+++ b/packages/file-menu/package.json
@@ -12,9 +12,8 @@
     },
     "scripts": {
         "prebuild": "rimraf ./build/*",
-        "build": "npm run localize && npm run build:es",
-        "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-        "watch": "npm run build:es -- --watch",
+        "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+        "watch": "npm run localize && npm run build -- --watch",
         "test-ci": "jest --config=../../jest.config.js packages/file-menu",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
         "prettify": "prettier \"src/**/*.{js,jsx,json,css}\" --write",

--- a/packages/file-menu/package.json
+++ b/packages/file-menu/package.json
@@ -2,6 +2,7 @@
     "name": "@dhis2/d2-ui-file-menu",
     "version": "4.0.0",
     "description": "File menu component for DHIS2",
+    "main": "./build/index.js",
     "module": "./build/index.js",
     "license": "BSD-3-Clause",
     "author": "Edoardo Sabadelli <edoardo@dhis2.org>",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-forms",
   "version": "2.0.0",
   "description": "Forms for D2-ui",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "author": "",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-forms",
   "version": "2.0.0",
   "description": "Forms for D2-ui",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "author": "",
   "scripts": {
@@ -11,9 +10,8 @@
     "test-ci": "jest --config=../../jest.config.js packages/forms",
     "lint": "eslint src/",
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
+    "build": "npm run build:es",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
     "watch": "npm run build:es --  --watch"
   },
   "repository": {

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -7,12 +7,11 @@
   "author": "",
   "scripts": {
     "coverage": "jest --coverage",
-    "test-ci": "jest --config=../../jest.config.js packages/forms",
     "lint": "eslint src/",
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:es",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "watch": "npm run build:es --  --watch"
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "watch": "npm run build --  --watch",
+    "test-ci": "jest --config=../../jest.config.js packages/forms"
   },
   "repository": {
     "type": "git",

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-formula-editor",
   "version": "2.0.0",
   "description": "Formula editor component for DHIS2",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "d2": "^31.1.1",
@@ -19,9 +18,8 @@
   ],
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
+    "build": "npm run build:es",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
     "watch": "npm run build:es --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/formula-editor"
   },

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -18,9 +18,8 @@
   ],
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:es",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "watch": "npm run build:es --  --watch",
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/formula-editor"
   },
   "dependencies": {

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-formula-editor",
   "version": "2.0.0",
   "description": "Formula editor component for DHIS2",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {

--- a/packages/group-editor/package.json
+++ b/packages/group-editor/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-group-editor",
   "version": "2.0.0",
   "description": "Group editor component for DHIS2",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {

--- a/packages/group-editor/package.json
+++ b/packages/group-editor/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-group-editor",
   "version": "2.0.0",
   "description": "Group editor component for DHIS2",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "d2": "^31.1.1",
@@ -19,9 +18,8 @@
   ],
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
+    "build": "npm run build:es",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
     "watch": "npm run build:es --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/group-editor"
   },

--- a/packages/group-editor/package.json
+++ b/packages/group-editor/package.json
@@ -18,9 +18,8 @@
   ],
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:es",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "watch": "npm run build:es --  --watch",
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/group-editor"
   },
   "dependencies": {

--- a/packages/header-bar/package.json
+++ b/packages/header-bar/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "prebuild": "rimraf ./build/*",
     "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "watch": "npm run build:es --  --watch",
+    "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/header-bar"
   },
   "publishConfig": {

--- a/packages/header-bar/package.json
+++ b/packages/header-bar/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-header-bar",
   "version": "2.0.0",
   "description": "The header bar for all DHIS2 applications",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "react": "^16.2.0",
@@ -26,9 +25,7 @@
   },
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
     "watch": "npm run build:es --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/header-bar"
   },

--- a/packages/header-bar/package.json
+++ b/packages/header-bar/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-header-bar",
   "version": "2.0.0",
   "description": "The header bar for all DHIS2 applications",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {

--- a/packages/icon-picker/package.json
+++ b/packages/icon-picker/package.json
@@ -2,8 +2,7 @@
     "name": "@dhis2/d2-ui-icon-picker",
     "version": "2.0.0",
     "description": "DHIS2 component for selecting icon",
-    "main": "./build/cjs/index.js",
-    "module": "./build/es/index.js",
+    "module": "./build/index.js",
     "license": "BSD-3-Clause",
     "peerDependencies": {
         "d2": "^31.1.1",
@@ -19,10 +18,8 @@
     ],
     "scripts": {
         "prebuild": "rimraf ./build/*",
-        "build": "npm run build:commonjs && npm run build:es",
-        "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-        "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
-        "watch": "npm run build:es --  --watch",
+        "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+        "watch": "npm run build --  --watch",
         "test-ci": "jest --config=../../jest.config.js packages/icon-picker"
     },
     "dependencies": {

--- a/packages/icon-picker/package.json
+++ b/packages/icon-picker/package.json
@@ -2,6 +2,7 @@
     "name": "@dhis2/d2-ui-icon-picker",
     "version": "2.0.0",
     "description": "DHIS2 component for selecting icon",
+    "main": "./build/index.js",
     "module": "./build/index.js",
     "license": "BSD-3-Clause",
     "peerDependencies": {

--- a/packages/interpretations/package.json
+++ b/packages/interpretations/package.json
@@ -14,8 +14,8 @@
   "contributors": [],
   "scripts": {
     "prebuild": "rm -rf ./build",
-    "build": "cross-env BABEL_ENV=es babel src --copy-files --out-dir build --ignore spec.js",
-    "watch": "yarn localize && npm run build -- --watch",
+    "build": "yarn localize && cross-env BABEL_ENV=es babel src --copy-files --out-dir build --ignore spec.js",
+    "watch": "npm run build -- --watch",
     "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
     "localize": "yarn extract-pot && d2-i18n-generate -n d2-ui-interpretations -p ./i18n/ -o ./src/locales/",
     "test-ci": "jest --config=../../jest.config.js packages/interpretations"

--- a/packages/interpretations/package.json
+++ b/packages/interpretations/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-interpretations",
   "version": "2.0.0",
   "description": "DHIS2 component for interpretations",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {

--- a/packages/interpretations/package.json
+++ b/packages/interpretations/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-interpretations",
   "version": "2.0.0",
   "description": "DHIS2 component for interpretations",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "d2": "^31.1.1",
@@ -14,9 +13,7 @@
   "contributors": [],
   "scripts": {
     "prebuild": "rm -rf ./build",
-    "build": "yarn localize && npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --copy-files --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --copy-files --out-dir build/es --ignore spec.js",
+    "build": "cross-env BABEL_ENV=es babel src --copy-files --out-dir build/es --ignore spec.js",
     "prestart": "yarn localize",
     "watch": "yarn localize && npm run build:es -- --watch",
     "extract-pot": "d2-i18n-extract -p src/ -o i18n/",

--- a/packages/interpretations/package.json
+++ b/packages/interpretations/package.json
@@ -13,9 +13,9 @@
   "contributors": [],
   "scripts": {
     "prebuild": "rm -rf ./build",
-    "build": "cross-env BABEL_ENV=es babel src --copy-files --out-dir build/es --ignore spec.js",
+    "build": "cross-env BABEL_ENV=es babel src --copy-files --out-dir build --ignore spec.js",
     "prestart": "yarn localize",
-    "watch": "yarn localize && npm run build:es -- --watch",
+    "watch": "yarn localize && npm run build -- --watch",
     "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
     "localize": "yarn extract-pot && d2-i18n-generate -n d2-ui-interpretations -p ./i18n/ -o ./src/locales/",
     "test-ci": "jest --config=../../jest.config.js packages/interpretations"
@@ -42,9 +42,7 @@
     "rxjs": "^5.5.7"
   },
   "devDependencies": {
-    "css-loader": "^0.28.7",
-    "sinon": "^6.0.0",
-    "style-loader": "^0.18.2"
+    "sinon": "^6.0.0"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/interpretations/package.json
+++ b/packages/interpretations/package.json
@@ -15,7 +15,6 @@
   "scripts": {
     "prebuild": "rm -rf ./build",
     "build": "cross-env BABEL_ENV=es babel src --copy-files --out-dir build --ignore spec.js",
-    "prestart": "yarn localize",
     "watch": "yarn localize && npm run build -- --watch",
     "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
     "localize": "yarn extract-pot && d2-i18n-generate -n d2-ui-interpretations -p ./i18n/ -o ./src/locales/",

--- a/packages/legend/package.json
+++ b/packages/legend/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-legend",
   "version": "2.0.0",
   "description": "Legend component for DHIS2",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {

--- a/packages/legend/package.json
+++ b/packages/legend/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-legend",
   "version": "2.0.0",
   "description": "Legend component for DHIS2",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "d2": "^31.1.1",
@@ -19,10 +18,8 @@
   ],
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
-    "watch": "npm run build:es --  --watch",
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/legend"
   },
   "dependencies": {

--- a/packages/mentions-wrapper/package.json
+++ b/packages/mentions-wrapper/package.json
@@ -2,6 +2,7 @@
     "name": "@dhis2/d2-ui-mentions-wrapper",
     "version": "3.0.0",
     "description": "Mentions wrapper component for DHIS2",
+    "main": "./build/index.js",
     "module": "./build/index.js",
     "license": "BSD-3-Clause",
     "author": "Edoardo Sabadelli <edoardo@dhis2.org>",

--- a/packages/mentions-wrapper/package.json
+++ b/packages/mentions-wrapper/package.json
@@ -13,8 +13,8 @@
     },
     "scripts": {
         "prebuild": "rimraf ./build/*",
-        "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-        "watch": "yarn localize && yarn build -- --watch",
+        "build": "yarn localize && cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+        "watch": "yarn build -- --watch",
         "test-ci": "jest --config=../../jest.config.js packages/mentions-wrapper",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
         "prettify": "prettier \"src/**/*.{js,jsx,json,css}\" --write",

--- a/packages/mentions-wrapper/package.json
+++ b/packages/mentions-wrapper/package.json
@@ -13,7 +13,7 @@
     "scripts": {
         "prebuild": "rimraf ./build/*",
         "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-        "watch": "yarn build -- --watch",
+        "watch": "yarn localize && yarn build -- --watch",
         "test-ci": "jest --config=../../jest.config.js packages/mentions-wrapper",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
         "prettify": "prettier \"src/**/*.{js,jsx,json,css}\" --write",

--- a/packages/mentions-wrapper/package.json
+++ b/packages/mentions-wrapper/package.json
@@ -2,8 +2,7 @@
     "name": "@dhis2/d2-ui-mentions-wrapper",
     "version": "3.0.0",
     "description": "Mentions wrapper component for DHIS2",
-    "main": "./build/cjs/index.js",
-    "module": "./build/es/index.js",
+    "module": "./build/index.js",
     "license": "BSD-3-Clause",
     "author": "Edoardo Sabadelli <edoardo@dhis2.org>",
     "peerDependencies": {
@@ -13,10 +12,8 @@
     },
     "scripts": {
         "prebuild": "rimraf ./build/*",
-        "build": "yarn localize && yarn build:commonjs && yarn build:es",
-        "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-        "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
-        "watch": "yarn build:es -- --watch",
+        "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+        "watch": "yarn build -- --watch",
         "test-ci": "jest --config=../../jest.config.js packages/mentions-wrapper",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
         "prettify": "prettier \"src/**/*.{js,jsx,json,css}\" --write",

--- a/packages/org-unit-dialog/package.json
+++ b/packages/org-unit-dialog/package.json
@@ -13,7 +13,7 @@
     "scripts": {
         "prebuild": "rimraf ./build/*",
         "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-        "watch": "npm run build --  --watch",
+        "watch": "npm run localize && npm run build --  --watch",
         "test-ci": "jest --config=../../jest.config.js packages/org-unit-dialog",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
         "prettify": "prettier \"src/**/*.{js,jsx,json,css}\" --write",

--- a/packages/org-unit-dialog/package.json
+++ b/packages/org-unit-dialog/package.json
@@ -2,8 +2,7 @@
     "name": "@dhis2/d2-ui-org-unit-dialog",
     "version": "1.0.0",
     "description": "Org Unit Dialog component for d2-ui",
-    "main": "./build/cjs/index.js",
-    "module": "./build/es/index.js",
+    "module": "./build/index.js",
     "license": "BSD-3-Clause",
     "peerDependencies": {
         "d2": "^31.1.1",
@@ -13,10 +12,8 @@
     "author": "Ilya Nee <ilya@dhis2.org>",
     "scripts": {
         "prebuild": "rimraf ./build/*",
-        "build": "npm run localize && npm run build:commonjs && npm run build:es",
-        "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-        "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
-        "watch": "npm run build:es --  --watch",
+        "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+        "watch": "npm run build --  --watch",
         "test-ci": "jest --config=../../jest.config.js packages/org-unit-dialog",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
         "prettify": "prettier \"src/**/*.{js,jsx,json,css}\" --write",

--- a/packages/org-unit-dialog/package.json
+++ b/packages/org-unit-dialog/package.json
@@ -13,8 +13,8 @@
     "author": "Ilya Nee <ilya@dhis2.org>",
     "scripts": {
         "prebuild": "rimraf ./build/*",
-        "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-        "watch": "npm run localize && npm run build --  --watch",
+        "build": "npm run localize && cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+        "watch": "npm run build --  --watch",
         "test-ci": "jest --config=../../jest.config.js packages/org-unit-dialog",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
         "prettify": "prettier \"src/**/*.{js,jsx,json,css}\" --write",

--- a/packages/org-unit-dialog/package.json
+++ b/packages/org-unit-dialog/package.json
@@ -2,6 +2,7 @@
     "name": "@dhis2/d2-ui-org-unit-dialog",
     "version": "1.0.0",
     "description": "Org Unit Dialog component for d2-ui",
+    "main": "./build/index.js",
     "module": "./build/index.js",
     "license": "BSD-3-Clause",
     "peerDependencies": {

--- a/packages/org-unit-select/package.json
+++ b/packages/org-unit-select/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-org-unit-select",
   "version": "2.0.0",
   "description": "Org Unit Selection component for D2-UI",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "d2": "^31.1.1",
@@ -19,10 +18,8 @@
   ],
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
-    "watch": "npm run build:es --  --watch",
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/org-unit-select"
   },
   "dependencies": {

--- a/packages/org-unit-select/package.json
+++ b/packages/org-unit-select/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-org-unit-select",
   "version": "2.0.0",
   "description": "Org Unit Selection component for D2-UI",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {

--- a/packages/org-unit-tree/package.json
+++ b/packages/org-unit-tree/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-org-unit-tree",
   "version": "2.0.0",
   "description": "Org Unit Tree component for d2-ui",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "d2": "^31.1.1",
@@ -20,10 +19,8 @@
   ],
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
-    "watch": "npm run build:es --  --watch",
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/org-unit-tree"
   },
   "dependencies": {

--- a/packages/org-unit-tree/package.json
+++ b/packages/org-unit-tree/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-org-unit-tree",
   "version": "2.0.0",
   "description": "Org Unit Tree component for d2-ui",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {

--- a/packages/org-unit-tree/src/OrgUnitTree.component.js
+++ b/packages/org-unit-tree/src/OrgUnitTree.component.js
@@ -8,7 +8,7 @@ import StopIcon from '@material-ui/icons/Stop';
 import ModelBase from 'd2/model/Model';
 import ModelCollection from 'd2/model/ModelCollection';
 
-import TreeView from '@dhis2/d2-ui-core/build/es/tree-view/TreeView.component';
+import TreeView from '@dhis2/d2-ui-core/build/tree-view/TreeView.component';
 
 
 const styles = {

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "prebuild": "rimraf ./build/*",
     "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js && npm run build:css",
-    "build:css": "cp -R ./css ./build/",
+    "build:css": "cp -R ./css/* ./build/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/period-selector-dialog",
     "test:watch": "npm test -- --watch"

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -18,7 +18,6 @@
     "build:css": "cp -R ./css ./build/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/period-selector-dialog",
-    "test": "jest",
     "test:watch": "npm test -- --watch"
   },
   "dependencies": {

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-period-selector-dialog",
   "version": "2.0.2",
   "description": "Period selector dialog component for DHIS2",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "author": "Ilya Nee <ilya@dhis2.org>",
   "contributors": [
@@ -15,11 +14,9 @@
   },
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js && npm run build:css",
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js && npm run build:css",
     "build:css": "cp -R ./css ./build/",
-    "watch": "npm run build:es --  --watch",
+    "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/period-selector-dialog",
     "test": "jest",
     "test:watch": "npm test -- --watch"
@@ -37,8 +34,6 @@
   },
   "devDependencies": {
     "babel-jest": "^23.0.1",
-    "css-loader": "^0.28.11",
-    "jest": "^23.1.0",
-    "style-loader": "^0.21.0"
+    "jest": "^23.1.0"
   }
 }

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-period-selector-dialog",
   "version": "2.0.2",
   "description": "Period selector dialog component for DHIS2",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "author": "Ilya Nee <ilya@dhis2.org>",

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -8,7 +8,7 @@ import PeriodTypeButton from './PeriodTypeButton';
 import SelectedPeriods from './SelectedPeriods';
 import { OfferedPeriods } from './OfferedPeriods';
 import PeriodTypes from './PeriodTypes';
-import './css/PeriodSelector.css';
+import './PeriodSelector.css';
 
 import {
     setPeriodType,

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -8,7 +8,7 @@ import PeriodTypeButton from './PeriodTypeButton';
 import SelectedPeriods from './SelectedPeriods';
 import { OfferedPeriods } from './OfferedPeriods';
 import PeriodTypes from './PeriodTypes';
-import '../css/PeriodSelector.css';
+import './css/PeriodSelector.css';
 
 import {
     setPeriodType,

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -26,10 +26,6 @@
         "react": "^16.4.0",
         "react-dom": "^16.4.0"
     },
-    "pre-commit": [
-        "validate",
-        "test"
-    ],
     "publishConfig": {
         "access": "public"
     }

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -2,8 +2,7 @@
     "name": "@dhis2/d2-ui-rich-text",
     "version": "1.0.0",
     "description": "Rich text components for DHIS2 in d2-ui",
-    "main": "./build/cjs/index.js",
-    "module": "./build/es/index.js",
+    "module": "./build/index.js",
     "license": "BSD-3-Clause",
     "author": "Edoardo Sabadelli <edoardo@dhis2.org>",
     "scripts": {
@@ -11,10 +10,8 @@
         "test-ci": "jest --config=../../jest.config.js packages/rich-text",
         "lint": "eslint src/",
         "prebuild": "rimraf ./build/*",
-        "build": "yarn build:commonjs && yarn build:es",
-        "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-        "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
-        "watch": "yarn build:es --  --watch"
+        "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+        "watch": "yarn build --  --watch"
     },
     "repository": {
         "type": "git",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -2,6 +2,7 @@
     "name": "@dhis2/d2-ui-rich-text",
     "version": "1.0.0",
     "description": "Rich text components for DHIS2 in d2-ui",
+    "main": "./build/index.js",
     "module": "./build/index.js",
     "license": "BSD-3-Clause",
     "author": "Edoardo Sabadelli <edoardo@dhis2.org>",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -10,7 +10,7 @@
         "test-ci": "jest --config=../../jest.config.js packages/rich-text",
         "lint": "eslint src/",
         "prebuild": "rimraf ./build/*",
-        "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+        "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
         "watch": "yarn build --  --watch"
     },
     "repository": {

--- a/packages/sharing-dialog/package.json
+++ b/packages/sharing-dialog/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-sharing-dialog",
   "version": "3.0.0",
   "description": "DHIS2 component for sharing dialog",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {

--- a/packages/sharing-dialog/package.json
+++ b/packages/sharing-dialog/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-sharing-dialog",
   "version": "3.0.0",
   "description": "DHIS2 component for sharing dialog",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "d2": "^31.1.1",
@@ -19,10 +18,8 @@
   ],
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
-    "watch": "npm run build:es --  --watch",
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/sharing-dialog"
   },
   "dependencies": {

--- a/packages/sharing-dialog/src/Sharing.component.js
+++ b/packages/sharing-dialog/src/Sharing.component.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Divider from '@material-ui/core/Divider';
 import Typography from '@material-ui/core/Typography';
-import Heading from '@dhis2/d2-ui-core/build/es/headings/Heading.component';
+import Heading from '@dhis2/d2-ui-core/build/headings/Heading.component';
 import UserSearch from './UserSearch.component';
 import CreatedBy from './CreatedBy.component';
 import {

--- a/packages/sharing-dialog/src/__tests__/Sharing.component.spec.js
+++ b/packages/sharing-dialog/src/__tests__/Sharing.component.spec.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import Typography from '@material-ui/core/Typography';
 import { getStubContext } from '../../../../config/inject-theme';
 import Sharing from '../Sharing.component';
-import Heading from '@dhis2/d2-ui-core/build/es/headings/Heading.component';
+import Heading from '@dhis2/d2-ui-core/build/headings/Heading.component';
 import CreatedBy from '../CreatedBy.component';
 import UserSearch from '../UserSearch.component';
 import { GroupAccess } from '../Access.component';

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-table",
   "version": "2.0.0",
   "description": "Table components for d2-ui",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "d2": "^31.1.1",
@@ -19,10 +18,8 @@
   ],
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
-    "watch": "npm run build:es --  --watch",
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/table"
   },
   "dependencies": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-table",
   "version": "2.0.0",
   "description": "Table components for d2-ui",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {

--- a/packages/translation-dialog/package.json
+++ b/packages/translation-dialog/package.json
@@ -2,6 +2,7 @@
   "name": "@dhis2/d2-ui-translation-dialog",
   "version": "3.0.0",
   "description": "Translation Dialog for DHIS2",
+  "main": "./build/index.js",
   "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {

--- a/packages/translation-dialog/package.json
+++ b/packages/translation-dialog/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/translation-dialog"
   },

--- a/packages/translation-dialog/package.json
+++ b/packages/translation-dialog/package.json
@@ -2,8 +2,7 @@
   "name": "@dhis2/d2-ui-translation-dialog",
   "version": "3.0.0",
   "description": "Translation Dialog for DHIS2",
-  "main": "./build/cjs/index.js",
-  "module": "./build/es/index.js",
+  "module": "./build/index.js",
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "d2": "^31.1.1",
@@ -19,10 +18,8 @@
   ],
   "scripts": {
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:commonjs && npm run build:es",
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build/cjs --ignore spec.js",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build/es --ignore spec.js",
-    "watch": "npm run build:es --  --watch",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/translation-dialog"
   },
   "dependencies": {

--- a/packages/translation-dialog/src/TranslationForm.component.js
+++ b/packages/translation-dialog/src/TranslationForm.component.js
@@ -6,7 +6,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import camelCaseToUnderscores from 'd2-utilizr/lib/camelCaseToUnderscores';
 import { Observable } from 'rxjs/Observable';
-import Store from '@dhis2/d2-ui-core/build/es/store/Store';
+import Store from '@dhis2/d2-ui-core/build/store/Store';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import LocaleSelector from './LocaleSelector.component';
 import { getLocales, getTranslationsForModel, saveTranslations } from './translationForm.actions';

--- a/packages/translation-dialog/src/translation.store.js
+++ b/packages/translation-dialog/src/translation.store.js
@@ -1,3 +1,3 @@
-import Store from '@dhis2/d2-ui-core/build/es/store/Store';
+import Store from '@dhis2/d2-ui-core/build/store/Store';
 
 export default Store.create();

--- a/packages/translation-dialog/src/translationForm.actions.js
+++ b/packages/translation-dialog/src/translationForm.actions.js
@@ -1,6 +1,6 @@
 import { getInstance } from 'd2';
 import { Observable } from 'rxjs/Observable';
-import Action from '@dhis2/d2-ui-core/build/es/action/Action';
+import Action from '@dhis2/d2-ui-core/build/action/Action';
 
 export function getLocales() {
     if (!getLocales.localePromise) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -483,14 +483,6 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
-JSONStream@^1.0.4:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
-  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
-
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -600,11 +592,6 @@ acorn@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.2.tgz#6a459041c320ab17592c6317abbfdf4bbaa98ca4"
   integrity sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg==
-
-add-stream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
-  integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
 
 address@1.0.3, address@^1.0.1:
   version "1.0.3"
@@ -824,11 +811,6 @@ array-from@^2.1.1:
   resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
   integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
-array-ify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
-  integrity sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
-
 array-includes@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
@@ -951,7 +933,7 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
-async@^1.5.0, async@^1.5.2, async@~1.5.2:
+async@^1.5.2, async@~1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
@@ -2416,11 +2398,6 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-byline@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
-  integrity sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=
-
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -2492,15 +2469,6 @@ camelcase-keys@^2.0.0:
   dependencies:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
-
-camelcase-keys@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
-  integrity sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=
-  dependencies:
-    camelcase "^4.1.0"
-    map-obj "^2.0.0"
-    quick-lru "^1.0.0"
 
 camelcase@^1.0.2:
   version "1.2.1"
@@ -2817,14 +2785,6 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
-cmd-shim@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-2.0.2.tgz#6fcbda99483a8fd15d7d30a196ca69d688a2efdb"
-  integrity sha1-b8vamUg6j9FdfTChlspp1oii79s=
-  dependencies:
-    graceful-fs "^4.1.2"
-    mkdirp "~0.5.0"
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2927,25 +2887,12 @@ colors@~1.1.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
   integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
 
-columnify@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
-  integrity sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=
-  dependencies:
-    strip-ansi "^3.0.0"
-    wcwidth "^1.0.0"
-
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
   integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
   dependencies:
     delayed-stream "~1.0.0"
-
-command-join@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/command-join/-/command-join-2.0.0.tgz#52e8b984f4872d952ff1bdc8b98397d27c7144cf"
-  integrity sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=
 
 commander@2.17.x, commander@~2.17.1:
   version "2.17.1"
@@ -2994,14 +2941,6 @@ commoner@^0.10.1:
     q "^1.1.2"
     recast "^0.11.17"
 
-compare-func@^1.3.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/compare-func/-/compare-func-1.3.2.tgz#99dd0ba457e1f9bc722b12c08ec33eeab31fa648"
-  integrity sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=
-  dependencies:
-    array-ify "^1.0.0"
-    dot-prop "^3.0.0"
-
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
@@ -3037,7 +2976,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.4.10, concat-stream@^1.5.0, concat-stream@^1.6.0:
+concat-stream@^1.5.0, concat-stream@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -3100,173 +3039,6 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
-
-conventional-changelog-angular@^1.6.6:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz#b27f2b315c16d0a1f23eb181309d0e6a4698ea0f"
-  integrity sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==
-  dependencies:
-    compare-func "^1.3.1"
-    q "^1.5.1"
-
-conventional-changelog-atom@^0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz#8037693455990e3256f297320a45fa47ee553a14"
-  integrity sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==
-  dependencies:
-    q "^1.5.1"
-
-conventional-changelog-cli@^1.3.13:
-  version "1.3.22"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-cli/-/conventional-changelog-cli-1.3.22.tgz#13570fe1728f56f013ff7a88878ff49d5162a405"
-  integrity sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==
-  dependencies:
-    add-stream "^1.0.0"
-    conventional-changelog "^1.1.24"
-    lodash "^4.2.1"
-    meow "^4.0.0"
-    tempfile "^1.1.1"
-
-conventional-changelog-codemirror@^0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz#a1982c8291f4ee4d6f2f62817c6b2ecd2c4b7b47"
-  integrity sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==
-  dependencies:
-    q "^1.5.1"
-
-conventional-changelog-core@^2.0.11:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz#19b5fbd55a9697773ed6661f4e32030ed7e30287"
-  integrity sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==
-  dependencies:
-    conventional-changelog-writer "^3.0.9"
-    conventional-commits-parser "^2.1.7"
-    dateformat "^3.0.0"
-    get-pkg-repo "^1.0.0"
-    git-raw-commits "^1.3.6"
-    git-remote-origin-url "^2.0.0"
-    git-semver-tags "^1.3.6"
-    lodash "^4.2.1"
-    normalize-package-data "^2.3.5"
-    q "^1.5.1"
-    read-pkg "^1.1.0"
-    read-pkg-up "^1.0.1"
-    through2 "^2.0.0"
-
-conventional-changelog-ember@^0.3.12:
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz#b7d31851756d0fcb49b031dffeb6afa93b202400"
-  integrity sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==
-  dependencies:
-    q "^1.5.1"
-
-conventional-changelog-eslint@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz#b13cc7e4b472c819450ede031ff1a75c0e3d07d3"
-  integrity sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==
-  dependencies:
-    q "^1.5.1"
-
-conventional-changelog-express@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz#4a6295cb11785059fb09202180d0e59c358b9c2c"
-  integrity sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==
-  dependencies:
-    q "^1.5.1"
-
-conventional-changelog-jquery@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz#0208397162e3846986e71273b6c79c5b5f80f510"
-  integrity sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=
-  dependencies:
-    q "^1.4.1"
-
-conventional-changelog-jscs@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz#0479eb443cc7d72c58bf0bcf0ef1d444a92f0e5c"
-  integrity sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=
-  dependencies:
-    q "^1.4.1"
-
-conventional-changelog-jshint@^0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz#9051c1ac0767abaf62a31f74d2fe8790e8acc6c8"
-  integrity sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==
-  dependencies:
-    compare-func "^1.3.1"
-    q "^1.5.1"
-
-conventional-changelog-preset-loader@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz#40bb0f142cd27d16839ec6c74ee8db418099b373"
-  integrity sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==
-
-conventional-changelog-writer@^3.0.9:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz#4aecdfef33ff2a53bb0cf3b8071ce21f0e994634"
-  integrity sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==
-  dependencies:
-    compare-func "^1.3.1"
-    conventional-commits-filter "^1.1.6"
-    dateformat "^3.0.0"
-    handlebars "^4.0.2"
-    json-stringify-safe "^5.0.1"
-    lodash "^4.2.1"
-    meow "^4.0.0"
-    semver "^5.5.0"
-    split "^1.0.0"
-    through2 "^2.0.0"
-
-conventional-changelog@^1.1.24:
-  version "1.1.24"
-  resolved "https://registry.yarnpkg.com/conventional-changelog/-/conventional-changelog-1.1.24.tgz#3d94c29c960f5261c002678315b756cdd3d7d1f0"
-  integrity sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==
-  dependencies:
-    conventional-changelog-angular "^1.6.6"
-    conventional-changelog-atom "^0.2.8"
-    conventional-changelog-codemirror "^0.3.8"
-    conventional-changelog-core "^2.0.11"
-    conventional-changelog-ember "^0.3.12"
-    conventional-changelog-eslint "^1.0.9"
-    conventional-changelog-express "^0.3.6"
-    conventional-changelog-jquery "^0.1.0"
-    conventional-changelog-jscs "^0.1.0"
-    conventional-changelog-jshint "^0.3.8"
-    conventional-changelog-preset-loader "^1.1.8"
-
-conventional-commits-filter@^1.1.1, conventional-commits-filter@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz#4389cd8e58fe89750c0b5fb58f1d7f0cc8ad3831"
-  integrity sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==
-  dependencies:
-    is-subset "^0.1.1"
-    modify-values "^1.0.0"
-
-conventional-commits-parser@^2.1.1, conventional-commits-parser@^2.1.7:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz#eca45ed6140d72ba9722ee4132674d639e644e8e"
-  integrity sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==
-  dependencies:
-    JSONStream "^1.0.4"
-    is-text-path "^1.0.0"
-    lodash "^4.2.1"
-    meow "^4.0.0"
-    split2 "^2.0.0"
-    through2 "^2.0.0"
-    trim-off-newlines "^1.0.0"
-
-conventional-recommended-bump@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz#1b7137efb5091f99fe009e2fe9ddb7cc490e9375"
-  integrity sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==
-  dependencies:
-    concat-stream "^1.4.10"
-    conventional-commits-filter "^1.1.1"
-    conventional-commits-parser "^2.1.1"
-    git-raw-commits "^1.3.0"
-    git-semver-tags "^1.3.0"
-    meow "^3.3.0"
-    object-assign "^4.0.1"
 
 convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.6.0"
@@ -3490,7 +3262,7 @@ css-loader@0.28.7:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
-css-loader@^0.28.11, css-loader@^0.28.7:
+css-loader@^0.28.7:
   version "0.28.11"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.11.tgz#c3f9864a700be2711bb5a2462b2389b1a392dab7"
   integrity sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==
@@ -3730,13 +3502,6 @@ damerau-levenshtein@^1.0.0:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
   integrity sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=
 
-dargs@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
-  integrity sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=
-  dependencies:
-    number-is-nan "^1.0.0"
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -3757,11 +3522,6 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
-
-dateformat@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
-  integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
 debounce@^1.1.0:
   version "1.2.0"
@@ -3789,15 +3549,7 @@ debug@^3.0.1, debug@^3.1.0, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
-decamelize-keys@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
-  integrity sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=
-  dependencies:
-    decamelize "^1.1.0"
-    map-obj "^1.0.0"
-
-decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -3813,11 +3565,6 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
-
-dedent@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
-  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-diff@^0.3.5:
   version "0.3.8"
@@ -3865,13 +3612,6 @@ default-require-extensions@^1.0.0:
   integrity sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=
   dependencies:
     strip-bom "^2.0.0"
-
-defaults@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
-  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
-  dependencies:
-    clone "^1.0.2"
 
 define-properties@^1.1.2:
   version "1.1.3"
@@ -3966,11 +3706,6 @@ detect-indent@^4.0.0:
   integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
   dependencies:
     repeating "^2.0.0"
-
-detect-indent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
-  integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
 detect-libc@^1.0.2:
   version "1.0.3"
@@ -4152,13 +3887,6 @@ domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
-
-dot-prop@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
-  integrity sha1-G3CK8JSknJoOfbyteQq6U52sEXc=
-  dependencies:
-    is-obj "^1.0.0"
 
 dot-prop@^4.1.0:
   version "4.2.0"
@@ -4916,19 +4644,6 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
-  integrity sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
 execa@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
@@ -5424,15 +5139,6 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
-  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-extra@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
@@ -5549,22 +5255,6 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
-get-pkg-repo@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz#c73b489c06d80cc5536c2c853f9e05232056972d"
-  integrity sha1-xztInAbYDMVTbCyFP54FIyBWly0=
-  dependencies:
-    hosted-git-info "^2.1.4"
-    meow "^3.3.0"
-    normalize-package-data "^2.3.0"
-    parse-github-repo-url "^1.3.0"
-    through2 "^2.0.0"
-
-get-port@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
-  integrity sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=
-
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -5599,40 +5289,6 @@ gettext-parser@^1.3.1:
   dependencies:
     encoding "^0.1.12"
     safe-buffer "^5.1.1"
-
-git-raw-commits@^1.3.0, git-raw-commits@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-1.3.6.tgz#27c35a32a67777c1ecd412a239a6c19d71b95aff"
-  integrity sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==
-  dependencies:
-    dargs "^4.0.1"
-    lodash.template "^4.0.2"
-    meow "^4.0.0"
-    split2 "^2.0.0"
-    through2 "^2.0.0"
-
-git-remote-origin-url@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz#5282659dae2107145a11126112ad3216ec5fa65f"
-  integrity sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=
-  dependencies:
-    gitconfiglocal "^1.0.0"
-    pify "^2.3.0"
-
-git-semver-tags@^1.3.0, git-semver-tags@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-1.3.6.tgz#357ea01f7280794fe0927f2806bee6414d2caba5"
-  integrity sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==
-  dependencies:
-    meow "^4.0.0"
-    semver "^5.5.0"
-
-gitconfiglocal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz#41d045f3851a5ea88f03f24ca1c6178114464b9b"
-  integrity sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=
-  dependencies:
-    ini "^1.3.2"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -5821,7 +5477,7 @@ handle-thing@^1.2.5:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
   integrity sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=
 
-handlebars@^4.0.11, handlebars@^4.0.2, handlebars@^4.0.3:
+handlebars@^4.0.11, handlebars@^4.0.3:
   version "4.0.12"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.12.tgz#2c15c8a96d46da5e266700518ba8cb8d919d5bc5"
   integrity sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==
@@ -5972,7 +5628,7 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
-hosted-git-info@^2.1.4, hosted-git-info@^2.5.0:
+hosted-git-info@^2.1.4:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
@@ -6280,11 +5936,6 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
-indent-string@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
-  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
-
 indexes-of@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
@@ -6313,7 +5964,7 @@ inherits@2.0.1:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
-ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -6326,7 +5977,7 @@ inline-style-prefixer@^3.0.8:
     bowser "^1.7.3"
     css-in-js-utils "^2.0.0"
 
-inquirer@3.3.0, inquirer@^3.0.6, inquirer@^3.2.2:
+inquirer@3.3.0, inquirer@^3.0.6:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   integrity sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==
@@ -6670,7 +6321,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
+is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
@@ -6759,13 +6410,6 @@ is-symbol@^1.0.2:
   integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
   dependencies:
     has-symbols "^1.0.0"
-
-is-text-path@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-text-path/-/is-text-path-1.0.1.tgz#4e1aa0fb51bfbcb3e92688001397202c1775b66e"
-  integrity sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=
-  dependencies:
-    text-extensions "^1.0.0"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -7689,7 +7333,7 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -7729,11 +7373,6 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
-
-jsonparse@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
-  integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -7921,51 +7560,6 @@ left-pad@^1.3.0:
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
   integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
-lerna@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.11.0.tgz#89b5681e286d388dda5bbbdbbf6b84c8094eff65"
-  integrity sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==
-  dependencies:
-    async "^1.5.0"
-    chalk "^2.1.0"
-    cmd-shim "^2.0.2"
-    columnify "^1.5.4"
-    command-join "^2.0.0"
-    conventional-changelog-cli "^1.3.13"
-    conventional-recommended-bump "^1.2.1"
-    dedent "^0.7.0"
-    execa "^0.8.0"
-    find-up "^2.1.0"
-    fs-extra "^4.0.1"
-    get-port "^3.2.0"
-    glob "^7.1.2"
-    glob-parent "^3.1.0"
-    globby "^6.1.0"
-    graceful-fs "^4.1.11"
-    hosted-git-info "^2.5.0"
-    inquirer "^3.2.2"
-    is-ci "^1.0.10"
-    load-json-file "^4.0.0"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-    npmlog "^4.1.2"
-    p-finally "^1.0.0"
-    package-json "^4.0.1"
-    path-exists "^3.0.0"
-    read-cmd-shim "^1.0.1"
-    read-pkg "^3.0.0"
-    rimraf "^2.6.1"
-    safe-buffer "^5.1.1"
-    semver "^5.4.1"
-    signal-exit "^3.0.2"
-    slash "^1.0.0"
-    strong-log-transformer "^1.0.6"
-    temp-write "^3.3.0"
-    write-file-atomic "^2.3.0"
-    write-json-file "^2.2.0"
-    write-pkg "^3.1.0"
-    yargs "^8.0.2"
-
 leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
@@ -8005,16 +7599,6 @@ load-json-file@^2.0.0:
     graceful-fs "^4.1.2"
     parse-json "^2.2.0"
     pify "^2.0.0"
-    strip-bom "^3.0.0"
-
-load-json-file@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
-  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^4.0.0"
-    pify "^3.0.0"
     strip-bom "^3.0.0"
 
 loader-fs-cache@^1.0.0:
@@ -8251,7 +7835,7 @@ lodash.tail@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
   integrity sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=
 
-lodash.template@^4.0.2, lodash.template@^4.4.0:
+lodash.template@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
   integrity sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=
@@ -8359,11 +7943,6 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
-
-map-obj@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
-  integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -8483,21 +8062,6 @@ meow@^3.3.0, meow@^3.7.0:
     read-pkg-up "^1.0.1"
     redent "^1.0.0"
     trim-newlines "^1.0.0"
-
-meow@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-4.0.1.tgz#d48598f6f4b1472f35bf6317a95945ace347f975"
-  integrity sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==
-  dependencies:
-    camelcase-keys "^4.0.0"
-    decamelize-keys "^1.0.0"
-    loud-rejection "^1.0.0"
-    minimist "^1.1.3"
-    minimist-options "^3.0.1"
-    normalize-package-data "^2.3.4"
-    read-pkg-up "^3.0.0"
-    redent "^2.0.0"
-    trim-newlines "^2.0.0"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -8623,23 +8187,10 @@ minimatch@3.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimist-options@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
-  integrity sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==
-  dependencies:
-    arrify "^1.0.1"
-    is-plain-obj "^1.1.0"
-
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
-  integrity sha1-md9lelJXTCHJBXSX33QnkLK0wN4=
 
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
@@ -8705,12 +8256,7 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   dependencies:
     minimist "0.0.8"
 
-modify-values@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
-  integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
-
-moment@^2.22.1, moment@^2.6.0:
+moment@^2.22.1:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
   integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
@@ -8998,7 +8544,7 @@ nopt@~1.0.10:
   dependencies:
     abbrev "1"
 
-normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5:
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   integrity sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==
@@ -9062,7 +8608,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2, npmlog@^4.1.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -9397,7 +8943,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
   integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
 
-package-json@^4.0.0, package-json@^4.0.1:
+package-json@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
   integrity sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=
@@ -9438,11 +8984,6 @@ parse-asn1@^5.0.0:
     create-hash "^1.1.0"
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
-
-parse-github-repo-url@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz#9e7d8bb252a6cb6ba42595060b7bf6df3dbc1f50"
-  integrity sha1-nn2LslKmy2ukJZUGC3v23z28H1A=
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -9575,13 +9116,6 @@ path-type@^2.0.0:
   integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
   dependencies:
     pify "^2.0.0"
-
-path-type@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
-  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
-  dependencies:
-    pify "^3.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.17"
@@ -10178,7 +9712,7 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-q@^1.1.2, q@^1.4.1, q@^1.5.1:
+q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
@@ -10210,11 +9744,6 @@ querystringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
   integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
-
-quick-lru@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
-  integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
 raf@3.4.0, raf@^3.4.0:
   version "3.4.0"
@@ -10505,13 +10034,6 @@ reactcss@^1.2.0:
   dependencies:
     lodash "^4.0.1"
 
-read-cmd-shim@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz#2d5d157786a37c055d22077c32c53f8329e91c7b"
-  integrity sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=
-  dependencies:
-    graceful-fs "^4.1.2"
-
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -10528,15 +10050,7 @@ read-pkg-up@^2.0.0:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
 
-read-pkg-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
-  integrity sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=
-  dependencies:
-    find-up "^2.0.0"
-    read-pkg "^3.0.0"
-
-read-pkg@^1.0.0, read-pkg@^1.1.0:
+read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
   integrity sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=
@@ -10553,15 +10067,6 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
-
-read-pkg@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
-  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
-  dependencies:
-    load-json-file "^4.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^3.0.0"
 
 read-pkg@^4.0.1:
   version "4.0.1"
@@ -10685,14 +10190,6 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
-
-redent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
-  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
-  dependencies:
-    indent-string "^3.0.0"
-    strip-indent "^2.0.0"
 
 reduce-css-calc@^1.2.6:
   version "1.3.0"
@@ -11560,13 +11057,6 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-sort-keys@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
-  integrity sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=
-  dependencies:
-    is-plain-obj "^1.0.0"
-
 sortobject@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/sortobject/-/sortobject-1.1.1.tgz#4f695d4d44ed0a4c06482c34c2582a2dcdc2ab34"
@@ -11689,20 +11179,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
-
-split2@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
-  integrity sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
-  dependencies:
-    through2 "^2.0.2"
-
-split@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
-  integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
-  dependencies:
-    through "2"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -11894,26 +11370,10 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
-  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
-
 strip-json-comments@2.0.1, strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
-strong-log-transformer@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz#f7fb93758a69a571140181277eea0c2eb1301fa3"
-  integrity sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=
-  dependencies:
-    byline "^5.0.0"
-    duplexer "^0.1.1"
-    minimist "^0.1.0"
-    moment "^2.6.0"
-    through "^2.3.4"
 
 style-loader@0.19.0:
   version "0.19.0"
@@ -11930,14 +11390,6 @@ style-loader@^0.18.2:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
-
-style-loader@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.21.0.tgz#68c52e5eb2afc9ca92b6274be277ee59aea3a852"
-  integrity sha512-T+UNsAcl3Yg+BsPKs1vd22Fr8sVT+CJMtzqc6LEw9bbJZb43lm9GoeIfUcDEefBSWC0BhYbcdupV1GtI4DGzxg==
-  dependencies:
-    loader-utils "^1.1.0"
-    schema-utils "^0.4.5"
 
 stylis-rule-sheet@^0.0.10:
   version "0.0.10"
@@ -12126,31 +11578,6 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-temp-dir@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
-  integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
-
-temp-write@^3.3.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/temp-write/-/temp-write-3.4.0.tgz#8cff630fb7e9da05f047c74ce4ce4d685457d492"
-  integrity sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=
-  dependencies:
-    graceful-fs "^4.1.2"
-    is-stream "^1.1.0"
-    make-dir "^1.0.0"
-    pify "^3.0.0"
-    temp-dir "^1.0.0"
-    uuid "^3.0.1"
-
-tempfile@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/tempfile/-/tempfile-1.1.1.tgz#5bcc4eaecc4ab2c707d8bc11d99ccc9a2cb287f2"
-  integrity sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=
-  dependencies:
-    os-tmpdir "^1.0.0"
-    uuid "^2.0.1"
-
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -12173,11 +11600,6 @@ text-encoding@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
   integrity sha1-45mpgiV6J22uQou5KEXLcb3CbRk=
-
-text-extensions@^1.0.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
-  integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
 
 text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
@@ -12202,7 +11624,7 @@ through2-filter@^2.0.0:
     through2 "~2.0.0"
     xtend "~4.0.0"
 
-through2@^2.0.0, through2@^2.0.1, through2@^2.0.2, through2@^2.0.3, through2@~2.0.0:
+through2@^2.0.0, through2@^2.0.1, through2@^2.0.3, through2@~2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   integrity sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=
@@ -12210,7 +11632,7 @@ through2@^2.0.0, through2@^2.0.1, through2@^2.0.2, through2@^2.0.3, through2@~2.
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3.4, through@~2.3.8:
+through@^2.3.6, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -12345,16 +11767,6 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
-
-trim-newlines@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
-  integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
-
-trim-off-newlines@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
-  integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
 trim-right@^1.0.1:
   version "1.0.1"
@@ -12700,7 +12112,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^2.0.1, uuid@^2.0.2:
+uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
   integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
@@ -12865,13 +12277,6 @@ wbuf@^1.1.0, wbuf@^1.7.2:
   integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   dependencies:
     minimalistic-assert "^1.0.0"
-
-wcwidth@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
-  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
-  dependencies:
-    defaults "^1.0.3"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
@@ -13226,7 +12631,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^2.0.0, write-file-atomic@^2.1.0, write-file-atomic@^2.3.0:
+write-file-atomic@^2.0.0, write-file-atomic@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
   integrity sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==
@@ -13234,26 +12639,6 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.1.0, write-file-atomic@^2.3.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
-
-write-json-file@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-2.3.0.tgz#2b64c8a33004d54b8698c76d585a77ceb61da32f"
-  integrity sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=
-  dependencies:
-    detect-indent "^5.0.0"
-    graceful-fs "^4.1.2"
-    make-dir "^1.0.0"
-    pify "^3.0.0"
-    sort-keys "^2.0.0"
-    write-file-atomic "^2.0.0"
-
-write-pkg@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/write-pkg/-/write-pkg-3.2.0.tgz#0e178fe97820d389a8928bc79535dbe68c2cff21"
-  integrity sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==
-  dependencies:
-    sort-keys "^2.0.0"
-    write-json-file "^2.2.0"
 
 write@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
The commonjs build is not in use and is being removed to simplify the build

Changes include:
- remove cjs build
- remove webpack loaders that hadn't previously been removed from packages
- remove obsolete pre-commit steps
- in period-selector-dialog, put css file in same directory as js files in build/