### PR TITLE
Fix/set correct d2 ui dialog rules

### DIFF
--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -20,7 +20,6 @@ import GroupEditor from './components/group-editor';
 import Layout from './components/layout';
 import Legend from './components/legend';
 import PeriodPicker from './components/period-picker';
-import PeriodSelectorDialog from './components/period-selector-dialog';
 import PeriodSelector from './components/period-selector';
 import OrgUnitDialog from './components/org-unit-dialog';
 import OrgUnitSelector from './components/org-unit-selector';
@@ -150,7 +149,6 @@ class App extends Component {
                     <FormEditor />
 
                     <h2>Period selector dialog</h2>
-                    <PeriodSelectorDialog d2={this.state.d2} />
 
                     <h2>Period selector</h2>
                     <PeriodSelector d2={this.state.d2} />

--- a/examples/create-react-app/src/components/period-selector.js
+++ b/examples/create-react-app/src/components/period-selector.js
@@ -28,13 +28,19 @@ class PeriodSelectorExample extends Component {
     };
 
     selectPeriods = (selectedPeriods) => {
-        this.setState({ selectedPeriods });
+        this.setState({
+            selectedPeriods: [
+                ...this.state.selectedPeriods,
+                ...selectedPeriods,
+            ],
+        });
     };
 
     deselectPeriods = (removedPeriods) => {
-        const selectedPeriods = this.state.selectedPeriods.filter(period =>
-            !removedPeriods.includes(period) && period,
-        );
+        const removedPeriodsIds = removedPeriods.map(period => period.id);
+        const selectedPeriods = this.state
+            .selectedPeriods
+            .filter(period => !removedPeriodsIds.includes(period.id));
 
         this.setState({ selectedPeriods });
     };

--- a/packages/core/src/theme/mui3.theme.js
+++ b/packages/core/src/theme/mui3.theme.js
@@ -96,19 +96,19 @@ export const theme = {
         },
         MuiDialog: {
             paperWidthSm: {
-                minWidth: 400,
-                width: 400,
+                flexBasis: 400,
                 maxWidth: 400,
+                maxHeight: 'calc(100vh - 19%)',
             },
             paperWidthMd: {
-                minWidth: 600,
-                width: 600,
+                flexBasis: 600,
                 maxWidth: 600,
+                maxHeight: 'calc(100vh - 19%)',
             },
             paperWidthLg: {
-                minWidth: 800,
-                width: 800,
+                flexBasis: 800,
                 maxWidth: 800,
+                maxHeight: 'calc(100vh - 19%)',
             },
         },
         MuiDialogTitle: {

--- a/packages/period-selector-dialog/css/PeriodSelector.css
+++ b/packages/period-selector-dialog/css/PeriodSelector.css
@@ -2,7 +2,7 @@
     user-select: none;
     display: flex;
     flex-flow: row nowrap;
-    height: 498px;
+    height: 449px;
     padding-top: 18px;
 }
 
@@ -59,10 +59,8 @@ button.nav-button {
     border-bottom: 1px solid #e8e8e8;
 }
 
-.periods-list-offered .periods-list-selected {
-    overflow: auto;
-    padding: 0px;
-    margin: 0px;
+.periods-list-offered, .periods-list-selected {
+    overflow-y: scroll;
 
 }
 .periods-list-offered {
@@ -70,7 +68,7 @@ button.nav-button {
 }
 
 .periods-list-selected {
-    height: calc(100% - 79px); /* sum of header and clear button with padding = 79px */
+    height: calc(100% - 71px);
 }
 
 .period-dimension-item {
@@ -102,15 +100,14 @@ button.nav-button {
 
 .subtitle-container {
     border-bottom: 1px solid #E0E0E0;
-    height: 42px;
+    height: 34px;
     display: flex;
 }
 
 .subtitle {
-    color: black;
     font-size: 15px;
     font-weight: 500;
-    padding: 10px 0px 0px 8px;
+    padding: 10px 0px 0px 10px;
 }
 
 .move-all-items-button {
@@ -122,7 +119,7 @@ button.nav-button {
     font-size: 14px;
  }
 
-.unselected-icon {
+.unselected-icon, .selected-icon,  .highlighted-icon{
     background-color: grey;
     min-height: 6px;
     min-width: 6px;
@@ -131,16 +128,10 @@ button.nav-button {
 
 .selected-icon {
     background-color: #00796B;
-    min-height: 6px;
-    min-width: 6px;
-    margin: 0px 5px;    
 }
 
 .highlighted-icon {
     background-color: white;
-    min-height: 6px;
-    min-width: 6px;
-    margin: 0px 5px;
 }
 
 .form-control-period-type { 
@@ -149,7 +140,7 @@ button.nav-button {
 }
 
 .form-control-year { 
-    width: 32%; 
+    width: 35%; 
 }
 
 .input-label {

--- a/packages/period-selector-dialog/css/PeriodSelector.css
+++ b/packages/period-selector-dialog/css/PeriodSelector.css
@@ -1,13 +1,16 @@
 .periods-container {
-    min-width: 709px;
-    margin-top: 18px;
+    user-select: none;
+    display: flex;
+    flex-flow: row nowrap;
+    height: 498px;
+    padding-top: 18px;
 }
 
 button.nav-button {
-    padding: 5px 13px 3px;
-    border: 1px solid #ECEFF1;
-    border-radius: 2px 0 0 2px;
     text-transform: none;
+    border: 1px solid #ECEFF1;
+    border-radius: 2px 0px 0px 2px;
+    padding: 5px 13px 3px;
 }
 
 .nav-button.active, .nav-button.active:hover {
@@ -15,39 +18,40 @@ button.nav-button {
     color: #fff;
 }
 
-.block {
-    display: inline-block;
-    vertical-align: middle;
-}
-
-.block.options {
-    width: 50%;
-    height: 460px;
+.block-offered-periods {
+    flex: 3 unset 190px;
     border: 1px solid #e8e8e8;
 }
 
-.block.selected-periods {
-    width: 38%;
-    height: 460px;
-    vertical-align: top;
-    border: 1px solid #e8e8e8;
+.block-buttons {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex-grow: 1;
+    padding: 0px 5px;
+    max-width: 60px;
 }
 
-.block.buttons {
-    width: 10%;
-    padding: 0 5px;
-}
-
-.block.buttons button {
-    min-width: 0;
+.block-buttons button {
+    padding: 0px;
+    border-radius: 4px;
+    width: 40px;
+    height: 36px;
+    background-color: white;
     box-shadow: 0 2px 5px #b1b1b1;
-    padding: 7px 10px 5px;
-    margin: 0 auto;
-    display: block;
 }
 
-.block.buttons button:first-child {
-    margin-bottom: 35px;
+.block-buttons button:nth-child(1) {
+    margin: 0px auto 35px;
+}
+
+.block-buttons button:nth-child(2) {
+    margin: 0px auto;
+}
+
+.block-selected-periods {
+    flex: 2 unset 125px;
+    border: 1px solid #f0e3e3;
 }
 
 .options-area {
@@ -55,20 +59,18 @@ button.nav-button {
     border-bottom: 1px solid #e8e8e8;
 }
 
-.periods-list-selected {
+.periods-list-offered .periods-list-selected {
     overflow: auto;
-    list-style: none;
-    height: calc(100% - 81px); /* sum of header and clear button with padding = 81px */
-    padding: 0;
+    padding: 0px;
     margin: 0px;
+
+}
+.periods-list-offered {
+    height: calc(100% - 91px);
 }
 
-.periods-list-offered {
-    list-style: none;
-    overflow: auto;
-    height: calc(100% - 93px);
-    margin: 0px;
-    padding: 0;
+.periods-list-selected {
+    height: calc(100% - 79px); /* sum of header and clear button with padding = 79px */
 }
 
 .period-dimension-item {
@@ -101,31 +103,24 @@ button.nav-button {
 .subtitle-container {
     border-bottom: 1px solid #E0E0E0;
     height: 42px;
+    display: flex;
 }
 
-.selected-periods .subtitle {
-    position: relative;
+.subtitle {
     color: black;
-    height: 20px;
     font-size: 15px;
     font-weight: 500;
-    top: 12px;
-    left: 8px;
+    padding: 10px 0px 0px 8px;
 }
 
-.selector-area {
-    height: 460px;
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+.move-all-items-button {
+    text-align: center;
 }
 
-.selector-area .periods-list {
-    overflow: auto;
-}
+.list-text {
+    padding: 2px;
+    font-size: 14px;
+ }
 
 .unselected-icon {
     background-color: grey;
@@ -148,23 +143,22 @@ button.nav-button {
     margin: 0px 5px;
 }
 
-.list-text {
-    padding: 2px;
-    font-size: 14px;
- }
-
- .remove-item-button {
-    border: none;
-    outline: none;
-    background: none;
-    padding: 0px;
-    height: 18px;
-    width: 18px;
+.form-control-period-type { 
+    width: 65%; 
+    padding-right: 10px; 
 }
 
-.selector-area .form-control.period-type { width: 65%; padding-right: 10px; }
-.selector-area .form-control.year { width: 32%; }
-.selector-area .period-li.selected h3 { color: white; }
+.form-control-year { 
+    width: 32%; 
+}
+
+.input-label {
+    color: #494949;
+}
+
+.period-li.selected h3 { 
+    color: white; 
+}
 
 #year-select {
     cursor: pointer;

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -16,7 +16,7 @@
     "prebuild": "rimraf ./build/*",
     "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js && npm run build:css",
     "build:css": "cp -R ./css/* ./build/",
-    "watch": "npm run build --  --watch",
+    "watch": "npm run build --watch",
     "test-ci": "jest --config=../../jest.config.js packages/period-selector-dialog",
     "test:watch": "npm test -- --watch"
   },

--- a/packages/period-selector-dialog/src/FixedPeriods.js
+++ b/packages/period-selector-dialog/src/FixedPeriods.js
@@ -11,7 +11,6 @@ import ArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import ArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 import FixedPeriodsGenerator from './utils/FixedPeriodsGenerator';
 import PeriodsList from './PeriodsList';
-import styles from './styles/PeriodListItem.style';
 
 export const defaultState = {
     periodType: 'Monthly',
@@ -31,12 +30,12 @@ class FixedPeriods extends Component {
         this.state = defaultState;
     }
 
-    componentDidMount = () => {
+    componentDidMount() {
         const periods = this.generatePeriods(this.state.periodType, this.state.year);
         const selectedIds = this.props.selectedItems.map(period => period.id);
 
         this.props.setOfferedPeriods(periods.filter(period => !selectedIds.includes(period.id)));
-    };
+    }
 
     onPeriodTypeChange = (event) => {
         this.setState({
@@ -118,8 +117,8 @@ class FixedPeriods extends Component {
 
         return (
             <div className="options-area">
-                <FormControl className="form-control period-type">
-                    <InputLabel style={styles.inputLabel} className="input-label" htmlFor="period-type">
+                <FormControl className="form-control-period-type">
+                    <InputLabel className="input-label" htmlFor="period-type">
                         {i18n.t('Period type')}
                     </InputLabel>
                     <Select
@@ -134,8 +133,8 @@ class FixedPeriods extends Component {
                             )}
                     </Select>
                 </FormControl>
-                <FormControl className="form-control year">
-                    <InputLabel style={styles.inputLabel} className="input-label" htmlFor="year">
+                <FormControl className="form-control-year">
+                    <InputLabel className="input-label" htmlFor="year">
                         {i18n.t('Year')}
                     </InputLabel>
                     <Select
@@ -187,26 +186,26 @@ class FixedPeriods extends Component {
         );
     };
 
-    render = () => {
+    render() {
         const Options = this.renderOptions();
 
         return (
-            <div className="selector-area">
+            <div className="block-offered-periods">
                 {Options}
                 <PeriodsList
+                    className="periods-list-offered"
                     items={this.props.items}
                     onPeriodDoubleClick={this.props.onPeriodDoubleClick}
                     onPeriodClick={this.props.onPeriodClick}
-                    listClassName={'periods-list-offered'}
                 />
-                <div style={{ textAlign: 'center' }}>
+                <div className="move-all-items-button">
                     <Button onClick={this.selectAll}>
                         {i18n.t('Select all')}
                     </Button>
                 </div>
             </div>
         );
-    };
+    }
 }
 
 FixedPeriods.propTypes = {

--- a/packages/period-selector-dialog/src/FixedPeriods.js
+++ b/packages/period-selector-dialog/src/FixedPeriods.js
@@ -32,7 +32,10 @@ class FixedPeriods extends Component {
     }
 
     componentDidMount = () => {
-        this.props.setOfferedPeriods(this.generatePeriods(this.state.periodType, this.state.year));
+        const periods = this.generatePeriods(this.state.periodType, this.state.year);
+        const selectedIds = this.props.selectedItems.map(period => period.id);
+
+        this.props.setOfferedPeriods(periods.filter(period => !selectedIds.includes(period.id)));
     };
 
     onPeriodTypeChange = (event) => {
@@ -205,6 +208,7 @@ class FixedPeriods extends Component {
 
 FixedPeriods.propTypes = {
     items: PropTypes.array.isRequired,
+    selectedItems: PropTypes.array.isRequired,
     onDoubleClick: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,

--- a/packages/period-selector-dialog/src/FixedPeriods.js
+++ b/packages/period-selector-dialog/src/FixedPeriods.js
@@ -83,12 +83,15 @@ class FixedPeriods extends Component {
 
     generatePeriods = (periodType, year) => {
         const generator = this.periodsGenerator.get(periodType);
+        const selectedIds = this.props.selectedItems.map(item => item.id);
 
-        return generator.generatePeriods({
-            offset: year - (new Date()).getFullYear(),
-            filterFuturePeriods: false,
-            reversePeriods: false,
-        });
+        return generator
+            .generatePeriods({
+                offset: year - (new Date()).getFullYear(),
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+            .filter(period => !selectedIds.includes(period.id));
     };
 
     selectAll = () => {
@@ -192,7 +195,7 @@ class FixedPeriods extends Component {
                 {Options}
                 <PeriodsList
                     items={this.props.items}
-                    onDoubleClick={this.props.onDoubleClick}
+                    onPeriodDoubleClick={this.props.onPeriodDoubleClick}
                     onPeriodClick={this.props.onPeriodClick}
                     listClassName={'periods-list-offered'}
                 />
@@ -209,7 +212,7 @@ class FixedPeriods extends Component {
 FixedPeriods.propTypes = {
     items: PropTypes.array.isRequired,
     selectedItems: PropTypes.array.isRequired,
-    onDoubleClick: PropTypes.func.isRequired,
+    onPeriodDoubleClick: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
     addSelectedPeriods: PropTypes.func.isRequired,

--- a/packages/period-selector-dialog/src/OfferedPeriods.js
+++ b/packages/period-selector-dialog/src/OfferedPeriods.js
@@ -24,7 +24,7 @@ export const OfferedPeriods = (props) => {
 OfferedPeriods.propTypes = {
     periodType: PropTypes.string.isRequired,
     items: PropTypes.array.isRequired,
-    onDoubleClick: PropTypes.func.isRequired,
+    onPeriodDoubleClick: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
 };

--- a/packages/period-selector-dialog/src/PeriodListItem.js
+++ b/packages/period-selector-dialog/src/PeriodListItem.js
@@ -27,7 +27,6 @@ RemoveItemButton.propTypes = {
 class PeriodListItem extends Component {
     state = { isHovering: false };
 
-
     onPeriodClick = (event) => {
         this.props.onPeriodClick(this.props.period, this.props.index, event.shiftKey, event.metaKey);
     };
@@ -40,7 +39,6 @@ class PeriodListItem extends Component {
         event.stopPropagation();
         this.props.onRemovePeriodClick(this.props.period);
     };
-
 
     isOfferedList = () => this.props.listClassName === OFFERED_LIST;
 
@@ -89,7 +87,12 @@ class PeriodListItem extends Component {
                     className={className}
                 >
                     {Icon}
-                    <span style={this.props.period.selected ? styles.higlightedText : {}} className="list-text">{this.props.period.name}</span>
+                    <span
+                        style={this.props.period.selected ? styles.higlightedText : {}}
+                        className="list-text"
+                    >
+                        {this.props.period.name}
+                    </span>
                     {RemoveButton}
                 </div>
             </li>

--- a/packages/period-selector-dialog/src/PeriodListItem.js
+++ b/packages/period-selector-dialog/src/PeriodListItem.js
@@ -40,7 +40,7 @@ class PeriodListItem extends Component {
         this.props.onRemovePeriodClick(this.props.period);
     };
 
-    isOfferedList = () => this.props.listClassName === OFFERED_LIST;
+    isOfferedList = () => this.props.className === OFFERED_LIST;
 
     highlightItem = () => {
         this.setState({ isHovering: true });
@@ -66,7 +66,7 @@ class PeriodListItem extends Component {
             : <RemoveItemButton isHighlighted={this.props.period.selected} action={this.onRemovePeriodClick} />
     );
 
-    render = () => {
+    render() {
         const className = this.isOfferedList() ? 'period-offered-label' : 'period-selected-label';
         const Icon = this.renderIcon();
         const RemoveButton = this.renderRemoveButton();
@@ -97,7 +97,7 @@ class PeriodListItem extends Component {
                 </div>
             </li>
         );
-    };
+    }
 }
 
 PeriodListItem.propTypes = {
@@ -106,7 +106,7 @@ PeriodListItem.propTypes = {
     onPeriodClick: PropTypes.func.isRequired,
     onPeriodDoubleClick: PropTypes.func.isRequired,
     onRemovePeriodClick: PropTypes.func.isRequired,
-    listClassName: PropTypes.string.isRequired,
+    className: PropTypes.string.isRequired,
 };
 
 export default PeriodListItem;

--- a/packages/period-selector-dialog/src/PeriodListItem.js
+++ b/packages/period-selector-dialog/src/PeriodListItem.js
@@ -31,8 +31,8 @@ class PeriodListItem extends Component {
         this.props.onPeriodClick(this.props.period, this.props.index, event.shiftKey, event.metaKey);
     };
 
-    onDoubleClick = () => {
-        this.props.onDoubleClick(this.props.period);
+    onPeriodDoubleClick = () => {
+        this.props.onPeriodDoubleClick(this.props.period);
     };
 
     onRemovePeriodClick = (event) => {
@@ -83,7 +83,7 @@ class PeriodListItem extends Component {
                     onMouseEnter={this.highlightItem}
                     onMouseLeave={this.removeHighlight}
                     onClick={this.onPeriodClick}
-                    onDoubleClick={this.onDoubleClick}
+                    onDoubleClick={this.onPeriodDoubleClick}
                     className={className}
                 >
                     {Icon}
@@ -104,7 +104,7 @@ PeriodListItem.propTypes = {
     period: PropTypes.object.isRequired,
     index: PropTypes.number.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
-    onDoubleClick: PropTypes.func.isRequired,
+    onPeriodDoubleClick: PropTypes.func.isRequired,
     onRemovePeriodClick: PropTypes.func.isRequired,
     listClassName: PropTypes.string.isRequired,
 };

--- a/packages/period-selector-dialog/src/PeriodSelectorDialog.js
+++ b/packages/period-selector-dialog/src/PeriodSelectorDialog.js
@@ -37,7 +37,7 @@ class PeriodSelectorDialog extends React.Component {
         this.props.onDeselect(selectedPeriods);
     };
 
-    render = () => {
+    render() {
         const { classes, open, maxWidth, fullWidth, ...remaindingProps } = this.props;
 
         return (
@@ -65,7 +65,7 @@ class PeriodSelectorDialog extends React.Component {
 }
 
 PeriodSelectorDialog.defaultProps = {
-    maxWidth: 'md',
+    maxWidth: 'lg',
     fullWidth: true,
     onSelect: () => null,
     onDeselect: () => null,

--- a/packages/period-selector-dialog/src/PeriodTypeButton.js
+++ b/packages/period-selector-dialog/src/PeriodTypeButton.js
@@ -1,22 +1,17 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
-import i18n from '@dhis2/d2-i18n';
 
-class PeriodTypeButton extends Component {
-    handleClick = () => {
-        this.props.onClick(this.props.periodType);
-    };
 
-    render = () => (
-        <Button
-            className={`nav-button ${this.props.periodType === this.props.activePeriodType ? 'active' : ''}`}
-            onClick={this.handleClick}
-        >
-            {i18n.t(this.props.text)}
-        </Button>
-    )
-}
+export const PeriodTypeButton = ({ periodType, activePeriodType, text, onClick }) => (
+    <Button
+        className={`nav-button ${periodType === activePeriodType ? 'active' : ''}`}
+        // eslint-disable-next-line react/jsx-no-bind
+        onClick={() => onClick(periodType)}
+    >
+        {text}
+    </Button>
+);
 
 PeriodTypeButton.propTypes = {
     periodType: PropTypes.string.isRequired,

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -29,6 +29,7 @@ const SelectButton = ({ onClick }) => (
     <IconButton
         variant="contained"
         onClick={onClick}
+        disableRipple
     >
         <ArrowForwardIcon style={styles.arrowIcon} />
     </IconButton>
@@ -42,6 +43,7 @@ const DeselectButton = ({ onClick }) => (
     <IconButton
         variant="contained"
         onClick={onClick}
+        disableRipple
     >
         <ArrowBackIcon style={styles.arrowIcon} />
     </IconButton>

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -4,8 +4,9 @@ import PropTypes from 'prop-types';
 import IconButton from '@material-ui/core/IconButton';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
-import PeriodTypeButton from './PeriodTypeButton';
-import SelectedPeriods from './SelectedPeriods';
+import i18n from '@dhis2/d2-i18n';
+import { PeriodTypeButton } from './PeriodTypeButton';
+import { SelectedPeriods } from './SelectedPeriods';
 import { OfferedPeriods } from './OfferedPeriods';
 import PeriodTypes from './PeriodTypes';
 import styles from './styles/PeriodListItem.style';
@@ -24,32 +25,30 @@ import {
     toggleSelectedPeriod,
 } from './actions';
 
-const SelectButton = ({ action }) => (
+const SelectButton = ({ onClick }) => (
     <IconButton
-        style={styles.arrowButton}
-        className="select-button"
-        onClick={action}
+        variant="contained"
+        onClick={onClick}
     >
         <ArrowForwardIcon style={styles.arrowIcon} />
     </IconButton>
 );
 
 SelectButton.propTypes = {
-    action: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
 };
 
-const DeselectButton = ({ action }) => (
+const DeselectButton = ({ onClick }) => (
     <IconButton
-        style={styles.arrowButton}
-        className="select-button"
-        onClick={action}
+        variant="contained"
+        onClick={onClick}
     >
         <ArrowBackIcon style={styles.arrowIcon} />
     </IconButton>
 );
 
 DeselectButton.propTypes = {
-    action: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
 };
 
 class Periods extends Component {
@@ -122,60 +121,54 @@ class Periods extends Component {
             <PeriodTypeButton
                 periodType={PeriodTypes.RELATIVE}
                 activePeriodType={this.props.periodType}
-                text={'Relative periods'}
+                text={i18n.t('Relative periods')}
                 onClick={this.onPeriodTypeClick}
             />
             <PeriodTypeButton
                 periodType={PeriodTypes.FIXED}
                 activePeriodType={this.props.periodType}
-                text={'Fixed periods'}
+                text={i18n.t('Fixed periods')}
                 onClick={this.onPeriodTypeClick}
             />
         </Fragment>
     );
 
     renderSelectButtons = () => (
-        <Fragment>
-            <SelectButton action={this.onSelectPeriods} />
-            <DeselectButton action={this.onDeselectPeriods} />
-        </Fragment>
+        <div className="block-buttons">
+            <SelectButton onClick={this.onSelectPeriods} />
+            <DeselectButton onClick={this.onDeselectPeriods} />
+        </div>
     );
 
-    render = () => {
+    render() {
         const PeriodTypeButtons = this.renderPeriodTypeButtons();
         const SelectButtons = this.renderSelectButtons();
 
         return (
-            <div>
+            <Fragment>
                 {PeriodTypeButtons}
                 <div className="periods-container">
-                    <div className="block options">
-                        <OfferedPeriods
-                            periodType={this.props.periodType}
-                            items={this.props.offeredPeriods.periods}
-                            onPeriodDoubleClick={this.onOfferedPeriodDoubleClick}
-                            onPeriodClick={this.props.toggleOfferedPeriod}
-                            setOfferedPeriods={this.props.setOfferedPeriods}
-                            addSelectedPeriods={this.props.addSelectedPeriods}
-                            selectedItems={this.props.selectedItems}
-                        />
-                    </div>
-                    <div className="block buttons">
-                        {SelectButtons}
-                    </div>
-                    <div className="block selected-periods">
-                        <SelectedPeriods
-                            items={this.props.selectedPeriods.periods}
-                            onClearAll={this.onClearAll}
-                            onPeriodDoubleClick={this.onSelectedPeriodDoubleClick}
-                            onPeriodClick={this.props.toggleSelectedPeriod}
-                            onRemovePeriodClick={this.onRemovePeriod}
-                        />
-                    </div>
+                    <OfferedPeriods
+                        periodType={this.props.periodType}
+                        items={this.props.offeredPeriods.periods}
+                        onPeriodDoubleClick={this.onOfferedPeriodDoubleClick}
+                        onPeriodClick={this.props.toggleOfferedPeriod}
+                        setOfferedPeriods={this.props.setOfferedPeriods}
+                        addSelectedPeriods={this.props.addSelectedPeriods}
+                        selectedItems={this.props.selectedItems}
+                    />
+                    {SelectButtons}
+                    <SelectedPeriods
+                        items={this.props.selectedPeriods.periods}
+                        onClearAll={this.onClearAll}
+                        onPeriodDoubleClick={this.onSelectedPeriodDoubleClick}
+                        onPeriodClick={this.props.toggleSelectedPeriod}
+                        onRemovePeriodClick={this.onRemovePeriod}
+                    />
                 </div>
-            </div>
+            </Fragment>
         );
-    };
+    }
 }
 
 Periods.propTypes = {

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -155,6 +155,7 @@ class Periods extends Component {
                             onPeriodClick={this.props.toggleOfferedPeriod}
                             setOfferedPeriods={this.props.setOfferedPeriods}
                             addSelectedPeriods={this.props.addSelectedPeriods}
+                            selectedItems={this.props.selectedItems}
                         />
                     </div>
                     <div className="block buttons">

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -87,12 +87,20 @@ class Periods extends Component {
         this.props.addOfferedPeriods(removedPeriods);
     };
 
-    onDoubleClick = (selectedPeriod) => {
-        const itemToAdd = [selectedPeriod];
+    onOfferedPeriodDoubleClick = (period) => {
+        const itemToAdd = [period];
 
         this.props.onSelect(itemToAdd);
         this.props.addSelectedPeriods(itemToAdd);
         this.props.removeOfferedPeriods(itemToAdd);
+    };
+
+    onSelectedPeriodDoubleClick = (period) => {
+        const itemToAdd = [period];
+
+        this.props.onDeselect(itemToAdd);
+        this.props.removeSelectedPeriods(itemToAdd);
+        this.props.addOfferedPeriods(itemToAdd);
     };
 
     onRemovePeriod = (removedPeriod) => {
@@ -107,11 +115,6 @@ class Periods extends Component {
         this.props.onDeselect(removedPeriods);
         this.props.addOfferedPeriods(removedPeriods);
         this.props.setSelectedPeriods([]);
-    };
-
-    getOfferedPeriods = () => {
-        const selectedIds = this.props.selectedItems.map(item => item.id);
-        return this.props.offeredPeriods.periods.filter(item => !selectedIds.includes(item.id));
     };
 
     renderPeriodTypeButtons = () => (
@@ -141,7 +144,6 @@ class Periods extends Component {
     render = () => {
         const PeriodTypeButtons = this.renderPeriodTypeButtons();
         const SelectButtons = this.renderSelectButtons();
-        const unselectedItems = this.getOfferedPeriods();
 
         return (
             <div>
@@ -150,8 +152,8 @@ class Periods extends Component {
                     <div className="block options">
                         <OfferedPeriods
                             periodType={this.props.periodType}
-                            items={unselectedItems}
-                            onDoubleClick={this.onDoubleClick}
+                            items={this.props.offeredPeriods.periods}
+                            onPeriodDoubleClick={this.onOfferedPeriodDoubleClick}
                             onPeriodClick={this.props.toggleOfferedPeriod}
                             setOfferedPeriods={this.props.setOfferedPeriods}
                             addSelectedPeriods={this.props.addSelectedPeriods}
@@ -165,6 +167,7 @@ class Periods extends Component {
                         <SelectedPeriods
                             items={this.props.selectedPeriods.periods}
                             onClearAll={this.onClearAll}
+                            onPeriodDoubleClick={this.onSelectedPeriodDoubleClick}
                             onPeriodClick={this.props.toggleSelectedPeriod}
                             onRemovePeriodClick={this.onRemovePeriod}
                         />

--- a/packages/period-selector-dialog/src/PeriodsList.js
+++ b/packages/period-selector-dialog/src/PeriodsList.js
@@ -5,16 +5,16 @@ import PeriodListItem from './PeriodListItem';
 const PeriodsList = (props) => {
     const { items, ...remaindingProps } = props;
 
-    const ListItems = props.items.map((period, index) =>
-        (<PeriodListItem
+    const ListItems = items.map((period, index) => (
+        <PeriodListItem
             period={period}
             index={index}
             key={period.id}
             {...remaindingProps}
-        />),
-    );
+        />
+    ));
 
-    return <ul className={remaindingProps.listClassName}> {ListItems} </ul>;
+    return <ul className={remaindingProps.listClassName}>{ListItems}</ul>;
 };
 
 PeriodsList.propTypes = {

--- a/packages/period-selector-dialog/src/PeriodsList.js
+++ b/packages/period-selector-dialog/src/PeriodsList.js
@@ -20,13 +20,13 @@ const PeriodsList = (props) => {
 PeriodsList.propTypes = {
     items: PropTypes.array.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
-    onDoubleClick: PropTypes.func,
+    onPeriodDoubleClick: PropTypes.func,
     onRemovePeriodClick: PropTypes.func,
     listClassName: PropTypes.string.isRequired,
 };
 
 PeriodsList.defaultProps = {
-    onDoubleClick: () => null,
+    onPeriodDoubleClick: () => null,
     onRemovePeriodClick: () => null,
 };
 

--- a/packages/period-selector-dialog/src/PeriodsList.js
+++ b/packages/period-selector-dialog/src/PeriodsList.js
@@ -7,6 +7,7 @@ const PeriodsList = (props) => {
 
     const ListItems = items.map((period, index) => (
         <PeriodListItem
+            className={remaindingProps.className}
             period={period}
             index={index}
             key={period.id}
@@ -14,7 +15,7 @@ const PeriodsList = (props) => {
         />
     ));
 
-    return <ul className={remaindingProps.listClassName}>{ListItems}</ul>;
+    return <ul className={remaindingProps.className}>{ListItems}</ul>;
 };
 
 PeriodsList.propTypes = {
@@ -22,7 +23,6 @@ PeriodsList.propTypes = {
     onPeriodClick: PropTypes.func.isRequired,
     onPeriodDoubleClick: PropTypes.func,
     onRemovePeriodClick: PropTypes.func,
-    listClassName: PropTypes.string.isRequired,
 };
 
 PeriodsList.defaultProps = {

--- a/packages/period-selector-dialog/src/RelativePeriods.js
+++ b/packages/period-selector-dialog/src/RelativePeriods.js
@@ -23,7 +23,10 @@ class RelativePeriods extends Component {
     }
 
     componentDidMount = () => {
-        this.props.setOfferedPeriods(this.generatePeriods(this.state.periodType));
+        const periods = this.generatePeriods(this.state.periodType);
+        const selectedIds = this.props.selectedItems.map(period => period.id);
+
+        this.props.setOfferedPeriods(periods.filter(period => !selectedIds.includes(period.id)));
     };
 
     onPeriodTypeChange = (event) => {
@@ -89,6 +92,7 @@ class RelativePeriods extends Component {
 
 RelativePeriods.propTypes = {
     items: PropTypes.array.isRequired,
+    selectedItems: PropTypes.array.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
     addSelectedPeriods: PropTypes.func.isRequired,
     onDoubleClick: PropTypes.func.isRequired,

--- a/packages/period-selector-dialog/src/RelativePeriods.js
+++ b/packages/period-selector-dialog/src/RelativePeriods.js
@@ -8,7 +8,6 @@ import i18n from '@dhis2/d2-i18n';
 import Button from '@material-ui/core/Button';
 import RelativePeriodsGenerator from './utils/RelativePeriodsGenerator';
 import PeriodsList from './PeriodsList';
-import styles from './styles/PeriodListItem.style';
 
 export const defaultState = {
     periodType: 'Months',
@@ -22,12 +21,12 @@ class RelativePeriods extends Component {
         this.periodsGenerator = new RelativePeriodsGenerator();
     }
 
-    componentDidMount = () => {
+    componentDidMount() {
         const periods = this.generatePeriods(this.state.periodType);
         const selectedIds = this.props.selectedItems.map(period => period.id);
 
         this.props.setOfferedPeriods(periods.filter(period => !selectedIds.includes(period.id)));
-    };
+    }
 
     onPeriodTypeChange = (event) => {
         this.setState({
@@ -51,8 +50,8 @@ class RelativePeriods extends Component {
 
     renderOptions = () => (
         <div className="options-area">
-            <FormControl className="form-control period-type">
-                <InputLabel style={styles.inputLabel} className="input-label" htmlFor="period-type">
+            <FormControl className="form-control-period-type">
+                <InputLabel className="input-label" htmlFor="period-type">
                     {i18n.t('Period type')}
                 </InputLabel>
                 <Select
@@ -70,26 +69,26 @@ class RelativePeriods extends Component {
         </div>
     );
 
-    render = () => {
+    render() {
         const Options = this.renderOptions();
 
         return (
-            <div className="selector-area">
+            <div className="block-offered-periods">
                 {Options}
                 <PeriodsList
+                    className="periods-list-offered"
                     items={this.props.items}
                     onPeriodClick={this.props.onPeriodClick}
                     onPeriodDoubleClick={this.props.onPeriodDoubleClick}
-                    listClassName={'periods-list-offered'}
                 />
-                <div style={{ textAlign: 'center' }}>
+                <div className="move-all-items-button">
                     <Button onClick={this.selectAll}>
                         {i18n.t('Select all')}
                     </Button>
                 </div>
             </div>
         );
-    };
+    }
 }
 
 RelativePeriods.propTypes = {

--- a/packages/period-selector-dialog/src/RelativePeriods.js
+++ b/packages/period-selector-dialog/src/RelativePeriods.js
@@ -39,7 +39,9 @@ class RelativePeriods extends Component {
 
     generatePeriods = (periodType) => {
         const generator = this.periodsGenerator.get(periodType);
-        return generator.generatePeriods();
+        const selectedIds = this.props.selectedItems.map(item => item.id);
+
+        return generator.generatePeriods().filter(item => !selectedIds.includes(item.id));
     };
 
     selectAll = () => {
@@ -77,7 +79,7 @@ class RelativePeriods extends Component {
                 <PeriodsList
                     items={this.props.items}
                     onPeriodClick={this.props.onPeriodClick}
-                    onDoubleClick={this.props.onDoubleClick}
+                    onPeriodDoubleClick={this.props.onPeriodDoubleClick}
                     listClassName={'periods-list-offered'}
                 />
                 <div style={{ textAlign: 'center' }}>
@@ -95,7 +97,7 @@ RelativePeriods.propTypes = {
     selectedItems: PropTypes.array.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
     addSelectedPeriods: PropTypes.func.isRequired,
-    onDoubleClick: PropTypes.func.isRequired,
+    onPeriodDoubleClick: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
 };
 

--- a/packages/period-selector-dialog/src/SelectedPeriods.js
+++ b/packages/period-selector-dialog/src/SelectedPeriods.js
@@ -4,31 +4,29 @@ import Button from '@material-ui/core/Button';
 import i18n from '@dhis2/d2-i18n';
 import PeriodsList from './PeriodsList';
 
-class SelectedPeriods extends React.Component {
-    clearPeriods = () => {
-        this.props.onClearAll(this.props.items);
-    };
+const Subtitle = () => (
+    <div className="subtitle-container">
+        <span className="subtitle"> {i18n.t('Selected periods')} </span>
+    </div>
+);
 
-    render = () => (
-        <div className="selector-area">
-            <div className="subtitle-container">
-                <span className="subtitle"> {i18n.t('Selected periods')} </span>
-            </div>
-            <PeriodsList
-                items={this.props.items}
-                onPeriodClick={this.props.onPeriodClick}
-                onPeriodDoubleClick={this.props.onPeriodDoubleClick}
-                onRemovePeriodClick={this.props.onRemovePeriodClick}
-                listClassName={'periods-list-selected'}
-            />
-            <div style={{ textAlign: 'center' }}>
-                <Button onClick={this.clearPeriods} >
-                    {i18n.t('Deselect all')}
-                </Button>
-            </div>
+export const SelectedPeriods = ({ onClearAll, ...remaindingProps }) => (
+    <div className="block-selected-periods">
+        <Subtitle />
+        <PeriodsList
+            className="periods-list-selected"
+            {...remaindingProps}
+        />
+        <div className="move-all-items-button">
+            <Button
+                // eslint-disable-next-line react/jsx-no-bind
+                onClick={() => onClearAll(remaindingProps.items)}
+            >
+                {i18n.t('Deselect all')}
+            </Button>
         </div>
-    )
-}
+    </div>
+);
 
 SelectedPeriods.propTypes = {
     items: PropTypes.array.isRequired,

--- a/packages/period-selector-dialog/src/SelectedPeriods.js
+++ b/packages/period-selector-dialog/src/SelectedPeriods.js
@@ -17,6 +17,7 @@ class SelectedPeriods extends React.Component {
             <PeriodsList
                 items={this.props.items}
                 onPeriodClick={this.props.onPeriodClick}
+                onPeriodDoubleClick={this.props.onPeriodDoubleClick}
                 onRemovePeriodClick={this.props.onRemovePeriodClick}
                 listClassName={'periods-list-selected'}
             />
@@ -32,6 +33,7 @@ class SelectedPeriods extends React.Component {
 SelectedPeriods.propTypes = {
     items: PropTypes.array.isRequired,
     onClearAll: PropTypes.func.isRequired,
+    onPeriodDoubleClick: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
     onRemovePeriodClick: PropTypes.func.isRequired,
 };

--- a/packages/period-selector-dialog/src/reducers/periods.js
+++ b/packages/period-selector-dialog/src/reducers/periods.js
@@ -51,7 +51,7 @@ export default (periodType = 'offered') => (state = defaultState, action) => {
 
     case actionTypes[`TOGGLE_${periodType.toUpperCase()}_PERIOD`]: {
         const { index, isShiftPressed, isCtrlPressed } = action;
-        
+
         // If control was not pressed, then only select
         // current period and unselect all others
         if (isCtrlPressed === false && isShiftPressed === false) {

--- a/packages/period-selector-dialog/src/styles/PeriodListItem.style.js
+++ b/packages/period-selector-dialog/src/styles/PeriodListItem.style.js
@@ -1,18 +1,8 @@
 export default {
     removeItemButton: {
-        border: 'none',
-        outline: 'none',
-        background: 'none',
         padding: '0px',
         height: '18px',
         width: '18px',
-    },
-    arrowButton: {
-        padding: '0px',
-        borderRadius: '4px',
-        minWidth: '40px',
-        minHeight: '36px',
-        backgroundColor: 'white',
     },
     arrowIcon: {
         height: '20px',


### PR DESCRIPTION
Change rules to Paper components for MuiDialog:

- Use FlexBasis instead of width such that Dialog sizes can be rendered dynamically and have its widht flex freely based on User's screen size.
- Remove minWidth (will most likely cause problems on smaller screens)
- Set maxHeight to 19% of total viewport (this value is something i just picked, after  testing Dialogs on my 15 inch screen - not 100% sure if it is sufficient for smaller screen sizes) as the "AddToLayoutButton" on Dimension dialogs in DV crammed the dropDown Menu.
![image](https://user-images.githubusercontent.com/13645152/49004187-07854c00-f164-11e8-91ee-abd1f485047d.png)
