### PR TITLE
Improve styling of Interpretations cards

### DIFF
--- a/examples/create-react-app/src/components/org-unit-dialog.js
+++ b/examples/create-react-app/src/components/org-unit-dialog.js
@@ -153,7 +153,7 @@ export default class OrgUnitDialogExample extends Component {
             <div style={{ padding: 16 }}>
                 <Button
                     onClick={this.toggleDialog}
-                    variant="raised"
+                    variant="contained"
                 >
                     Select org units
                 </Button>

--- a/examples/create-react-app/src/components/org-unit-select.js
+++ b/examples/create-react-app/src/components/org-unit-select.js
@@ -136,7 +136,6 @@ export default class OrgUnitSelectExample extends React.Component {
 
         const state = this.state;
         if (!state.levels || !state.selected) {
-            console.info('What is state?', state);
             return null;
         }
 

--- a/packages/interpretations/package.json
+++ b/packages/interpretations/package.json
@@ -33,6 +33,7 @@
     "@material-ui/core": "^3.3.1",
     "@material-ui/icons": "^3.0.1",
     "babel-runtime": "^6.26.0",
+    "classnames": "^2.2.6",
     "husky": "^1.0.0-rc.8",
     "postcss-rtl": "^1.3.0",
     "prop-types": "^15.5.10",

--- a/packages/interpretations/src/components/CollapsibleCard.js
+++ b/packages/interpretations/src/components/CollapsibleCard.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
@@ -18,14 +18,14 @@ const styles = theme => ({
         position: 'relative',
     },
     actions: {
-        position: 'absolute',
-        top: 0,
-        right: 48,
-        padding: 0,
-        display: 'block',
+        marginTop: 0,
+        marginRight: -4,
+        '& button': {
+            padding: theme.spacing.unit * 0.5,
+        },
     },
     header: {
-        padding: '0 24px 0 12px',
+        padding: '4px 12px 4px 12px',
     },
     title: {
         fontSize: 15,
@@ -44,10 +44,6 @@ const styles = theme => ({
         transition: theme.transitions.create('transform', {
             duration: theme.transitions.duration.shortest,
         }),
-        marginLeft: 'auto',
-        [theme.breakpoints.up('sm')]: {
-            marginRight: -8,
-        },
     },
     expandOpen: {
         transform: 'rotate(180deg)',
@@ -66,27 +62,26 @@ class CollapsibleCard extends React.Component {
         const { expanded } = this.state;
 
         return (
-            <Card className={classes.card} raised={true}>
+            <Card className={classes.card}>
                 <CardHeader
                     title={title}
-                    classes={{ root: classes.header, title: classes.title }}
+                    classes={{ root: classes.header, title: classes.title, action: classes.actions }}
                     action={
-                        <IconButton
-                            className={classnames(classes.expand, {
-                                [classes.expandOpen]: expanded,
-                            })}
-                            onClick={this.handleExpandClick}
-                            aria-expanded={expanded}
-                            disableRipple
-                        >
-                            <ExpandMoreIcon />
-                        </IconButton>
+                        <Fragment>
+                            {expanded ? actions : null}
+                            <IconButton
+                                className={classnames(classes.expand, {
+                                    [classes.expandOpen]: expanded,
+                                })}
+                                onClick={this.handleExpandClick}
+                                aria-expanded={expanded}
+                                disableRipple
+                            >
+                                <ExpandMoreIcon />
+                            </IconButton>
+                        </Fragment>
                     }
                 />
-
-                <CardActions className={classes.actions} disableActionSpacing={true}>
-                    {expanded ? actions : null}
-                </CardActions>
 
                 <Collapse in={expanded} timeout="auto" unmountOnExit className={classes.collapse}>
                     <CardContent classes={{ root: classes.content }}>{children}</CardContent>

--- a/packages/interpretations/src/components/details/DetailsCardStyles.js
+++ b/packages/interpretations/src/components/details/DetailsCardStyles.js
@@ -43,6 +43,8 @@ export default {
     subscriberIcon: {
         float: 'right',
         top: 0,
-        right: 10,
+        right: 0,
+        padding: 8,
+        margin: 4,
     },
 };

--- a/packages/interpretations/src/components/interpretations/CommentTextarea.js
+++ b/packages/interpretations/src/components/interpretations/CommentTextarea.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Link, ActionSeparator } from './misc';
 import i18n from '@dhis2/d2-i18n';
@@ -51,7 +51,7 @@ class CommentTextarea extends React.Component {
         const postText = onCancel ? i18n.t('OK') : i18n.t('Post comment');
 
         return (
-            <div>
+            <Fragment>
                 <MentionsWrapper d2={d2} onUserSelect={this.onChange}>
                     <textarea
                         ref={this.setTextareaRef}
@@ -71,7 +71,7 @@ class CommentTextarea extends React.Component {
                         <Link label={i18n.t('Cancel')} onClick={onCancel} />
                     </span>
                 )}
-            </div>
+            </Fragment>
         );
     }
 }

--- a/packages/interpretations/src/components/interpretations/InterpretationsCard.js
+++ b/packages/interpretations/src/components/interpretations/InterpretationsCard.js
@@ -1,52 +1,70 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import Divider from '@material-ui/core/Divider';
-import IconButton from '@material-ui/core/IconButton';
-import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
-import AddIcon from '@material-ui/icons/Add';
-import i18n from '@dhis2/d2-i18n';
-import orderBy from 'lodash/fp/orderBy';
+import React from "react";
+import PropTypes from "prop-types";
+import Divider from "@material-ui/core/Divider";
+import IconButton from "@material-ui/core/IconButton";
+import ChevronLeftIcon from "@material-ui/icons/ChevronLeft";
+import AddIcon from "@material-ui/icons/Add";
+import i18n from "@dhis2/d2-i18n";
+import orderBy from "lodash/fp/orderBy";
 
-import CollapsibleCard from '../CollapsibleCard';
-import InterpretationDialog from './InterpretationDialog';
-import Interpretation from './Interpretation';
-import InterpretationModel from '../../models/interpretation';
-import styles from './InterpretationsStyles.js';
+import CollapsibleCard from "../CollapsibleCard";
+import InterpretationDialog from "./InterpretationDialog";
+import Interpretation from "./Interpretation";
+import InterpretationModel from "../../models/interpretation";
+import styles from "./InterpretationsStyles.js";
 
 const getInterpretationsList = props => {
-    const { d2, model, interpretations, setCurrentInterpretation, onChange } = props;
-    const getUserUrl = user => `${baseurl}/dhis-web-messaging/profile.action?id=${user.id}`;
+    const {
+        d2,
+        model,
+        interpretations,
+        setCurrentInterpretation,
+        onChange
+    } = props;
+    const getUserUrl = user =>
+        `${baseurl}/dhis-web-messaging/profile.action?id=${user.id}`;
 
-    return (
-        <div>
-            <div style={{ fontStyle: 'italic', marginLeft: 15 }}>
-                {interpretations.length === 0 && <span>{i18n.t('No interpretations')}</span>}
-            </div>
-
-            {interpretations.map(interpretation => (
-                <div
-                    key={interpretation.id}
-                    style={styles.interpretation}
-                    className="interpretation-box"
-                    onClick={() => setCurrentInterpretation(interpretation.id)}
-                >
-                    <Interpretation
-                        d2={d2}
-                        model={model}
-                        interpretation={interpretation}
-                        onChange={onChange}
-                        extended={false}
-                        onSelect={setCurrentInterpretation}
-                    />
-                </div>
-            ))}
+    return interpretations.length === 0 ? (
+        <div style={{ fontStyle: "italic" }}>
+            <span>{i18n.t("No interpretations")}</span>
         </div>
+    ) : (
+        interpretations.map((interpretation, i) => (
+            <div
+                key={interpretation.id}
+                style={
+                    i === interpretations.length - 1
+                        ? {
+                              ...styles.interpretation,
+                              paddingBottom: 0
+                          }
+                        : styles.interpretation
+                }
+                className="interpretation-box"
+                onClick={() => setCurrentInterpretation(interpretation.id)}
+            >
+                <Interpretation
+                    d2={d2}
+                    model={model}
+                    interpretation={interpretation}
+                    onChange={onChange}
+                    extended={false}
+                    onSelect={setCurrentInterpretation}
+                />
+            </div>
+        ))
     );
 };
 
 const getInterpretationDetails = props => {
-    const { d2, model, setCurrentInterpretation, interpretation, onChange } = props;
-    const comments = orderBy(['created'], ['desc'], interpretation.comments);
+    const {
+        d2,
+        model,
+        setCurrentInterpretation,
+        interpretation,
+        onChange
+    } = props;
+    const comments = orderBy(["created"], ["desc"], interpretation.comments);
 
     return (
         <Interpretation
@@ -66,22 +84,20 @@ const getInterpretationButtons = props => {
         model,
         currentInterpretation,
         setCurrentInterpretation,
-        openNewInterpretationDialog,
+        openNewInterpretationDialog
     } = props;
 
     return currentInterpretation ? (
         <IconButton
-            style={styles.action}
             onClick={() => setCurrentInterpretation(null)}
-            title={i18n.t('Clear interpretation')}
+            title={i18n.t("Clear interpretation")}
         >
             <ChevronLeftIcon />
         </IconButton>
     ) : (
         <IconButton
-            style={styles.action}
             onClick={openNewInterpretationDialog}
-            title={i18n.t('Write new interpretation')}
+            title={i18n.t("Write new interpretation")}
         >
             <AddIcon />
         </IconButton>
@@ -93,19 +109,27 @@ class InterpretationsCard extends React.Component {
         super(props);
         this.state = {
             interpretationToEdit: null,
-            currentInterpretationId: props.currentInterpretationId,
+            currentInterpretationId: props.currentInterpretationId
         };
 
         this.notifyChange = this.notifyChange.bind(this);
-        this.openNewInterpretationDialog = this.openNewInterpretationDialog.bind(this);
-        this.closeInterpretationDialog = this.closeInterpretationDialog.bind(this);
-        this.setCurrentInterpretation = this.setCurrentInterpretation.bind(this);
+        this.openNewInterpretationDialog = this.openNewInterpretationDialog.bind(
+            this
+        );
+        this.closeInterpretationDialog = this.closeInterpretationDialog.bind(
+            this
+        );
+        this.setCurrentInterpretation = this.setCurrentInterpretation.bind(
+            this
+        );
         this.isControlledComponent = !!props.onCurrentInterpretationChange;
     }
 
     componentWillReceiveProps(nextProps) {
         if (this.isControlledComponent) {
-            this.setState({ currentInterpretationId: nextProps.currentInterpretationId });
+            this.setState({
+                currentInterpretationId: nextProps.currentInterpretationId
+            });
         }
     }
 
@@ -114,7 +138,7 @@ class InterpretationsCard extends React.Component {
         if (currentInterpretation && this.props.onCurrentInterpretationChange) {
             this.props.onCurrentInterpretationChange(currentInterpretation);
         }
-        if (this.props.currentInterpretationId == 'new') {
+        if (this.props.currentInterpretationId == "new") {
             this.openNewInterpretationDialog();
         }
     }
@@ -152,7 +176,8 @@ class InterpretationsCard extends React.Component {
         const { currentInterpretationId } = this.state;
         return model && model.interpretations && currentInterpretationId
             ? model.interpretations.find(
-                  interpretation => interpretation.id === currentInterpretationId
+                  interpretation =>
+                      interpretation.id === currentInterpretationId
               )
             : null;
     }
@@ -161,18 +186,25 @@ class InterpretationsCard extends React.Component {
         const { model } = this.props;
         const { interpretationToEdit } = this.state;
         const { d2 } = this.context;
-        const sortedInterpretations = orderBy(['created'], ['desc'], model.interpretations);
+        const sortedInterpretations = orderBy(
+            ["created"],
+            ["desc"],
+            model.interpretations
+        );
         const currentInterpretation = this.getCurrentInterpretation();
         const actions = getInterpretationButtons({
             d2: d2,
             model: model,
             currentInterpretation: currentInterpretation,
             setCurrentInterpretation: this.setCurrentInterpretation,
-            openNewInterpretationDialog: this.openNewInterpretationDialog,
+            openNewInterpretationDialog: this.openNewInterpretationDialog
         });
 
         return (
-            <CollapsibleCard title={i18n.t('Interpretations')} actions={actions}>
+            <CollapsibleCard
+                title={i18n.t("Interpretations")}
+                actions={actions}
+            >
                 {interpretationToEdit && (
                     <InterpretationDialog
                         model={model}
@@ -182,21 +214,25 @@ class InterpretationsCard extends React.Component {
                     />
                 )}
 
-                {currentInterpretation
-                    ? getInterpretationDetails({
-                          d2: d2,
-                          model: model,
-                          interpretation: currentInterpretation,
-                          setCurrentInterpretation: this.setCurrentInterpretation,
-                          onChange: this.notifyChange,
-                      })
-                    : getInterpretationsList({
-                          d2: d2,
-                          model: model,
-                          interpretations: sortedInterpretations,
-                          setCurrentInterpretation: this.setCurrentInterpretation,
-                          onChange: this.notifyChange,
-                      })}
+                <div style={{ margin: 12 }}>
+                    {currentInterpretation
+                        ? getInterpretationDetails({
+                              d2: d2,
+                              model: model,
+                              interpretation: currentInterpretation,
+                              setCurrentInterpretation: this
+                                  .setCurrentInterpretation,
+                              onChange: this.notifyChange
+                          })
+                        : getInterpretationsList({
+                              d2: d2,
+                              model: model,
+                              interpretations: sortedInterpretations,
+                              setCurrentInterpretation: this
+                                  .setCurrentInterpretation,
+                              onChange: this.notifyChange
+                          })}
+                </div>
             </CollapsibleCard>
         );
     }
@@ -206,11 +242,11 @@ InterpretationsCard.propTypes = {
     model: PropTypes.object.isRequired,
     currentInterpretationId: PropTypes.string,
     onChange: PropTypes.func.isRequired,
-    onCurrentInterpretationChange: PropTypes.func,
+    onCurrentInterpretationChange: PropTypes.func
 };
 
 InterpretationsCard.contextTypes = {
-    d2: PropTypes.object.isRequired,
+    d2: PropTypes.object.isRequired
 };
 
 export default InterpretationsCard;

--- a/packages/interpretations/src/components/interpretations/InterpretationsStyles.js
+++ b/packages/interpretations/src/components/interpretations/InterpretationsStyles.js
@@ -1,114 +1,109 @@
 export default {
-    action: {
-        height: 24,
-        padding: 5,
-        width: 24,
-    },
-
     body: {
-        padding: 0,
+        padding: 0
     },
 
     commentArea: {
-        border: '1px solid #ccc',
-        fontFamily: 'Roboto,Arial,sans-serif',
+        border: "1px solid #ccc",
+        boxSizing: "border-box",
+        fontFamily: "Roboto,Arial,sans-serif",
         fontSize: 12,
         height: 50,
-        overflow: 'auto',
-        padding: '4px 0px 0px 6px',
-        resize: 'none',
-        width: '95%',
+        overflow: "auto",
+        padding: "4px 0px 0px 6px",
+        resize: "none",
+        width: "100%",
     },
 
     commentAuthor: {
-        marginBottom: 2,
+        marginBottom: 2
     },
 
     commentText: {
-        marginBottom: 2,
-        whiteSpace: 'pre-line',
-        lineHeight: '1.5em',
+        width: "100%",
+        whiteSpace: "pre-line",
+        lineHeight: "1.5em"
     },
 
     container: {
-        paddingBottom: 0,
+        paddingBottom: 0
     },
 
     date: {
-        color: '#9e9999',
-        fontWeight: 'normal',
-        marginLeft: 4,
+        color: "#9e9999",
+        fontWeight: "normal",
+        marginLeft: 4
     },
 
     actions: {
-        marginBottom: 5,
+        marginBottom: 5
     },
 
     greyBackground: {
-        backgroundColor: '#efefef',
+        backgroundColor: "#efefef",
         marginTop: 2,
         paddingBottom: 4,
-        paddingTop: 4,
+        paddingTop: 4
     },
 
     headerText: {
         paddingRight: 0,
-        position: 'relative',
-        top: '50%',
-        transform: 'translateY(-50%)',
-        width: 210,
+        position: "relative",
+        top: "50%",
+        transform: "translateY(-50%)",
+        width: 210
     },
 
     interpretation: {
-        cursor: 'pointer',
+        cursor: "pointer",
         padding: 0,
+        paddingBottom: 12
     },
 
     interpretationCommentArea: {
         fontSize: 12,
-        margin: '2px 0 5px 0px',
+        margin: "2px 0 5px 0px"
     },
 
     interpretationDescSection: {
-        fontSize: 12,
-        padding: '12px 12px 10px 12px',
+        fontSize: 12
     },
 
     interpretationLink: {
-        color: '#3162C5',
-        cursor: 'pointer',
+        color: "#3162C5",
+        cursor: "pointer"
     },
 
     interpretationName: {
-        display: 'inline-block',
+        display: "inline-block"
     },
 
     interpretationText: {
-        whiteSpace: 'pre-line',
-        lineHeight: '1.5em',
+        whiteSpace: "pre-line",
+        lineHeight: "1.5em"
     },
 
     interpretationTextWrapper: {
         marginBottom: 5,
         marginLeft: 0,
-        marginTop: 5,
+        marginTop: 5
     },
 
     interpretationTextLimited: {
-        display: 'block',
-        textOverflow: 'ellipsis',
-        wordWrap: 'break-word',
-        overflow: 'hidden',
-        maxHeight: '3.0em',
-        lineHeight: '1.5em',
-        whiteSpace: 'pre-line',
+        display: "block",
+        textOverflow: "ellipsis",
+        wordWrap: "break-word",
+        overflow: "hidden",
+        maxHeight: "3.0em",
+        lineHeight: "1.5em",
+        whiteSpace: "pre-line"
     },
 
     interpretationsCard: {
-        clear: 'both',
-        margin: '8px 4px 8px 4px',
+        clear: "both",
+        margin: "8px 4px 8px 4px",
         paddingBottom: 6,
-        zIndex: 1010,
+        zIndex: 1010
     },
 
     interpretationsCardHeader: {
@@ -116,87 +111,85 @@ export default {
         height: 32,
         marginRight: -8,
         paddingLeft: 14,
-        paddingRight: 8,
+        paddingRight: 8
     },
 
     interpretationsCardToolbar: {
-        backgroundColor: '#eee',
+        backgroundColor: "#eee",
         height: 32,
-        paddingLeft: 7,
+        paddingLeft: 7
     },
 
     likeArea: {
-        backgroundColor: '#efefef',
+        backgroundColor: "#efefef",
         marginTop: 2,
-        padding: '4px 4px 4px 5px',
+        padding: "4px 4px 4px 5px",
         paddingBottom: 4,
         paddingTop: 4,
-        display: 'flex',
-        alignItems: 'center',
+        display: "flex",
+        alignItems: "center"
     },
 
     icon: {
         width: 14,
         height: 14,
         padding: 0,
-        marginLeft: 2,
+        marginLeft: 2
     },
 
     likeIcon: {
         height: 16,
         marginRight: 5,
-        verticalAlign: 'top',
-        width: 16,
+        verticalAlign: "top",
+        width: 16
     },
 
     linkArea: {
         paddingLeft: 5,
-        paddingRight: 5,
+        paddingRight: 5
     },
 
     tipText: {
-        color: '#9e9999',
-        fontWeight: 'normal',
+        color: "#9e9999",
+        fontWeight: "normal"
     },
 
     userLink: {
-        color: '#3d4245',
-        fontWeight: 'bold',
-        textDecoration: 'none',
+        color: "#3d4245",
+        fontWeight: "bold",
+        textDecoration: "none"
     },
 
     showMoreComments: {
-        fontSize: '11px',
-        textTransform: 'uppercase',
-        paddingLeft: '16px',
-        paddingRight: '16px',
-        fontWeight: '500',
+        fontSize: "11px",
+        textTransform: "uppercase",
+        paddingLeft: "16px",
+        paddingRight: "16px",
+        fontWeight: "500"
     },
 
     avatarWrapper: {
-        display: 'flex',
+        display: "flex",
         marginTop: 10,
-        backgroundColor: '#efefef',
-        marginTop: 2,
-        paddingBottom: 4,
-        paddingTop: 4,
+        backgroundColor: "#efefef",
+        margin: "4px 0",
+        padding: 8
     },
 
     avatarBox: {
         width: 32,
-        marginLeft: 5,
-        marginRight: 5,
+        marginRight: 8
     },
 
     avatarBoxContent: {
-        width: '90%',
+        flex: 1,
     },
 
     avatar: {
-        color: 'black',
+        color: "black",
         fontSize: 15,
-        fontWeight: 'bold',
+        fontWeight: "bold",
         width: 32,
-        height: 32,
-    },
+        height: 32
+    }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2697,7 +2697,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==


### PR DESCRIPTION
In particular:

* Increase padding around `No Interpretations` text
* Fix card action hover, padding, margins, etc. and consolidate them into one `div`
* Use non-raised Mui `Card` style since we don't use raised cards anywhere else
* Refactor some DOM elements to use more idiomatic styles
* Improve padding around comment avatars

Also remove Mui deprecation warning from the example app

Before:
![screenshot 2018-11-22 16 55 32](https://user-images.githubusercontent.com/947888/48913054-9dc12580-ee77-11e8-873a-f407cfea1a26.png)
![screenshot 2018-11-22 16 55 42](https://user-images.githubusercontent.com/947888/48913056-9dc12580-ee77-11e8-9ac9-f1a78bf0d3c2.png)
![screenshot 2018-11-22 16 56 13](https://user-images.githubusercontent.com/947888/48913057-9dc12580-ee77-11e8-8152-efd1013d1a6e.png)

After:
![screenshot 2018-11-22 16 51 56](https://user-images.githubusercontent.com/947888/48912946-5044b880-ee77-11e8-8a80-4279923c15ca.png)
![screenshot 2018-11-22 16 52 03](https://user-images.githubusercontent.com/947888/48912947-5044b880-ee77-11e8-908c-8ed7efe77ddc.png)
![screenshot 2018-11-22 16 52 31](https://user-images.githubusercontent.com/947888/48912948-5044b880-ee77-11e8-92cc-67e3ef7a822a.png)