### PR TITLE
Fix success callback handling for delete action

### DIFF
--- a/packages/file-menu/src/DeleteDialog.js
+++ b/packages/file-menu/src/DeleteDialog.js
@@ -24,7 +24,7 @@ const DeleteDialog = props => {
         if (fileModel) {
             fileModel
                 .delete()
-                .then(onRequestDelete(fileModel.id))
+                .then(() => onRequestDelete(fileModel.id))
                 .catch(onRequestDeleteError);
         }
     };


### PR DESCRIPTION
Fixes partly DHIS2-5257.

Changes proposed in this pull request:

- Fix success callback handling for delete action
Only call it when the promise resolves.
