### PR TITLE
remove minWidth and width rules, change to 'flexBasis', also set maxH…

### DIFF
--- a/packages/core/src/theme/mui3.theme.js
+++ b/packages/core/src/theme/mui3.theme.js
@@ -96,19 +96,18 @@ export const theme = {
         },
         MuiDialog: {
             paperWidthSm: {
-                flexBasis: 400,
-                maxWidth: 400,
-                maxHeight: 'calc(100vh - 15%)',
+                flex: '0 1 400px',
+                width: '400px',
+                maxWidth: '400px',
             },
             paperWidthMd: {
-                flexBasis: 600,
-                maxWidth: 600,
-                maxHeight: 'calc(100vh - 15%)',
+                flex: '0 1 600px',
+                width: '600px',
+                maxWidth: '600px',
             },
             paperWidthLg: {
-                flexBasis: 800,
-                maxWidth: 800,
-                maxHeight: 'calc(100vh - 20%)',
+                flex: '0 1 800px',
+                maxWidth: '800px',
             },
         },
         MuiDialogTitle: {

--- a/packages/core/src/theme/mui3.theme.js
+++ b/packages/core/src/theme/mui3.theme.js
@@ -96,19 +96,19 @@ export const theme = {
         },
         MuiDialog: {
             paperWidthSm: {
-                minWidth: 400,
-                width: 400,
+                flexBasis: 400,
                 maxWidth: 400,
+                maxHeight: 'calc(100vh - 19%)',
             },
             paperWidthMd: {
-                minWidth: 600,
-                width: 600,
+                flexBasis: 600,
                 maxWidth: 600,
+                maxHeight: 'calc(100vh - 19%)',
             },
             paperWidthLg: {
-                minWidth: 800,
-                width: 800,
+                flexBasis: 800,
                 maxWidth: 800,
+                maxHeight: 'calc(100vh - 19%)',
             },
         },
         MuiDialogTitle: {

--- a/packages/core/src/theme/mui3.theme.js
+++ b/packages/core/src/theme/mui3.theme.js
@@ -98,17 +98,17 @@ export const theme = {
             paperWidthSm: {
                 flexBasis: 400,
                 maxWidth: 400,
-                maxHeight: 'calc(100vh - 19%)',
+                maxHeight: 'calc(100vh - 15%)',
             },
             paperWidthMd: {
                 flexBasis: 600,
                 maxWidth: 600,
-                maxHeight: 'calc(100vh - 19%)',
+                maxHeight: 'calc(100vh - 15%)',
             },
             paperWidthLg: {
                 flexBasis: 800,
                 maxWidth: 800,
-                maxHeight: 'calc(100vh - 19%)',
+                maxHeight: 'calc(100vh - 20%)',
             },
         },
         MuiDialogTitle: {


### PR DESCRIPTION
Change rules to Paper components for MuiDialog:

Use FlexBasis instead of width such that Dialog sizes can be rendered dynamically and have its width flex freely based on available screen space.
Remove minWidth (will most likely cause problems on smaller screens).
Set maxHeight to 19% of total viewport (this value is something i just picked, after testing Dialogs on my 15 inch screen - not 100% sure if it is sufficient for smaller screen sizes) as the "AddToLayoutButton" on Dimension dialogs in DV crammed the dropDown Menu.
![image](https://user-images.githubusercontent.com/13645152/49004620-f1c45680-f164-11e8-873f-b3be452148c4.png)
