### PR TITLE
Fix/periods selector dialog

### DIFF
--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -16,7 +16,7 @@
     "prebuild": "rimraf ./build/*",
     "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js && npm run build:css",
     "build:css": "cp -R ./css/* ./build/",
-    "watch": "npm run build --  --watch",
+    "watch": "npm run build --watch",
     "test-ci": "jest --config=../../jest.config.js packages/period-selector-dialog",
     "test:watch": "npm test -- --watch"
   },

--- a/packages/period-selector-dialog/src/FixedPeriods.js
+++ b/packages/period-selector-dialog/src/FixedPeriods.js
@@ -32,7 +32,10 @@ class FixedPeriods extends Component {
     }
 
     componentDidMount = () => {
-        this.props.setOfferedPeriods(this.generatePeriods(this.state.periodType, this.state.year));
+        const periods = this.generatePeriods(this.state.periodType, this.state.year);
+        const selectedIds = this.props.selectedItems.map(period => period.id);
+
+        this.props.setOfferedPeriods(periods.filter(period => !selectedIds.includes(period.id)));
     };
 
     onPeriodTypeChange = (event) => {
@@ -205,6 +208,7 @@ class FixedPeriods extends Component {
 
 FixedPeriods.propTypes = {
     items: PropTypes.array.isRequired,
+    selectedItems: PropTypes.array.isRequired,
     onDoubleClick: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,

--- a/packages/period-selector-dialog/src/PeriodListItem.js
+++ b/packages/period-selector-dialog/src/PeriodListItem.js
@@ -27,7 +27,6 @@ RemoveItemButton.propTypes = {
 class PeriodListItem extends Component {
     state = { isHovering: false };
 
-
     onPeriodClick = (event) => {
         this.props.onPeriodClick(this.props.period, this.props.index, event.shiftKey, event.metaKey);
     };
@@ -40,7 +39,6 @@ class PeriodListItem extends Component {
         event.stopPropagation();
         this.props.onRemovePeriodClick(this.props.period);
     };
-
 
     isOfferedList = () => this.props.listClassName === OFFERED_LIST;
 
@@ -89,7 +87,12 @@ class PeriodListItem extends Component {
                     className={className}
                 >
                     {Icon}
-                    <span style={this.props.period.selected ? styles.higlightedText : {}} className="list-text">{this.props.period.name}</span>
+                    <span
+                        style={this.props.period.selected ? styles.higlightedText : {}}
+                        className="list-text"
+                    >
+                        {this.props.period.name}
+                    </span>
                     {RemoveButton}
                 </div>
             </li>

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -155,6 +155,7 @@ class Periods extends Component {
                             onPeriodClick={this.props.toggleOfferedPeriod}
                             setOfferedPeriods={this.props.setOfferedPeriods}
                             addSelectedPeriods={this.props.addSelectedPeriods}
+                            selectedItems={this.props.selectedItems}
                         />
                     </div>
                     <div className="block buttons">

--- a/packages/period-selector-dialog/src/PeriodsList.js
+++ b/packages/period-selector-dialog/src/PeriodsList.js
@@ -5,16 +5,16 @@ import PeriodListItem from './PeriodListItem';
 const PeriodsList = (props) => {
     const { items, ...remaindingProps } = props;
 
-    const ListItems = props.items.map((period, index) =>
-        (<PeriodListItem
+    const ListItems = items.map((period, index) => (
+        <PeriodListItem
             period={period}
             index={index}
             key={period.id}
             {...remaindingProps}
-        />),
-    );
+        />
+    ));
 
-    return <ul className={remaindingProps.listClassName}> {ListItems} </ul>;
+    return <ul className={remaindingProps.listClassName}>{ListItems}</ul>;
 };
 
 PeriodsList.propTypes = {

--- a/packages/period-selector-dialog/src/RelativePeriods.js
+++ b/packages/period-selector-dialog/src/RelativePeriods.js
@@ -23,7 +23,10 @@ class RelativePeriods extends Component {
     }
 
     componentDidMount = () => {
-        this.props.setOfferedPeriods(this.generatePeriods(this.state.periodType));
+        const periods = this.generatePeriods(this.state.periodType);
+        const selectedIds = this.props.selectedItems.map(period => period.id);
+
+        this.props.setOfferedPeriods(periods.filter(period => !selectedIds.includes(period.id)));
     };
 
     onPeriodTypeChange = (event) => {
@@ -89,6 +92,7 @@ class RelativePeriods extends Component {
 
 RelativePeriods.propTypes = {
     items: PropTypes.array.isRequired,
+    selectedItems: PropTypes.array.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
     addSelectedPeriods: PropTypes.func.isRequired,
     onDoubleClick: PropTypes.func.isRequired,

--- a/packages/period-selector-dialog/src/reducers/periods.js
+++ b/packages/period-selector-dialog/src/reducers/periods.js
@@ -51,7 +51,7 @@ export default (periodType = 'offered') => (state = defaultState, action) => {
 
     case actionTypes[`TOGGLE_${periodType.toUpperCase()}_PERIOD`]: {
         const { index, isShiftPressed, isCtrlPressed } = action;
-        
+
         // If control was not pressed, then only select
         // current period and unselect all others
         if (isCtrlPressed === false && isShiftPressed === false) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Make sure offered periods list does not contain items  Fix a bug where user is not able to select last offered period in periods list

Steps to reproduce the bug:
- Load fresh AO
- Open periods dialog
- Make sure you have `Last 12 months` selected
- Try to select last item in offered periods list (`Months this year`) - fails