### PR TITLE
Task/update theme

### DIFF
--- a/packages/core/src/theme/mui3.theme.js
+++ b/packages/core/src/theme/mui3.theme.js
@@ -9,7 +9,7 @@ export const colors = {
     accentSecondaryDark: '#004C40',
     accentSecondaryLight: '#48A999',
     accentSecondaryLightest: '#B2DFDB',
-    accentSecondaryTransparent: '#D9ECEB',
+    accentSecondaryBackground: '#D9ECEB',
 
     black: '#000000',
     greyBlack: '#494949',
@@ -23,12 +23,6 @@ export const colors = {
     warning: '#F19C02',
     positive: '#3D9305',
     info: '#EAF4FF',
-
-    // TODO remove these?
-    paleGrey: '#FAFAFA',
-    lightGrey: '#F5F5F5',
-    charcoalGrey: '#CCCCCC',
-    blue: '#004BA0',
 };
 
 export const palette = {
@@ -153,10 +147,10 @@ export const theme = {
                 paddingBottom: spacingUnit,
                 fontSize: '15px',
                 '&$selected': {
-                    backgroundColor: colors.accentSecondaryTransparent,
+                    backgroundColor: colors.accentSecondaryBackground,
                 },
                 '&:hover': {
-                    backgroundColor: colors.lightGrey,
+                    backgroundColor: '#FAFAFA', // TODO: Make a theme color
                 },
                 [childSelectorMuiTypography]: {
                     fontSize: 'inherit',

--- a/packages/core/src/theme/mui3.theme.js
+++ b/packages/core/src/theme/mui3.theme.js
@@ -9,6 +9,7 @@ export const colors = {
     accentSecondaryDark: '#004C40',
     accentSecondaryLight: '#48A999',
     accentSecondaryLightest: '#B2DFDB',
+    accentSecondaryTransparent: '#D9ECEB',
 
     black: '#000000',
     greyBlack: '#494949',
@@ -22,6 +23,12 @@ export const colors = {
     warning: '#F19C02',
     positive: '#3D9305',
     info: '#EAF4FF',
+
+    // TODO remove these?
+    paleGrey: '#FAFAFA',
+    lightGrey: '#F5F5F5',
+    charcoalGrey: '#CCCCCC',
+    blue: '#004BA0',
 };
 
 export const palette = {
@@ -74,7 +81,8 @@ export const palette = {
 };
 
 const spacingUnit = 8;
-
+const childSelectorMuiTypography =
+    '& span[class^="MuiTypography"], & span[class*=" MuiTypography"]';
 export const theme = {
     colors,
     palette,
@@ -124,6 +132,40 @@ export const theme = {
                 '&> *:last-child': {
                     marginRight: 0,
                 },
+            },
+        },
+        MuiInput: {
+            underline: {
+                '&:after': {
+                    borderBottom: '1px solid #aaa',
+                },
+                '&:before': {
+                    borderBottom: `1px solid ${colors.greyLight}`,
+                },
+                '&:hover:not($disabled):not($focused):not($error):before': {
+                    borderBottom: `1px solid ${colors.greyLight}`,
+                },
+            },
+        },
+        MuiMenuItem: {
+            root: {
+                paddingTop: spacingUnit,
+                paddingBottom: spacingUnit,
+                fontSize: '15px',
+                '&$selected': {
+                    backgroundColor: colors.accentSecondaryTransparent,
+                },
+                '&:hover': {
+                    backgroundColor: colors.lightGrey,
+                },
+                [childSelectorMuiTypography]: {
+                    fontSize: 'inherit',
+                },
+            },
+        },
+        MuiListItem: {
+            button: {
+                transition: 'none',
             },
         },
     },

--- a/packages/core/src/theme/mui3.theme.js
+++ b/packages/core/src/theme/mui3.theme.js
@@ -165,7 +165,7 @@ export const theme = {
         },
         MuiListItem: {
             button: {
-                transition: 'none',
+                transitionDuration: '0s',
             },
         },
     },


### PR DESCRIPTION
Move theme customizations from Data Visualizer into `d2-ui` for use across apps.

**NB** I removed the `overflow: hidden` properties from Dialog Content because it makes FileMenu dialogs unusable on small screens, we should remove that from the theme in Data Visualizer as well. @joakimia I think that came from a change you made originally?  We should probably move the `overflow: hidden` into the specific Dialog implementations you were targeting or remove it completely.

This change does the following for MenuItems, including File Menu:

- No fade-in transitions on hover
- Smaller padding between items
- Smaller font size (15px)
- Blue-background "selected" style for MUI Select menu items

File menu before:

![screenshot 2018-11-22 10 58 44](https://user-images.githubusercontent.com/947888/48897505-8fa8e000-ee4a-11e8-8754-602d402761bf.png)

File menu after:

![screenshot 2018-11-22 10 57 28](https://user-images.githubusercontent.com/947888/48897513-95062a80-ee4a-11e8-82c7-82efce3cdfe0.png)
