### PR TITLE
task/remove "build" from import path of d2-ui-core components

### DIFF
--- a/packages/core/src/app/__tests__/D2UIApp.spec.js
+++ b/packages/core/src/app/__tests__/D2UIApp.spec.js
@@ -1,14 +1,11 @@
 import React from 'react';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import CircularProgress from 'material-ui/CircularProgress';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import { shallow } from 'enzyme';
 import D2UIApp from '../index';
 import {theme} from '@dhis2/d2-ui-core';
 
-const identity = v => v;
 const isNotEqualTo = first => second => first !== second;
-const MyApp = () => (<div>My App</div>);
 const d2 = {};
 
 describe('D2UIApp component', () => {

--- a/packages/org-unit-tree/src/OrgUnitTree.component.js
+++ b/packages/org-unit-tree/src/OrgUnitTree.component.js
@@ -8,7 +8,7 @@ import StopIcon from '@material-ui/icons/Stop';
 import ModelBase from 'd2/model/Model';
 import ModelCollection from 'd2/model/ModelCollection';
 
-import TreeView from '@dhis2/d2-ui-core/build/tree-view/TreeView.component';
+import TreeView from '@dhis2/d2-ui-core/tree-view/TreeView.component';
 
 
 const styles = {

--- a/packages/sharing-dialog/src/Sharing.component.js
+++ b/packages/sharing-dialog/src/Sharing.component.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Divider from '@material-ui/core/Divider';
 import Typography from '@material-ui/core/Typography';
-import Heading from '@dhis2/d2-ui-core/build/headings/Heading.component';
+import Heading from '@dhis2/d2-ui-core/headings/Heading.component';
 import UserSearch from './UserSearch.component';
 import CreatedBy from './CreatedBy.component';
 import {

--- a/packages/sharing-dialog/src/__tests__/Sharing.component.spec.js
+++ b/packages/sharing-dialog/src/__tests__/Sharing.component.spec.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import Typography from '@material-ui/core/Typography';
 import { getStubContext } from '../../../../config/inject-theme';
 import Sharing from '../Sharing.component';
-import Heading from '@dhis2/d2-ui-core/build/headings/Heading.component';
+import Heading from '@dhis2/d2-ui-core/headings/Heading.component';
 import CreatedBy from '../CreatedBy.component';
 import UserSearch from '../UserSearch.component';
 import { GroupAccess } from '../Access.component';

--- a/packages/translation-dialog/src/TranslationForm.component.js
+++ b/packages/translation-dialog/src/TranslationForm.component.js
@@ -6,7 +6,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import camelCaseToUnderscores from 'd2-utilizr/lib/camelCaseToUnderscores';
 import { Observable } from 'rxjs/Observable';
-import Store from '@dhis2/d2-ui-core/build/store/Store';
+import Store from '@dhis2/d2-ui-core/store/Store';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import LocaleSelector from './LocaleSelector.component';
 import { getLocales, getTranslationsForModel, saveTranslations } from './translationForm.actions';

--- a/packages/translation-dialog/src/translation.store.js
+++ b/packages/translation-dialog/src/translation.store.js
@@ -1,3 +1,3 @@
-import Store from '@dhis2/d2-ui-core/build/store/Store';
+import Store from '@dhis2/d2-ui-core/store/Store';
 
 export default Store.create();

--- a/packages/translation-dialog/src/translationForm.actions.js
+++ b/packages/translation-dialog/src/translationForm.actions.js
@@ -1,6 +1,6 @@
 import { getInstance } from 'd2';
 import { Observable } from 'rxjs/Observable';
-import Action from '@dhis2/d2-ui-core/build/action/Action';
+import Action from '@dhis2/d2-ui-core/action/Action';
 
 export function getLocales() {
     if (!getLocales.localePromise) {


### PR DESCRIPTION
When the package is flatpacked, the build directory will not exist.

In D2UIApp.spec.js I removed an import and some variables that are not used.

