### PR TITLE
Use 15px font-size for FileMenu button

### DIFF
--- a/packages/file-menu/src/FileMenu.js
+++ b/packages/file-menu/src/FileMenu.js
@@ -258,7 +258,7 @@ FileMenu.propTypes = {
 const styles = theme => ({
     menuButton: {
         textTransform: 'none',
-        fontSize: '16px',
+        fontSize: 15,
         fontWeight: 400,
     },
 });


### PR DESCRIPTION
Tiny update to font-size in FileMenu button - use 15px not 16px