### PR TITLE
Fix IE flexbox bug and persistently-open tooltip in Favorites Dialog

### DIFF
--- a/packages/favorites-dialog/src/EnhancedToolbar.js
+++ b/packages/favorites-dialog/src/EnhancedToolbar.js
@@ -24,7 +24,7 @@ const toolbarStyles = () => ({
 
 class EnhancedToolbar extends Component {
     state = {
-        filterTooltipOpen: false,
+        filterTooltipOpen: false
     };
 
     showFilterTooltip = () => {
@@ -65,7 +65,7 @@ class EnhancedToolbar extends Component {
                         onMouseEnter={this.showFilterTooltip}
                         onMouseLeave={this.hideFilterTooltip}
                         MenuProps={{
-                            onEnter: this.hideFilterTooltip,
+                            onEnter: this.hideFilterTooltip
                         }}
                     >
                         <MenuItem value="all">Show all</MenuItem>
@@ -80,15 +80,15 @@ class EnhancedToolbar extends Component {
 
 const mapStateToProps = state => ({
     createdByValue: state.filtering.createdByValue,
-    searchValue: state.filtering.searchValue,
+    searchValue: state.filtering.searchValue
 });
 
 const mapDispatchToProps = {
     searchData,
-    filterData,
+    filterData
 };
 
 export default connect(
     mapStateToProps,
-    mapDispatchToProps,
+    mapDispatchToProps
 )(withStyles(toolbarStyles)(EnhancedToolbar));

--- a/packages/favorites-dialog/src/EnhancedToolbar.js
+++ b/packages/favorites-dialog/src/EnhancedToolbar.js
@@ -1,59 +1,82 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { Component } from "react";
+import { connect } from "react-redux";
 
-import { withStyles } from '@material-ui/core/styles';
-import MenuItem from '@material-ui/core/MenuItem';
-import Select from '@material-ui/core/Select';
-import TextField from '@material-ui/core/TextField';
-import Toolbar from '@material-ui/core/Toolbar';
-import Tooltip from '@material-ui/core/Tooltip';
+import { withStyles } from "@material-ui/core/styles";
+import MenuItem from "@material-ui/core/MenuItem";
+import Select from "@material-ui/core/Select";
+import TextField from "@material-ui/core/TextField";
+import Toolbar from "@material-ui/core/Toolbar";
+import Tooltip from "@material-ui/core/Tooltip";
 
-import { filterData, searchData } from './actions';
+import { filterData, searchData } from "./actions";
 
 const toolbarStyles = () => ({
     search: {
-        flex: '0 0 auto',
+        flex: "0 0 auto"
     },
     spacer: {
-        flex: '1 1 100%',
+        flex: "1 1 100%"
     },
+    filter: {
+        flex: "0 0 auto"
+    }
 });
 
-let EnhancedToolbar = props => {
-    const {
-        classes,
-        createdByValue,
-        searchValue,
-        searchData,
-        filterData,
-    } = props;
+class EnhancedToolbar extends Component {
+    state = {
+        filterTooltipOpen: false,
+    };
 
-    return (
-        <Toolbar>
-            <TextField
-                type="search"
-                label="Search by name"
-                className={classes.search}
-                value={searchValue}
-                onChange={searchData}
-            />
-            <div className={classes.spacer} />
-            <Tooltip title="Filter list">
-                <Select
-                    disableUnderline={true}
-                    value={createdByValue}
-                    onChange={filterData}
+    showFilterTooltip = () => {
+        this.setState({ filterTooltipOpen: true });
+    };
+    hideFilterTooltip = () => {
+        this.setState({ filterTooltipOpen: false });
+    };
+
+    render() {
+        const {
+            classes,
+            createdByValue,
+            searchValue,
+            searchData,
+            filterData
+        } = this.props;
+
+        return (
+            <Toolbar>
+                <TextField
+                    type="search"
+                    label="Search by name"
+                    className={classes.search}
+                    value={searchValue}
+                    onChange={searchData}
+                />
+                <div className={classes.spacer} />
+                <Tooltip
+                    className={classes.filter}
+                    title="Filter list"
+                    open={this.state.filterTooltipOpen}
                 >
-                    <MenuItem value="all">Show all</MenuItem>
-                    <MenuItem value="byme">Created by me</MenuItem>
-                    <MenuItem value="byothers">Created by others</MenuItem>
-                </Select>
-            </Tooltip>
-        </Toolbar>
-    );
-};
-
-EnhancedToolbar = withStyles(toolbarStyles)(EnhancedToolbar);
+                    <Select
+                        disableUnderline
+                        value={createdByValue}
+                        onChange={filterData}
+                        onMouseEnter={this.showFilterTooltip}
+                        onMouseLeave={this.hideFilterTooltip}
+                        MenuProps={{
+                            onEnter: this.hideFilterTooltip,
+                        }}
+                    >
+                        <MenuItem value="all">Show all</MenuItem>
+                        <MenuItem value="byme">Created by me</MenuItem>
+                        <MenuItem value="byothers">Created by others</MenuItem>
+                    </Select>
+                </Tooltip>
+            </Toolbar>
+        );
+    }
+}
 
 const mapStateToProps = state => ({
     createdByValue: state.filtering.createdByValue,
@@ -65,4 +88,7 @@ const mapDispatchToProps = {
     filterData,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(EnhancedToolbar);
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(withStyles(toolbarStyles)(EnhancedToolbar));


### PR DESCRIPTION
This PR does two things within Favorites Dialog:
- Fix an issue in Internet Explorer which defaults to `flex-shrink: 1` (unlike chrome which defaults to `flex-shrink: 0` and so was compressing the Select field
- Make the ToolTip around the Filter select field a controlled input so we can hide it when the select menu is open - previously the tooltip would stick on top of the menu causing mouse input issues or flickering and would also never be properly dismissed.

*NB*: Also did a prettify pass, though the settings seem a bit weird in d2-ui...