### PR TITLE
DHIS2-5043 - Standardize and clean up dialog styles.

### DIFF
--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+
 import './App.css';
 
 import Buttons from './components/button';
@@ -38,7 +40,7 @@ import IconPicker from './components/icon-picker';
 
 import ListSelectExamples from './components/list-select.js';
 
-import {App as D2UIApp} from '@dhis2/d2-ui-core';
+import { App as D2UIApp, mui3theme as dhis2theme } from '@dhis2/d2-ui-core';
 
 /** these examples need to be rewritten */
 import OrgUnitSelect from './components/org-unit-select';
@@ -66,120 +68,121 @@ class App extends Component {
 
         return (
             <D2UIApp>
-                <header className="header">
-                    <h1 className="App-title">Welcome to the DHIS2 UI library</h1>
-                </header>
+                <MuiThemeProvider theme={createMuiTheme(dhis2theme)}>
+                    <header className="header">
+                        <h1 className="App-title">Welcome to the DHIS2 UI library</h1>
+                    </header>
 
-                <h2>HeaderBar</h2>
-                <HeaderBarExample d2={this.state.d2} />
-                <p>Look at the top of the screen...</p>
+                    <h2>HeaderBar</h2>
+                    <HeaderBarExample d2={this.state.d2} />
+                    <p>Look at the top of the screen...</p>
 
-                <h2>Rich Text</h2>
-                <RichTextExample />
+                    <h2>Rich Text</h2>
+                    <RichTextExample />
 
-                <h2>Buttons</h2>
-                <Buttons />
+                    <h2>Buttons</h2>
+                    <Buttons />
 
-                <h2>Chips</h2>
-                <Chips />
+                    <h2>Chips</h2>
+                    <Chips />
 
-                <h2>Controlbars</h2>
-                <Controlbars />
+                    <h2>Controlbars</h2>
+                    <Controlbars />
 
-                <h2>Tables</h2>
-                <Tables d2={this.state.d2} />
+                    <h2>Tables</h2>
+                    <Tables d2={this.state.d2} />
 
-                <h2>Expression Manager</h2>
-                <ExpressionManager d2={this.state.d2} />
+                    <h2>Expression Manager</h2>
+                    <ExpressionManager d2={this.state.d2} />
 
-                <h2>File Menu</h2>
-                <FileMenu d2={this.state.d2} />
+                    <h2>File Menu</h2>
+                    <FileMenu d2={this.state.d2} />
 
-                <h2>Favorites Dialog</h2>
-                <FavoritesDialog d2={this.state.d2} />
+                    <h2>Favorites Dialog</h2>
+                    <FavoritesDialog d2={this.state.d2} />
 
-                <h2>Sharing Dialog</h2>
-                <SharingDialog d2={this.state.d2} />
+                    <h2>Sharing Dialog</h2>
+                    <SharingDialog d2={this.state.d2} />
 
-                <h2>Feedback Snackbar</h2>
-                <FeedbackSnackbar />
+                    <h2>Feedback Snackbar</h2>
+                    <FeedbackSnackbar />
 
-                <h2>FormBuilder</h2>
-                <FormBuilder />
+                    <h2>FormBuilder</h2>
+                    <FormBuilder />
 
-                <h2>GroupEditor</h2>
-                <GroupEditor d2={this.state.d2} />
+                    <h2>GroupEditor</h2>
+                    <GroupEditor d2={this.state.d2} />
 
-                <h2>Layout</h2>
-                <Layout />
+                    <h2>Layout</h2>
+                    <Layout />
 
-                <h2>Legend</h2>
-                <Legend d2={this.state.d2} />
+                    <h2>Legend</h2>
+                    <Legend d2={this.state.d2} />
 
-                <h2>List Select</h2>
-                <ListSelectExamples />
+                    <h2>List Select</h2>
+                    <ListSelectExamples />
 
-                <h2>PeriodPicker</h2>
-                <PeriodPicker d2={this.state.d2} />
+                    <h2>PeriodPicker</h2>
+                    <PeriodPicker d2={this.state.d2} />
 
-                <h2>SelectField</h2>
-                <SelectField />
+                    <h2>SelectField</h2>
+                    <SelectField />
 
-                <h2>Sidebar</h2>
-                <Sidebar />
+                    <h2>Sidebar</h2>
+                    <Sidebar />
 
-                <h2>SvgIcon</h2>
-                <SvgIcon />
+                    <h2>SvgIcon</h2>
+                    <SvgIcon />
 
-                <h2>TextField</h2>
-                <TextField />
+                    <h2>TextField</h2>
+                    <TextField />
 
-                <h2>Tabs</h2>
-                <Tabs />
+                    <h2>Tabs</h2>
+                    <Tabs />
 
-                <h2>Translation</h2>
-                <Translation d2={this.state.d2} />
+                    <h2>Translation</h2>
+                    <Translation d2={this.state.d2} />
 
-                <h2>IconPicker</h2>
-                <IconPicker d2={this.state.d2} />
+                    <h2>IconPicker</h2>
+                    <IconPicker d2={this.state.d2} />
 
-                <h2>FormEditor</h2>
-                <FormEditor />
+                    <h2>FormEditor</h2>
+                    <FormEditor />
 
-                <h2>Period selector dialog</h2>
-                <PeriodSelectorDialog d2={this.state.d2} />
+                    <h2>Period selector dialog</h2>
+                    <PeriodSelectorDialog d2={this.state.d2} />
 
-                <h2>Period selector</h2>
-                <PeriodSelector d2={this.state.d2} />
+                    <h2>Period selector</h2>
+                    <PeriodSelector d2={this.state.d2} />
 
-                <h2>OrgUnitSelect</h2>
-                <OrgUnitSelect d2={this.state.d2} />
+                    <h2>OrgUnitSelect</h2>
+                    <OrgUnitSelect d2={this.state.d2} />
 
-                <h2>OrgUnitTree</h2>
-                <OrgUnitTree d2={this.state.d2} />
+                    <h2>OrgUnitTree</h2>
+                    <OrgUnitTree d2={this.state.d2} />
 
-                <h2>Org unit dialog</h2>
-                <OrgUnitDialog d2={this.state.d2} />
+                    <h2>Org unit dialog</h2>
+                    <OrgUnitDialog d2={this.state.d2} />
 
-                <h2>Org unit selector</h2>
-                <OrgUnitSelector d2={this.state.d2} />
+                    <h2>Org unit selector</h2>
+                    <OrgUnitSelector d2={this.state.d2} />
 
-                <div style={{ clear: 'both' }}>
-                    <h2>TreeViews</h2>
-                    <TreeViews />
-                </div>
+                    <div style={{ clear: 'both' }}>
+                        <h2>TreeViews</h2>
+                        <TreeViews />
+                    </div>
 
-                <div style={{ clear: 'both' }}></div>
+                    <div style={{ clear: 'both' }}></div>
 
-                <h2>Intepretations</h2>
-                <InterpretationsExample d2={this.state.d2} />
+                    <h2>Intepretations</h2>
+                    <InterpretationsExample d2={this.state.d2} />
 
-                <h2>Mentions wrapper</h2>
-                <MentionsWrapperExample d2={this.state.d2} />
+                    <h2>Mentions wrapper</h2>
+                    <MentionsWrapperExample d2={this.state.d2} />
 
-                <h2>Circular Progress</h2>
-                <CircularProgresses />
-
+                    <h2>Circular Progress</h2>
+                    <CircularProgresses />
+                </MuiThemeProvider>
             </D2UIApp>
         );
     }

--- a/packages/core/src/theme/mui3.theme.js
+++ b/packages/core/src/theme/mui3.theme.js
@@ -97,6 +97,12 @@ export const theme = {
                 fontSize: 16,
                 fontWeight: 'bold',
                 padding: `${spacingUnit * 2.5}px ${spacingUnit * 3}px ${spacingUnit * 0.5}px`,
+
+                '&>h6': { // When not specifying 'disableTypography', an h6 element is created by default beneath DialogTitle
+                    fontSize: '1em',
+                    lineHeight: 'inherit',
+                    fontWeight: 'inherit',
+                },
             },
         },
         MuiDialogContent: {

--- a/packages/favorites-dialog/src/Favorites.js
+++ b/packages/favorites-dialog/src/Favorites.js
@@ -35,7 +35,7 @@ class Favorites extends Component {
                     <EnhancedTable onFavoriteSelect={handleOnFavoriteSelect} />
                 </DialogContent>
                 <DialogActions>
-                    <Button onClick={onRequestClose}>Close</Button>
+                    <Button color="primary" onClick={onRequestClose}>Close</Button>
                 </DialogActions>
             </Dialog>
         );

--- a/packages/org-unit-dialog/src/OrgUnitDialog.js
+++ b/packages/org-unit-dialog/src/OrgUnitDialog.js
@@ -36,9 +36,9 @@ class OrgUnitDialog extends React.PureComponent {
                     handleUserOrgUnitClick={this.props.handleUserOrgUnitClick}
                 />
             </DialogContent>
-            <DialogActions style={{ padding: '24px' }}>
-                <Button onClick={this.props.onClose}>{i18n.t('Hide')}</Button>
-                <Button color="primary" onClick={this.onUpdateClick}>
+            <DialogActions>
+                <Button color="primary" onClick={this.props.onClose}>{i18n.t('Hide')}</Button>
+                <Button variant="contained" color="primary" onClick={this.onUpdateClick}>
                     {i18n.t('Update')}
                 </Button>
             </DialogActions>

--- a/packages/period-selector-dialog/src/PeriodSelectorDialog.js
+++ b/packages/period-selector-dialog/src/PeriodSelectorDialog.js
@@ -13,12 +13,6 @@ const styles = {
         paddingTop: 0,
         overflow: 'hidden',
     },
-    dialogActions: {
-        padding: '24px',
-        marginTop: 0,
-        borderTop: '1px solid #E0E0E0',
-
-    },
 };
 
 class PeriodSelectorDialog extends React.Component {
@@ -63,10 +57,10 @@ class PeriodSelectorDialog extends React.Component {
                     <PeriodSelector {...remaindingProps} />
                 </DialogContent>
                 <DialogActions style={styles.dialogActions}>
-                    <Button onClick={this.onCloseClick}>
+                    <Button color="primary" onClick={this.onCloseClick}>
                         {this.i18n.getTranslation('Hide')}
                     </Button>
-                    <Button style={{ backgroundColor: '#004BA0', color: 'white' }} onClick={this.onUpdateClick}>
+                    <Button variant="contained" color="primary" onClick={this.onUpdateClick}>
                         {this.i18n.getTranslation('Update')}
                     </Button>
                 </DialogActions>

--- a/packages/period-selector-dialog/src/PeriodSelectorDialog.js
+++ b/packages/period-selector-dialog/src/PeriodSelectorDialog.js
@@ -9,9 +9,7 @@ import PeriodSelector from './PeriodSelector';
 
 const styles = {
     dialogContent: {
-        paddingBottom: 0,
-        paddingTop: 0,
-        overflow: 'hidden',
+        overflow: 'hidden', // TODO: Reflow DOM or enforce minimum dialog sizing rather than hiding important UI elements on small screens
     },
 };
 
@@ -56,7 +54,7 @@ class PeriodSelectorDialog extends React.Component {
                 <DialogContent style={styles.dialogContent}>
                     <PeriodSelector {...remaindingProps} />
                 </DialogContent>
-                <DialogActions style={styles.dialogActions}>
+                <DialogActions>
                     <Button color="primary" onClick={this.onCloseClick}>
                         {this.i18n.getTranslation('Hide')}
                     </Button>

--- a/packages/period-selector-dialog/src/PeriodSelectorDialog.js
+++ b/packages/period-selector-dialog/src/PeriodSelectorDialog.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
+import { withStyles } from '@material-ui/core/styles';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -41,7 +43,7 @@ class PeriodSelectorDialog extends React.Component {
     };
 
     render = () => {
-        const { open, maxWidth, fullWidth, ...remaindingProps } = this.props;
+        const { classes, open, maxWidth, fullWidth, ...remaindingProps } = this.props;
 
         return (
             <Dialog
@@ -51,7 +53,7 @@ class PeriodSelectorDialog extends React.Component {
                 maxWidth={maxWidth}
             >
                 <DialogTitle>{this.i18n.getTranslation('Period')}</DialogTitle>
-                <DialogContent style={styles.dialogContent}>
+                <DialogContent className={classes.dialogContent}>
                     <PeriodSelector {...remaindingProps} />
                 </DialogContent>
                 <DialogActions>
@@ -76,6 +78,7 @@ PeriodSelectorDialog.defaultProps = {
 };
 
 PeriodSelectorDialog.propTypes = {
+    classes: PropTypes.object.isRequired,
     d2: PropTypes.object.isRequired,
     open: PropTypes.bool.isRequired,
     fullWidth: PropTypes.bool,
@@ -87,4 +90,4 @@ PeriodSelectorDialog.propTypes = {
     selectedItems: PropTypes.array,
 };
 
-export default PeriodSelectorDialog;
+export default withStyles(styles)(PeriodSelectorDialog);

--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -198,7 +198,7 @@ class SharingDialog extends React.Component {
         const errorOccurred = this.state.errorMessage !== '';
         const isLoading = !this.state.sharedObject && this.props.open && !errorOccurred;
         const sharingDialogActions = [
-            <Button key="closeonly" variant="contained" onClick={this.closeDialog}>{this.translate('close')}</Button>,
+            <Button key="closeonly" color="primary" onClick={this.closeDialog}>{this.translate('close')}</Button>,
         ];
 
         if (this.props.doNotPost) {

--- a/packages/translation-dialog/src/TranslationForm.component.js
+++ b/packages/translation-dialog/src/TranslationForm.component.js
@@ -136,7 +136,7 @@ class TranslationForm extends Component {
         return (
             <DialogActions>
                 <Button
-                    variant="contained"
+                    color="primary"
                     onClick={this.props.onCancel}
                 >{this.getTranslation('cancel')}</Button>
                 <Button


### PR DESCRIPTION
Fixes DHIS2-5043.

Changes proposed in this pull request:

- Override `DialogTitle > h6` component for consistent dialog title styling consistent with design spec
- Standardize the use of `variant="contained"` and `color="primary"` in various `d2-ui` dialog components.
- Remove several cases of custom `style={}` usage
- Use the DHIS2 Mui3 theme in the `d2-ui` create-react-app example.

