### PR TITLE
feature/implement drag and drop to reorder selected periods in period-selector

### DIFF
--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -27,6 +27,7 @@
     "babel-runtime": "^6.26.0",
     "prop-types": "^15.6.0",
     "react-redux": "^5.0.7",
+    "react-sortable-hoc": "^0.8.4",
     "redux": "^4.0.1"
   },
   "publishConfig": {

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "babel-jest": "^23.0.1",
+    "enzyme": "^3.7.0",
     "jest": "^23.1.0",
     "mkdirp": "^0.5.1"
   },

--- a/packages/period-selector-dialog/src/PeriodListItem.js
+++ b/packages/period-selector-dialog/src/PeriodListItem.js
@@ -67,25 +67,27 @@ class PeriodListItem extends Component {
     );
 
     render = () => (
-        <div
-            role="button"
-            tabIndex={0}
-            style={this.props.period.selected ? styles.highlightedContainer : {}}
-            onMouseEnter={this.highlightItem}
-            onMouseLeave={this.removeHighlight}
-            onClick={this.onPeriodClick}
-            onDoubleClick={this.onPeriodDoubleClick}
-            className={this.isOfferedList() ? 'period-offered-label' : 'period-selected-label'}
-        >
-            {this.renderIcon()}
-            <span
-                style={this.props.period.selected ? styles.higlightedText : {}}
-                className="list-text"
+        <li className="period-dimension-item">
+            <div
+                role="button"
+                tabIndex={0}
+                style={this.props.period.selected ? styles.highlightedContainer : {}}
+                onMouseEnter={this.highlightItem}
+                onMouseLeave={this.removeHighlight}
+                onClick={this.onPeriodClick}
+                onDoubleClick={this.onPeriodDoubleClick}
+                className={this.isOfferedList() ? 'period-offered-label' : 'period-selected-label'}
             >
-                {this.props.period.name}
-            </span>
-            {this.renderRemoveButton()}
-        </div>
+                {this.renderIcon()}
+                <span
+                    style={this.props.period.selected ? styles.higlightedText : {}}
+                    className="list-text"
+                >
+                    {this.props.period.name}
+                </span>
+                {this.renderRemoveButton()}
+            </div>
+        </li>
     );
 }
 

--- a/packages/period-selector-dialog/src/PeriodListItem.js
+++ b/packages/period-selector-dialog/src/PeriodListItem.js
@@ -66,38 +66,27 @@ class PeriodListItem extends Component {
             : <RemoveItemButton isHighlighted={this.props.period.selected} action={this.onRemovePeriodClick} />
     );
 
-    render = () => {
-        const className = this.isOfferedList() ? 'period-offered-label' : 'period-selected-label';
-        const Icon = this.renderIcon();
-        const RemoveButton = this.renderRemoveButton();
-
-        if (typeof this.props.index == 'undefined') {
-            console.log('PLI index', this.props.index, this.props.period.name, this.props.listClassName);
-        }
-
-
-        return (
-            <div
-                role="button"
-                tabIndex={0}
-                style={this.props.period.selected ? styles.highlightedContainer : {}}
-                onMouseEnter={this.highlightItem}
-                onMouseLeave={this.removeHighlight}
-                onClick={this.onPeriodClick}
-                onDoubleClick={this.onPeriodDoubleClick}
-                className={className}
+    render = () => (
+        <div
+            role="button"
+            tabIndex={0}
+            style={this.props.period.selected ? styles.highlightedContainer : {}}
+            onMouseEnter={this.highlightItem}
+            onMouseLeave={this.removeHighlight}
+            onClick={this.onPeriodClick}
+            onDoubleClick={this.onPeriodDoubleClick}
+            className={this.isOfferedList() ? 'period-offered-label' : 'period-selected-label'}
+        >
+            {this.renderIcon()}
+            <span
+                style={this.props.period.selected ? styles.higlightedText : {}}
+                className="list-text"
             >
-                {Icon}
-                <span
-                    style={this.props.period.selected ? styles.higlightedText : {}}
-                    className="list-text"
-                >
-                    {this.props.period.name}
-                </span>
-                {RemoveButton}
-            </div>
-        );
-    };
+                {this.props.period.name}
+            </span>
+            {this.renderRemoveButton()}
+        </div>
+    );
 }
 
 PeriodListItem.propTypes = {

--- a/packages/period-selector-dialog/src/PeriodListItem.js
+++ b/packages/period-selector-dialog/src/PeriodListItem.js
@@ -71,6 +71,11 @@ class PeriodListItem extends Component {
         const Icon = this.renderIcon();
         const RemoveButton = this.renderRemoveButton();
 
+        if (typeof this.props.index == 'undefined') {
+            console.log('PLI index', this.props.index, this.props.period.name, this.props.listClassName);
+        }
+
+
         return (
             <div
                 role="button"

--- a/packages/period-selector-dialog/src/PeriodListItem.js
+++ b/packages/period-selector-dialog/src/PeriodListItem.js
@@ -72,30 +72,25 @@ class PeriodListItem extends Component {
         const RemoveButton = this.renderRemoveButton();
 
         return (
-            <li
-                key={this.props.period.id}
-                className="period-dimension-item"
+            <div
+                role="button"
+                tabIndex={0}
+                style={this.props.period.selected ? styles.highlightedContainer : {}}
+                onMouseEnter={this.highlightItem}
+                onMouseLeave={this.removeHighlight}
+                onClick={this.onPeriodClick}
+                onDoubleClick={this.onPeriodDoubleClick}
+                className={className}
             >
-                <div
-                    role="button"
-                    tabIndex={0}
-                    style={this.props.period.selected ? styles.highlightedContainer : {}}
-                    onMouseEnter={this.highlightItem}
-                    onMouseLeave={this.removeHighlight}
-                    onClick={this.onPeriodClick}
-                    onDoubleClick={this.onPeriodDoubleClick}
-                    className={className}
+                {Icon}
+                <span
+                    style={this.props.period.selected ? styles.higlightedText : {}}
+                    className="list-text"
                 >
-                    {Icon}
-                    <span
-                        style={this.props.period.selected ? styles.higlightedText : {}}
-                        className="list-text"
-                    >
-                        {this.props.period.name}
-                    </span>
-                    {RemoveButton}
-                </div>
-            </li>
+                    {this.props.period.name}
+                </span>
+                {RemoveButton}
+            </div>
         );
     };
 }

--- a/packages/period-selector-dialog/src/PeriodListItem.js
+++ b/packages/period-selector-dialog/src/PeriodListItem.js
@@ -10,7 +10,7 @@ const UnselectedIcon = () => <div className="unselected-icon" />;
 const HighlightedIcon = () => <div className="highlighted-icon" />;
 const SelectedIcon = () => <div className="selected-icon" />;
 
-const RemoveItemButton = ({ action, isHighlighted }) => (
+export const RemoveItemButton = ({ action, isHighlighted }) => (
     <IconButton
         style={styles.removeItemButton}
         onClick={action}

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -134,6 +134,10 @@ class Periods extends Component {
         this.props.setSelectedPeriods([]);
     };
 
+    onReorder = (periods) => {
+        this.props.setSelectedPeriods(periods);
+    }
+
     renderPeriodTypeButtons = () => (
         <Fragment>
             <PeriodTypeButton
@@ -187,6 +191,7 @@ class Periods extends Component {
                             onPeriodDoubleClick={this.onSelectedPeriodDoubleClick}
                             onPeriodClick={this.props.toggleSelectedPeriod}
                             onRemovePeriodClick={this.onRemovePeriod}
+                            onReorder={this.onReorder}
                         />
                     </div>
                 </div>

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -134,10 +134,6 @@ class Periods extends Component {
         this.props.setSelectedPeriods([]);
     };
 
-    onReorder = (periods) => {
-        this.props.setSelectedPeriods(periods);
-    }
-
     renderPeriodTypeButtons = () => (
         <Fragment>
             <PeriodTypeButton
@@ -191,7 +187,7 @@ class Periods extends Component {
                             onPeriodDoubleClick={this.onSelectedPeriodDoubleClick}
                             onPeriodClick={this.props.toggleSelectedPeriod}
                             onRemovePeriodClick={this.onRemovePeriod}
-                            onReorder={this.onReorder}
+                            onReorder={this.props.setSelectedPeriods}
                         />
                     </div>
                 </div>

--- a/packages/period-selector-dialog/src/PeriodsList.js
+++ b/packages/period-selector-dialog/src/PeriodsList.js
@@ -7,12 +7,12 @@ import {
 } from 'react-sortable-hoc';
 import PeriodListItem from './PeriodListItem';
 
-const SortableItem = SortableElement(({ period, index, listClassName, ...handlerProps }) => {
+const SortableItem = SortableElement(({ period, idx, listClassName, ...handlerProps }) => {
     return (
         <li key={period.id} className="period-dimension-item">
             <PeriodListItem
                 period={period}
-                index={index}
+                index={idx}
                 listClassName={listClassName}
                 {...handlerProps}
             />
@@ -29,6 +29,7 @@ const SortableList = SortableContainer(
                         key={period.id}
                         period={period}
                         index={index}
+                        idx={index}
                         listClassName={listClassName}
                         {...handlerProps}
                     />

--- a/packages/period-selector-dialog/src/PeriodsList.js
+++ b/packages/period-selector-dialog/src/PeriodsList.js
@@ -7,37 +7,31 @@ import {
 } from 'react-sortable-hoc';
 import PeriodListItem from './PeriodListItem';
 
-const SortableItem = SortableElement(({ period, idx, listClassName, ...handlerProps }) => {
-    return (
-        <li key={period.id} className="period-dimension-item">
-            <PeriodListItem
-                period={period}
-                index={idx}
-                listClassName={listClassName}
-                {...handlerProps}
-            />
-        </li>
-    );
-});
+const SortableItem = SortableElement(({ period, idx, listClassName, ...handlerProps }) => (
+    <PeriodListItem
+        key={period.id}
+        period={period}
+        index={idx}
+        listClassName={listClassName}
+        {...handlerProps}
+    />
+));
 
 const SortableList = SortableContainer(
-    ({ items, listClassName, ...handlerProps }) => {
-        return (
-            <ul className={listClassName}>
-                {items.map((period, index) => (
-                    <SortableItem
-                        key={period.id}
-                        period={period}
-                        index={index}
-                        idx={index}
-                        listClassName={listClassName}
-                        {...handlerProps}
-                    />
-                ))}
-            </ul>
-        );
-    },
-);
+    ({ items, listClassName, ...handlerProps }) => (
+        <ul className={listClassName}>
+            {items.map((period, index) => (
+                <SortableItem
+                    key={period.id}
+                    period={period}
+                    index={index}
+                    idx={index}
+                    listClassName={listClassName}
+                    {...handlerProps}
+                />
+            ))}
+        </ul>
+    ));
 
 class PeriodsList extends Component {
     onSortEnd = ({ oldIndex, newIndex }) => {
@@ -64,18 +58,13 @@ class PeriodsList extends Component {
         }
 
         const ListItems = items.map((period, index) => (
-            <li
+            <PeriodListItem
                 key={period.id}
-                className="period-dimension-item"
-            >
-                <PeriodListItem
-                    period={period}
-                    index={index}
-                    key={period.id}
-                    listClassName={listClassName}
-                    {...handlerProps}
-                />
-            </li>
+                period={period}
+                index={index}
+                listClassName={listClassName}
+                {...handlerProps}
+            />
         ));
 
         return <ul className={listClassName}>{ListItems}</ul>;
@@ -95,6 +84,7 @@ PeriodsList.propTypes = {
 PeriodsList.defaultProps = {
     onPeriodDoubleClick: () => null,
     onRemovePeriodClick: () => null,
+    onReorder: () => null,
 };
 
 export default PeriodsList;

--- a/packages/period-selector-dialog/src/PeriodsList.js
+++ b/packages/period-selector-dialog/src/PeriodsList.js
@@ -82,9 +82,9 @@ PeriodsList.propTypes = {
 };
 
 PeriodsList.defaultProps = {
-    onPeriodDoubleClick: () => null,
-    onRemovePeriodClick: () => null,
-    onReorder: () => null,
+    onPeriodDoubleClick: Function.prototype,
+    onRemovePeriodClick: Function.prototype,
+    onReorder: Function.prototype,
 };
 
 export default PeriodsList;

--- a/packages/period-selector-dialog/src/PeriodsList.js
+++ b/packages/period-selector-dialog/src/PeriodsList.js
@@ -1,28 +1,94 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import {
+    SortableContainer,
+    SortableElement,
+    arrayMove,
+} from 'react-sortable-hoc';
 import PeriodListItem from './PeriodListItem';
 
-const PeriodsList = (props) => {
-    const { items, ...remaindingProps } = props;
+const SortableItem = SortableElement(({ period, index, listClassName, ...handlerProps }) => {
+    return (
+        <li key={period.id} className="period-dimension-item">
+            <PeriodListItem
+                period={period}
+                index={index}
+                listClassName={listClassName}
+                {...handlerProps}
+            />
+        </li>
+    );
+});
 
-    const ListItems = items.map((period, index) => (
-        <PeriodListItem
-            period={period}
-            index={index}
-            key={period.id}
-            {...remaindingProps}
-        />
-    ));
+const SortableList = SortableContainer(
+    ({ items, listClassName, ...handlerProps }) => {
+        return (
+            <ul className={listClassName}>
+                {items.map((period, index) => (
+                    <SortableItem
+                        key={period.id}
+                        period={period}
+                        index={index}
+                        listClassName={listClassName}
+                        {...handlerProps}
+                    />
+                ))}
+            </ul>
+        );
+    },
+);
 
-    return <ul className={remaindingProps.listClassName}>{ListItems}</ul>;
-};
+class PeriodsList extends Component {
+    onSortEnd = ({ oldIndex, newIndex }) => {
+        this.props.onReorder(arrayMove(this.props.items, oldIndex, newIndex));
+    }
+
+    render() {
+        const {
+            items,
+            sortable,
+            listClassName,
+            ...handlerProps
+        } = this.props;
+
+        if (sortable) {
+            return (<SortableList
+                distance={3}
+                transitionDuration={200}
+                onSortEnd={this.onSortEnd}
+                items={items}
+                listClassName={listClassName}
+                {...handlerProps}
+            />);
+        }
+
+        const ListItems = items.map((period, index) => (
+            <li
+                key={period.id}
+                className="period-dimension-item"
+            >
+                <PeriodListItem
+                    period={period}
+                    index={index}
+                    key={period.id}
+                    listClassName={listClassName}
+                    {...handlerProps}
+                />
+            </li>
+        ));
+
+        return <ul className={listClassName}>{ListItems}</ul>;
+    }
+}
 
 PeriodsList.propTypes = {
     items: PropTypes.array.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
     onPeriodDoubleClick: PropTypes.func,
     onRemovePeriodClick: PropTypes.func,
+    onReorder: PropTypes.func,
     listClassName: PropTypes.string.isRequired,
+    sortable: PropTypes.bool,
 };
 
 PeriodsList.defaultProps = {

--- a/packages/period-selector-dialog/src/SelectedPeriods.js
+++ b/packages/period-selector-dialog/src/SelectedPeriods.js
@@ -5,10 +5,6 @@ import i18n from '@dhis2/d2-i18n';
 import PeriodsList from './PeriodsList';
 
 class SelectedPeriods extends React.Component {
-    onReorder = (periods) => {
-        this.props.onReorder(periods);
-    }
-
     clearPeriods = () => {
         this.props.onClearAll(this.props.items);
     };
@@ -23,7 +19,7 @@ class SelectedPeriods extends React.Component {
                 onPeriodClick={this.props.onPeriodClick}
                 onPeriodDoubleClick={this.props.onPeriodDoubleClick}
                 onRemovePeriodClick={this.props.onRemovePeriodClick}
-                onReorder={this.onReorder}
+                onReorder={this.props.onReorder}
                 listClassName={'periods-list-selected'}
                 sortable
             />

--- a/packages/period-selector-dialog/src/SelectedPeriods.js
+++ b/packages/period-selector-dialog/src/SelectedPeriods.js
@@ -5,6 +5,10 @@ import i18n from '@dhis2/d2-i18n';
 import PeriodsList from './PeriodsList';
 
 class SelectedPeriods extends React.Component {
+    onReorder = (periods) => {
+        this.props.onReorder(periods);
+    }
+
     clearPeriods = () => {
         this.props.onClearAll(this.props.items);
     };
@@ -19,7 +23,9 @@ class SelectedPeriods extends React.Component {
                 onPeriodClick={this.props.onPeriodClick}
                 onPeriodDoubleClick={this.props.onPeriodDoubleClick}
                 onRemovePeriodClick={this.props.onRemovePeriodClick}
+                onReorder={this.onReorder}
                 listClassName={'periods-list-selected'}
+                sortable
             />
             <div style={{ textAlign: 'center' }}>
                 <Button onClick={this.clearPeriods} >
@@ -36,6 +42,7 @@ SelectedPeriods.propTypes = {
     onPeriodDoubleClick: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
     onRemovePeriodClick: PropTypes.func.isRequired,
+    onReorder: PropTypes.func.isRequired,
 };
 
 export default SelectedPeriods;

--- a/packages/period-selector-dialog/src/__tests__/PeriodListItem.spec.js
+++ b/packages/period-selector-dialog/src/__tests__/PeriodListItem.spec.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import IconButton from '@material-ui/core/IconButton';
+import PeriodListItem, { RemoveItemButton } from '../PeriodListItem';
+
+describe('PeriodListItem', () => {
+    let props;
+    let shallowItem;
+    const getShallowItem = () => {
+        if (!shallowItem) {
+            shallowItem = shallow(<PeriodListItem {...props} />);
+        }
+        return shallowItem;
+    };
+
+    beforeEach(() => {
+        props = {
+            period: { id: 'hey', name: 'Hey', selected: true },
+            index: 0,
+            onPeriodClick: jest.fn(),
+            onPeriodDoubleClick: jest.fn(),
+            onRemovePeriodClick: jest.fn(),
+            listClassName: 'selected',
+        };
+        shallowItem = undefined;
+    });
+
+    it('renders a list item', () => {
+        expect(getShallowItem().find('li')).toHaveLength(1);
+    });
+
+    it('displays the name of the period', () => {
+        const itemText = getShallowItem().find('div').childAt(1).text();
+        expect(itemText).toEqual(props.period.name);
+    });
+
+    it('triggers onClick', () => {
+        const item = getShallowItem().find('div');
+        item.simulate('click', { shiftKey: 'a', metaKey: 'b' });
+        expect(props.onPeriodClick).toHaveBeenCalled();
+        expect(props.onPeriodClick).toHaveBeenCalledWith(props.period, props.index, 'a', 'b');
+    });
+
+    it('triggers onDoubleCLick', () => {
+        const item = getShallowItem().find('div');
+        item.simulate('doubleclick');
+        expect(props.onPeriodDoubleClick).toHaveBeenCalled();
+        expect(props.onPeriodDoubleClick).toHaveBeenCalledWith(props.period);
+    });
+
+    describe('unselected item', () => {
+        beforeEach(() => {
+            props.listClassName = 'periods-list-offered';
+            props.period.selected = false;
+        });
+
+        it('does not render the remove button', () => {
+            expect(getShallowItem().find(RemoveItemButton)).toHaveLength(0);
+        });
+    });
+
+    describe('selected item', () => {
+        beforeEach(() => {
+            props.listClassName = 'selected';
+            props.period.selected = true;
+        });
+
+        it('renders the remove button', () => {
+            expect(getShallowItem().find(RemoveItemButton)).toHaveLength(1);
+        });
+
+        it('triggers the onRemoveItem action', () => {
+            const item = getShallowItem().find(RemoveItemButton).dive().find(IconButton);
+            item.simulate('click', { stopPropagation: jest.fn() });
+            expect(props.onRemovePeriodClick).toHaveBeenCalled();
+            expect(props.onRemovePeriodClick).toHaveBeenCalledWith(props.period);
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4094,7 +4094,7 @@ enzyme-to-json@^3.3.0:
   dependencies:
     lodash "^4.17.4"
 
-enzyme@^3.0.0:
+enzyme@^3.0.0, enzyme@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.7.0.tgz#9b499e8ca155df44fef64d9f1558961ba1385a46"
   integrity sha512-QLWx+krGK6iDNyR1KlH5YPZqxZCQaVF6ike1eDJAOg0HvSkSCVImPsdWaNw6v+VrnK92Kg8jIOYhuOSS9sBpyg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,7 +2035,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.26.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
+babel-runtime@6.26.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -6022,7 +6022,7 @@ interpret@^1.0.0, interpret@^1.1.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
   integrity sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
 
-invariant@^2.2.0, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -9977,6 +9977,15 @@ react-select@^2.0.0:
     raf "^3.4.0"
     react-input-autosize "^2.2.1"
     react-transition-group "^2.2.1"
+
+react-sortable-hoc@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-0.8.4.tgz#11aa1f3e07ded79764a8bae9d107990ab9b3954b"
+  integrity sha512-J9AFEQAJ7u2YWdVzkU5E3ewrG82xQ4xF1ZPrZYKliDwlVBDkmjri+iKFAEt6NCDIRiBZ4hiN5vzI8pwy/dGPHw==
+  dependencies:
+    babel-runtime "^6.11.6"
+    invariant "^2.2.1"
+    prop-types "^15.5.7"
 
 react-stub-context@^0.8.1:
   version "0.8.1"


### PR DESCRIPTION
Enables user to drag and drop one selected item at a time to reorder. Multi-drag will be implemented in a follow-up PR
