### PR TITLE
set maxWidth on Dialogs for FileMenu and add Override rules for Material-UI Dialog  

### DIFF
--- a/examples/create-react-app/src/components/file-menu.js
+++ b/examples/create-react-app/src/components/file-menu.js
@@ -53,6 +53,7 @@ export default class FileMenuExample extends React.Component {
                 onWriteInterpretation={this.onFileMenuAction('Write interpretation')}
                 onDelete={this.onFileMenuAction('Delete')}
                 onError={this.onFileMenuError}
+                dialogMaxWidth="lg"
             />
             <Snackbar
                 open={this.state.snackbar.open}

--- a/packages/core/src/theme/mui3.theme.js
+++ b/packages/core/src/theme/mui3.theme.js
@@ -94,6 +94,23 @@ export const theme = {
                 backgroundColor: palette.divider, // No light dividers for now
             },
         },
+        MuiDialog: {
+            paperWidthSm: {
+                minWidth: 400,
+                width: 400,
+                maxWidth: 400,
+            },
+            paperWidthMd: {
+                minWidth: 600,
+                width: 600,
+                maxWidth: 600,
+            },
+            paperWidthLg: {
+                minWidth: 800,
+                width: 800,
+                maxWidth: 800,
+            },
+        },
         MuiDialogTitle: {
             root: {
                 fontSize: 16,
@@ -125,6 +142,13 @@ export const theme = {
 
                 '&> *:last-child': {
                     marginRight: 0,
+                },
+            },
+        },
+        MuiSelect: {
+            select: {
+                '&:focus': {
+                    background: '$labelcolor',
                 },
             },
         },

--- a/packages/favorites-dialog/src/Favorites.js
+++ b/packages/favorites-dialog/src/Favorites.js
@@ -21,7 +21,7 @@ class Favorites extends Component {
     }
 
     render() {
-        const { open, onRequestClose, onFavoriteSelect, dialogMaxWidth } = this.props;
+        const { open, onRequestClose, onFavoriteSelect } = this.props;
 
         const handleOnFavoriteSelect = (id) => {
             onFavoriteSelect(id);
@@ -30,7 +30,7 @@ class Favorites extends Component {
         };
 
         return (
-            <Dialog open={open} onClose={onRequestClose} disableEnforceFocus maxWidth={dialogMaxWidth}>
+            <Dialog open={open} onClose={onRequestClose} disableEnforceFocus maxWidth="lg">
                 <DialogContent>
                     <EnhancedToolbar />
                     <EnhancedTable onFavoriteSelect={handleOnFavoriteSelect} />
@@ -47,11 +47,9 @@ Favorites.propTypes = {
     open: PropTypes.bool.isRequired,
     onRequestClose: PropTypes.func.isRequired,
     onFavoriteSelect: PropTypes.func.isRequired,
-    dialogMaxWidth: PropTypes.string.isRequired,
     dataIsLoaded: PropTypes.bool.isRequired,
     refreshData: PropTypes.bool.isRequired,
     fetchData: PropTypes.func.isRequired,
-
 };
 
 const mapStateToProps = state => ({

--- a/packages/favorites-dialog/src/Favorites.js
+++ b/packages/favorites-dialog/src/Favorites.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -20,16 +21,16 @@ class Favorites extends Component {
     }
 
     render() {
-        const { open, onRequestClose, onFavoriteSelect } = this.props;
+        const { open, onRequestClose, onFavoriteSelect, dialogMaxWidth } = this.props;
 
-        const handleOnFavoriteSelect = id => {
+        const handleOnFavoriteSelect = (id) => {
             onFavoriteSelect(id);
             // XXX should this be in the favoriteSelect callback?
             onRequestClose();
         };
 
         return (
-            <Dialog open={open} onClose={onRequestClose} disableEnforceFocus={true} maxWidth="md">
+            <Dialog open={open} onClose={onRequestClose} disableEnforceFocus maxWidth={dialogMaxWidth}>
                 <DialogContent>
                     <EnhancedToolbar />
                     <EnhancedTable onFavoriteSelect={handleOnFavoriteSelect} />
@@ -42,6 +43,17 @@ class Favorites extends Component {
     }
 }
 
+Favorites.propTypes = {
+    open: PropTypes.bool.isRequired,
+    onRequestClose: PropTypes.func.isRequired,
+    onFavoriteSelect: PropTypes.func.isRequired,
+    dialogMaxWidth: PropTypes.string.isRequired,
+    dataIsLoaded: PropTypes.bool.isRequired,
+    refreshData: PropTypes.bool.isRequired,
+    fetchData: PropTypes.func.isRequired,
+
+};
+
 const mapStateToProps = state => ({
     dataIsLoaded: state.data.totalRecords > 0,
 });
@@ -52,5 +64,5 @@ const mapDispatchToProps = {
 
 export default connect(
     mapStateToProps,
-    mapDispatchToProps
+    mapDispatchToProps,
 )(Favorites);

--- a/packages/favorites-dialog/src/FavoritesDialog.js
+++ b/packages/favorites-dialog/src/FavoritesDialog.js
@@ -31,7 +31,7 @@ class FavoritesDialog extends Component {
     }
 
     render() {
-        const { open, type, onFavoriteSelect, onRequestClose, refreshData, dialogMaxWidth } = this.props;
+        const { open, type, onFavoriteSelect, onRequestClose, refreshData } = this.props;
 
         return (
             <Provider store={store}>
@@ -41,7 +41,6 @@ class FavoritesDialog extends Component {
                     refreshData={refreshData}
                     onFavoriteSelect={onFavoriteSelect}
                     onRequestClose={onRequestClose}
-                    dialogMaxWidth={dialogMaxWidth}
                 />
             </Provider>
         );
@@ -49,7 +48,6 @@ class FavoritesDialog extends Component {
 }
 
 FavoritesDialog.defaultProps = {
-    dialogMaxWidth: 'md',
     refreshData: false,
 };
 
@@ -60,7 +58,6 @@ FavoritesDialog.propTypes = {
     d2: PropTypes.object.isRequired,
     onRequestClose: PropTypes.func.isRequired,
     onFavoriteSelect: PropTypes.func.isRequired,
-    dialogMaxWidth: PropTypes.string,
 };
 
 FavoritesDialog.childContextTypes = {

--- a/packages/favorites-dialog/src/FavoritesDialog.js
+++ b/packages/favorites-dialog/src/FavoritesDialog.js
@@ -31,7 +31,7 @@ class FavoritesDialog extends Component {
     }
 
     render() {
-        const { open, type, onFavoriteSelect, onRequestClose, refreshData } = this.props;
+        const { open, type, onFavoriteSelect, onRequestClose, refreshData, dialogMaxWidth } = this.props;
 
         return (
             <Provider store={store}>
@@ -41,11 +41,27 @@ class FavoritesDialog extends Component {
                     refreshData={refreshData}
                     onFavoriteSelect={onFavoriteSelect}
                     onRequestClose={onRequestClose}
+                    dialogMaxWidth={dialogMaxWidth}
                 />
             </Provider>
         );
     }
 }
+
+FavoritesDialog.defaultProps = {
+    dialogMaxWidth: 'md',
+    refreshData: false,
+};
+
+FavoritesDialog.propTypes = {
+    open: PropTypes.bool.isRequired,
+    refreshData: PropTypes.bool,
+    type: PropTypes.oneOf(['chart', 'eventChart', 'reportTable', 'eventReport', 'map']).isRequired,
+    d2: PropTypes.object.isRequired,
+    onRequestClose: PropTypes.func.isRequired,
+    onFavoriteSelect: PropTypes.func.isRequired,
+    dialogMaxWidth: PropTypes.string,
+};
 
 FavoritesDialog.childContextTypes = {
     d2: PropTypes.object.isRequired,

--- a/packages/favorites-dialog/src/index.js
+++ b/packages/favorites-dialog/src/index.js
@@ -1,2 +1,3 @@
-import FavoritesDialog from './FavoritesDialog'
-export default FavoritesDialog
+import FavoritesDialog from './FavoritesDialog';
+
+export default FavoritesDialog;

--- a/packages/file-menu/src/DeleteDialog.js
+++ b/packages/file-menu/src/DeleteDialog.js
@@ -10,7 +10,7 @@ import Button from '@material-ui/core/Button';
 import i18n from '@dhis2/d2-i18n';
 import { getFileTypeLabel } from './util';
 
-const DeleteDialog = props => {
+const DeleteDialog = (props) => {
     const {
         open,
         fileType,
@@ -30,7 +30,7 @@ const DeleteDialog = props => {
     };
 
     return (
-        <Dialog open={open} onClose={onRequestClose} maxWidth={false}>
+        <Dialog open={open} onClose={onRequestClose} maxWidth="sm">
             <DialogTitle>
                 {i18n.t('Delete {{what}}', { what: getFileTypeLabel(fileType) })}
             </DialogTitle>

--- a/packages/file-menu/src/FileMenu.js
+++ b/packages/file-menu/src/FileMenu.js
@@ -40,13 +40,13 @@ export class FileMenu extends Component {
         }
     };
 
-    componentDidUpdate = prevProps => {
+    componentDidUpdate = (prevProps) => {
         if (this.props.fileId && prevProps.fileId !== this.props.fileId) {
             this.setFileModel(this.props.fileId);
         }
     };
 
-    setFileModel = async id => {
+    setFileModel = async (id) => {
         const model = await this.props.d2.models[this.props.fileType].get(id);
         this.setState({ fileModel: model });
     };
@@ -55,7 +55,7 @@ export class FileMenu extends Component {
         this.setState({ fileModel: null });
     };
 
-    toggleMenu = event => {
+    toggleMenu = (event) => {
         this.setState({
             menuIsOpen: !this.state.menuIsOpen,
             anchorEl: this.state.menuIsOpen ? null : event.currentTarget,
@@ -69,7 +69,7 @@ export class FileMenu extends Component {
         });
     };
 
-    onOpen = id => {
+    onOpen = (id) => {
         this.setFileModel(id);
         this.setState({ refreshDialogData: false });
 
@@ -97,7 +97,7 @@ export class FileMenu extends Component {
         this.props.onNew();
     };
 
-    onDelete = id => {
+    onDelete = (id) => {
         if (this.state.fileModel.id === id) {
             this.clearFileModel();
             this.setState({ refreshDialogData: true });
@@ -108,7 +108,7 @@ export class FileMenu extends Component {
         }
     };
 
-    onAction = (callback, refreshDialogData) => args => {
+    onAction = (callback, refreshDialogData) => (args) => {
         this.closeMenu();
 
         if (refreshDialogData) {
@@ -121,7 +121,7 @@ export class FileMenu extends Component {
     };
 
     render() {
-        const { classes, fileType, onSave, onSaveAs, onTranslate, onShare, onError } = this.props;
+        const { classes, fileType, onSave, onSaveAs, onTranslate, onShare, onError, dialogMaxWidth } = this.props;
 
         return (
             <Fragment>
@@ -136,7 +136,7 @@ export class FileMenu extends Component {
                     anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
                     getContentAnchorEl={null}
                 >
-                    <NewMenuItem enabled={true} onNew={this.onNew} />
+                    <NewMenuItem enabled onNew={this.onNew} />
                     <Divider light />
 
                     <OpenMenuItem
@@ -147,13 +147,14 @@ export class FileMenu extends Component {
                         onClose={this.onAction()}
                         onRename={this.onRename}
                         onDelete={this.onDelete}
+                        dialogMaxWidth={dialogMaxWidth}
                     />
 
                     <Divider />
                     <SaveMenuItem
                         enabled={Boolean(
                             !this.state.fileModel ||
-                                (this.state.fileModel && this.state.fileModel.access.update)
+                                (this.state.fileModel && this.state.fileModel.access.update),
                         )}
                         fileType={fileType}
                         fileModel={this.state.fileModel}
@@ -171,7 +172,7 @@ export class FileMenu extends Component {
                     <Divider />
                     <RenameMenuItem
                         enabled={Boolean(
-                            this.state.fileModel && this.state.fileModel.access.update
+                            this.state.fileModel && this.state.fileModel.access.update,
                         )}
                         fileType={fileType}
                         fileModel={this.state.fileModel}
@@ -181,7 +182,7 @@ export class FileMenu extends Component {
                     />
                     <TranslateMenuItem
                         enabled={Boolean(
-                            this.state.fileModel && this.state.fileModel.access.update
+                            this.state.fileModel && this.state.fileModel.access.update,
                         )}
                         fileModel={this.state.fileModel}
                         onTranslate={this.onAction(onTranslate)}
@@ -191,7 +192,7 @@ export class FileMenu extends Component {
                     <Divider />
                     <ShareMenuItem
                         enabled={Boolean(
-                            this.state.fileModel && this.state.fileModel.access.manage
+                            this.state.fileModel && this.state.fileModel.access.manage,
                         )}
                         fileType={fileType}
                         fileModel={this.state.fileModel}
@@ -207,7 +208,7 @@ export class FileMenu extends Component {
                     <Divider />
                     <DeleteMenuItem
                         enabled={Boolean(
-                            this.state.fileModel && this.state.fileModel.access.delete
+                            this.state.fileModel && this.state.fileModel.access.delete,
                         )}
                         fileType={fileType}
                         fileModel={this.state.fileModel}
@@ -226,6 +227,7 @@ FileMenu.childContextTypes = {
 };
 
 FileMenu.defaultProps = {
+    dialogMaxWidth: 'md',
     d2: null,
     fileType: 'chart',
     fileId: null,
@@ -241,6 +243,7 @@ FileMenu.defaultProps = {
 };
 
 FileMenu.propTypes = {
+    dialogMaxWidth: PropTypes.oneOf(['sm', 'md', 'lg']),
     d2: PropTypes.object,
     fileType: PropTypes.oneOf(['chart', 'eventChart', 'reportTable', 'eventReport', 'map']),
     fileId: PropTypes.string,

--- a/packages/file-menu/src/FileMenu.js
+++ b/packages/file-menu/src/FileMenu.js
@@ -46,29 +46,6 @@ export class FileMenu extends Component {
         }
     };
 
-    setFileModel = async (id) => {
-        const model = await this.props.d2.models[this.props.fileType].get(id);
-        this.setState({ fileModel: model });
-    };
-
-    clearFileModel = () => {
-        this.setState({ fileModel: null });
-    };
-
-    toggleMenu = (event) => {
-        this.setState({
-            menuIsOpen: !this.state.menuIsOpen,
-            anchorEl: this.state.menuIsOpen ? null : event.currentTarget,
-        });
-    };
-
-    closeMenu = () => {
-        this.setState({
-            menuIsOpen: false,
-            anchorEl: null,
-        });
-    };
-
     onOpen = (id) => {
         this.setFileModel(id);
         this.setState({ refreshDialogData: false });
@@ -120,8 +97,31 @@ export class FileMenu extends Component {
         }
     };
 
+    setFileModel = async (id) => {
+        const model = await this.props.d2.models[this.props.fileType].get(id);
+        this.setState({ fileModel: model });
+    };
+
+    clearFileModel = () => {
+        this.setState({ fileModel: null });
+    };
+
+    toggleMenu = (event) => {
+        this.setState({
+            menuIsOpen: !this.state.menuIsOpen,
+            anchorEl: this.state.menuIsOpen ? null : event.currentTarget,
+        });
+    };
+
+    closeMenu = () => {
+        this.setState({
+            menuIsOpen: false,
+            anchorEl: null,
+        });
+    };
+
     render() {
-        const { classes, fileType, onSave, onSaveAs, onTranslate, onShare, onError, dialogMaxWidth } = this.props;
+        const { classes, fileType, onSave, onSaveAs, onTranslate, onShare, onError } = this.props;
 
         return (
             <Fragment>
@@ -147,7 +147,6 @@ export class FileMenu extends Component {
                         onClose={this.onAction()}
                         onRename={this.onRename}
                         onDelete={this.onDelete}
-                        dialogMaxWidth={dialogMaxWidth}
                     />
 
                     <Divider />
@@ -227,7 +226,6 @@ FileMenu.childContextTypes = {
 };
 
 FileMenu.defaultProps = {
-    dialogMaxWidth: 'md',
     d2: null,
     fileType: 'chart',
     fileId: null,
@@ -243,7 +241,6 @@ FileMenu.defaultProps = {
 };
 
 FileMenu.propTypes = {
-    dialogMaxWidth: PropTypes.oneOf(['sm', 'md', 'lg']),
     d2: PropTypes.object,
     fileType: PropTypes.oneOf(['chart', 'eventChart', 'reportTable', 'eventReport', 'map']),
     fileId: PropTypes.string,

--- a/packages/file-menu/src/GetLinkDialog.js
+++ b/packages/file-menu/src/GetLinkDialog.js
@@ -47,7 +47,7 @@ const GetLinkDialog = (props, context) => {
     const { open, fileType, fileModel, onRequestClose } = props;
 
     return (
-        <Dialog open={open} onClose={onRequestClose}>
+        <Dialog open={open} onClose={onRequestClose} maxWidth="md">
             <DialogContent>
                 <DialogContentText>
                     {i18n.t('Open in this app')}

--- a/packages/file-menu/src/GetLinkDialog.js
+++ b/packages/file-menu/src/GetLinkDialog.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import Dialog from '@material-ui/core/Dialog';

--- a/packages/file-menu/src/OpenMenuItem.js
+++ b/packages/file-menu/src/OpenMenuItem.js
@@ -35,7 +35,7 @@ class OpenMenuItem extends Component {
     };
 
     render() {
-        const { refreshDialogData, fileType, onRename, onDelete, dialogMaxWidth } = this.props;
+        const { refreshDialogData, fileType, onRename, onDelete } = this.props;
 
         return (
             <Fragment>
@@ -54,7 +54,6 @@ class OpenMenuItem extends Component {
                     onFavoriteSelect={this.onOpen}
                     onFavoriteRename={onRename}
                     onFavoriteDelete={onDelete}
-                    dialogMaxWidth={dialogMaxWidth}
                 />
             </Fragment>
         );
@@ -72,7 +71,6 @@ OpenMenuItem.defaultProps = {
     onClose: Function.prototype,
     onRename: Function.prototype,
     onDelete: Function.prototype,
-    dialogMaxWidth: 'md',
 };
 
 OpenMenuItem.propTypes = {
@@ -82,7 +80,6 @@ OpenMenuItem.propTypes = {
     onClose: PropTypes.func,
     onRename: PropTypes.func,
     onDelete: PropTypes.func,
-    dialogMaxWidth: PropTypes.oneOf(['sm', 'md', 'lg']),
 };
 
 export default OpenMenuItem;

--- a/packages/file-menu/src/OpenMenuItem.js
+++ b/packages/file-menu/src/OpenMenuItem.js
@@ -24,7 +24,7 @@ class OpenMenuItem extends Component {
         this.props.onClose();
     };
 
-    onOpen = id => {
+    onOpen = (id) => {
         this.toggleFavoritesDialog();
 
         this.props.onOpen(id);
@@ -35,7 +35,7 @@ class OpenMenuItem extends Component {
     };
 
     render() {
-        const { refreshDialogData, fileType, onRename, onDelete } = this.props;
+        const { refreshDialogData, fileType, onRename, onDelete, dialogMaxWidth } = this.props;
 
         return (
             <Fragment>
@@ -54,6 +54,7 @@ class OpenMenuItem extends Component {
                     onFavoriteSelect={this.onOpen}
                     onFavoriteRename={onRename}
                     onFavoriteDelete={onDelete}
+                    dialogMaxWidth={dialogMaxWidth}
                 />
             </Fragment>
         );
@@ -65,21 +66,23 @@ OpenMenuItem.contextTypes = {
 };
 
 OpenMenuItem.defaultProps = {
-    refreshData: false,
     fileType: null,
+    refreshDialogData: false,
     onOpen: Function.prototype,
     onClose: Function.prototype,
     onRename: Function.prototype,
     onDelete: Function.prototype,
+    dialogMaxWidth: 'md',
 };
 
 OpenMenuItem.propTypes = {
-    refreshData: PropTypes.bool,
     fileType: PropTypes.oneOf(['chart', 'eventChart', 'reportTable', 'eventReport', 'map']),
+    refreshDialogData: PropTypes.bool,
     onOpen: PropTypes.func,
     onClose: PropTypes.func,
     onRename: PropTypes.func,
     onDelete: PropTypes.func,
+    dialogMaxWidth: PropTypes.oneOf(['sm', 'md', 'lg']),
 };
 
 export default OpenMenuItem;

--- a/packages/file-menu/src/RenameDialog.js
+++ b/packages/file-menu/src/RenameDialog.js
@@ -40,7 +40,7 @@ class RenameDialog extends Component {
         this.props.onRequestClose();
     };
 
-    handleChange = field => event => {
+    handleChange = field => (event) => {
         event.preventDefault();
 
         this.setState({
@@ -48,7 +48,7 @@ class RenameDialog extends Component {
         });
     };
 
-    handleSubmit = async event => {
+    handleSubmit = async (event) => {
         event.preventDefault();
 
         const { fileModel, onRequestRename, onRequestRenameError } = this.props;
@@ -68,7 +68,7 @@ class RenameDialog extends Component {
                 if (payload.name) {
                     const response = await this.context.d2.Api.getApi().patch(
                         fileModel.href,
-                        payload
+                        payload,
                     );
 
                     if (response.status === 'ERROR') {

--- a/packages/file-menu/src/SaveAsDialog.js
+++ b/packages/file-menu/src/SaveAsDialog.js
@@ -40,7 +40,7 @@ class SaveAsDialog extends Component {
         this.props.onRequestClose();
     };
 
-    handleChange = field => event => {
+    handleChange = field => (event) => {
         event.preventDefault();
 
         this.setState({
@@ -48,7 +48,7 @@ class SaveAsDialog extends Component {
         });
     };
 
-    handleSubmit = event => {
+    handleSubmit = (event) => {
         event.preventDefault();
 
         if (this.props.onRequestSaveAs) {

--- a/packages/file-menu/src/SaveAsMenuItem.js
+++ b/packages/file-menu/src/SaveAsMenuItem.js
@@ -26,7 +26,7 @@ class SaveAsMenuItem extends Component {
         }
     };
 
-    onSaveAs = form => {
+    onSaveAs = (form) => {
         this.toggleSaveAsDialog();
 
         if (this.props.onSaveAs) {

--- a/packages/file-menu/src/TranslateMenuItem.js
+++ b/packages/file-menu/src/TranslateMenuItem.js
@@ -26,7 +26,7 @@ class TranslateMenuItem extends Component {
         }
     };
 
-    onDialogReturn = success => args => {
+    onDialogReturn = success => (args) => {
         const { onTranslate, onTranslateError } = this.props;
 
         this.toggleTranslationDialog();

--- a/packages/period-selector-dialog/css/PeriodSelector.css
+++ b/packages/period-selector-dialog/css/PeriodSelector.css
@@ -22,13 +22,13 @@ button.nav-button {
 
 .block.options {
     width: 50%;
-    height: 460px;
+    height: 100%;
     border: 1px solid #e8e8e8;
 }
 
 .block.selected-periods {
     width: 38%;
-    height: 460px;
+    height: 100%;
     vertical-align: top;
     border: 1px solid #e8e8e8;
 }

--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -223,7 +223,7 @@ class SharingDialog extends React.Component {
                     autoHideDuration={3000}
                 />
                 <Dialog
-                    PaperProps={{ style: { width: '75%', maxWidth: '768px' } }}
+                    maxWidth="lg"
                     onClose={this.closeDialog}
                     {...this.muiDialogProps()}
                 >

--- a/packages/translation-dialog/src/TranslationDialog.component.js
+++ b/packages/translation-dialog/src/TranslationDialog.component.js
@@ -45,7 +45,11 @@ class TranslationDialog extends Component {
 
     render() {
         return (
-            <Dialog onClose={this.closeDialog} PaperProps={{ style: { width: '75%', maxWidth: '768px' } }} {...this.muiDialogProps()}>
+            <Dialog
+                onClose={this.closeDialog}
+                maxWidth="lg"
+                {...this.muiDialogProps()}
+            >
                 <DialogTitle id="form-dialog-title">{this.i18n.getTranslation('translation_dialog_title')}</DialogTitle>
                 <TranslationFormWithData
                     model={this.props.objectToTranslate}
@@ -58,6 +62,10 @@ class TranslationDialog extends Component {
         );
     }
 }
+
+TranslationDialog.defaultProps = {
+    fieldsToTranslate: [],
+};
 
 TranslationDialog.propTypes = {
     objectToTranslate: PropTypes.shape({


### PR DESCRIPTION
This PR is a dependency of, and related to Data Visualizer's: [Task/options dialog styling [DHIS2-5204] [DHIS2-5224] #136](https://github.com/dhis2/data-visualizer-app/pull/136).

In DV PR #136, consistent dialog sizes are specified by overriding [Material-UI's CSS API for Paper](https://material-ui.com/api/dialog/):

Specifically:
**paperWidthSm:** _Styles applied to the Paper component if maxWidth="sm"._
**paperWidthMd:** _Styles applied to the Paper component if maxWidth="md"._
**paperWidthLg:**  _Styles applied to the Paper component if maxWidth="lg"._

Small = maxWidth: 400px
Medium = maxWidth: 600px
Large = maxWidth: 800px

**No fixed height have been defined/ added to the override rules as of yet, it is currently defined by its content/material-ui component.**

The width are defined according to design document
https://projects.invisionapp.com/share/A7LT4TJYETS#/screens/331513972
https://projects.invisionapp.com/share/A7LT4TJYETS#/screens/331525334_d2ui-Molecules-Modal

More details are described in the DV PR.

Other info:
Since no height is specified in the Dialog, the height will be set dynamically (We can set Fixed heights / flex rules in _mui3.theme.js_ )  