### PR TITLE
fix/re-order build script so --watch applies to babel transpiling

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,9 +9,9 @@
     "coverage": "jest --coverage",
     "lint": "eslint src/",
     "prebuild": "rimraf ./build/*",
-    "build": "npm run build:es && npm run build:sass",
+    "build": "npm run build:sass && npm run build:es",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:sass": "node-sass ./scss --output ./build/css",
+    "build:sass": "cross-env mkdirp ./build && node-sass ./scss --output ./build/css",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/core"
   },
@@ -32,5 +32,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.0-PLACEHOLDER"
+  "version": "0.0.0-PLACEHOLDER",
+  "devDependencies": {
+    "mkdirp": "^0.5.1"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,10 +8,10 @@
   "scripts": {
     "coverage": "jest --coverage",
     "lint": "eslint src/",
-    "prebuild": "rimraf ./build/*",
+    "prebuild": "rimraf ./build/* && mkdirp ./build",
     "build": "npm run build:sass && npm run build:es",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:sass": "mkdirp ./build && node-sass ./scss --output ./build/css",
+    "build:sass": "node-sass ./scss --output ./build/css",
     "watch": "npm run build -- --watch",
     "test-ci": "jest --config=../../jest.config.js packages/core"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,8 +11,8 @@
     "prebuild": "rimraf ./build/*",
     "build": "npm run build:sass && npm run build:es",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:sass": "cross-env mkdirp ./build && node-sass ./scss --output ./build/css",
-    "watch": "npm run build --  --watch",
+    "build:sass": "mkdirp ./build && node-sass ./scss --output ./build/css",
+    "watch": "npm run build -- --watch",
     "test-ci": "jest --config=../../jest.config.js packages/core"
   },
   "repository": {

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -13,8 +13,8 @@
     "react-dom": "^15.0.0 || ^16.0.0"
   },
   "scripts": {
-    "prebuild": "rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js && npm run build:css",
+    "prebuild": "rimraf ./build/* && cross-env mkdirp ./build",
+    "build": "npm run build:css && cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
     "build:css": "cp -R ./css/* ./build/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/period-selector-dialog",
@@ -39,7 +39,8 @@
   },
   "devDependencies": {
     "babel-jest": "^23.0.1",
-    "jest": "^23.1.0"
+    "jest": "^23.1.0",
+    "mkdirp": "^0.5.1"
   },
   "version": "0.0.0-PLACEHOLDER"
 }

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^15.0.0 || ^16.0.0"
   },
   "scripts": {
-    "prebuild": "rimraf ./build/* && cross-env mkdirp ./build",
+    "prebuild": "rimraf ./build/* && mkdirp ./build",
     "build": "npm run build:css && cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
     "build:css": "cp -R ./css/* ./build/",
     "watch": "npm run build --  --watch",


### PR DESCRIPTION
Problem: js changes in period-selector-dialog and core were not re-transpiled when running `yarn watch`.  This is because the --watch option gets applied at the end of the command. When you have a compound npm script (command1 && command2), then the option is applied to the last command.



It is actually possible to insert the option using shell functions aka:
```"npm run lint -- -f unix"```
```"lint": "f() { eslint -f src $@ . && npm run tslint; }; f"```
credit: https://stackoverflow.com/questions/11580961/sending-command-line-arguments-to-npm-script?lq=1

But this seemed unnecessarily complex for this one case. 

Downside is that css changes dont trigger the build.
