### PR TITLE
Keep offered periods list populated with appropriate periods

### DIFF
--- a/packages/period-selector-dialog/css/PeriodSelector.css
+++ b/packages/period-selector-dialog/css/PeriodSelector.css
@@ -72,6 +72,10 @@ button.nav-button:last-child {
     margin: 0px;
 }
 
+.sortableHelper {
+    z-index: 10000;
+}
+
 .periods-list-offered {
     list-style: none;
     overflow: auto;

--- a/packages/period-selector-dialog/src/FixedPeriods.js
+++ b/packages/period-selector-dialog/src/FixedPeriods.js
@@ -98,8 +98,8 @@ class FixedPeriods extends Component {
     };
 
     selectAll = () => {
-        this.props.addSelectedPeriods(this.props.items);
-        this.setOfferedPeriods([]);
+        this.props.onSelect(this.props.items);
+        this.props.setOfferedPeriods([]);
     };
 
     closeYearSelect = () => {
@@ -219,7 +219,7 @@ FixedPeriods.propTypes = {
     onPeriodClick: PropTypes.func.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
     setOfferedPeriodIds: PropTypes.func.isRequired,
-    addSelectedPeriods: PropTypes.func.isRequired,
+    onSelect: PropTypes.func.isRequired,
 };
 
 FixedPeriods.contextTypes = {

--- a/packages/period-selector-dialog/src/FixedPeriods.js
+++ b/packages/period-selector-dialog/src/FixedPeriods.js
@@ -33,9 +33,8 @@ class FixedPeriods extends Component {
 
     componentDidMount = () => {
         const periods = this.generatePeriods(this.state.periodType, this.state.year);
-        const selectedIds = this.props.selectedItems.map(period => period.id);
 
-        this.props.setOfferedPeriods(periods.filter(period => !selectedIds.includes(period.id)));
+        this.setOfferedPeriods(periods);
     };
 
     onPeriodTypeChange = (event) => {
@@ -44,7 +43,7 @@ class FixedPeriods extends Component {
         });
 
         if (this.state.year) {
-            this.props.setOfferedPeriods(this.generatePeriods(event.target.value, this.state.year));
+            this.setOfferedPeriods(this.generatePeriods(event.target.value, this.state.year));
         }
     };
 
@@ -55,7 +54,7 @@ class FixedPeriods extends Component {
         });
 
         if (this.state.periodType) {
-            this.props.setOfferedPeriods(this.generatePeriods(this.state.periodType, event.target.value));
+            this.setOfferedPeriods(this.generatePeriods(this.state.periodType, event.target.value));
         }
     };
 
@@ -81,22 +80,26 @@ class FixedPeriods extends Component {
         return years;
     };
 
+    setOfferedPeriods = (periods) => {
+        const selectedIds = this.props.selectedItems.map(period => period.id);
+
+        this.props.setOfferedPeriodIds(periods);
+        this.props.setOfferedPeriods(periods.filter(period => !selectedIds.includes(period.id)));
+    };
+
     generatePeriods = (periodType, year) => {
         const generator = this.periodsGenerator.get(periodType);
-        const selectedIds = this.props.selectedItems.map(item => item.id);
 
-        return generator
-            .generatePeriods({
-                offset: year - (new Date()).getFullYear(),
-                filterFuturePeriods: false,
-                reversePeriods: false,
-            })
-            .filter(period => !selectedIds.includes(period.id));
+        return generator.generatePeriods({
+            offset: year - (new Date()).getFullYear(),
+            filterFuturePeriods: false,
+            reversePeriods: false,
+        });
     };
 
     selectAll = () => {
         this.props.addSelectedPeriods(this.props.items);
-        this.props.setOfferedPeriods([]);
+        this.setOfferedPeriods([]);
     };
 
     closeYearSelect = () => {
@@ -215,6 +218,7 @@ FixedPeriods.propTypes = {
     onPeriodDoubleClick: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
+    setOfferedPeriodIds: PropTypes.func.isRequired,
     addSelectedPeriods: PropTypes.func.isRequired,
 };
 

--- a/packages/period-selector-dialog/src/PeriodSelector.js
+++ b/packages/period-selector-dialog/src/PeriodSelector.js
@@ -13,12 +13,14 @@ const PeriodSelector = props => (
 PeriodSelector.propTypes = {
     onSelect: PropTypes.func,
     onDeselect: PropTypes.func,
+    onReorder: PropTypes.func,
     selectedItems: PropTypes.arrayOf(PropTypes.object),
 };
 
 PeriodSelector.defaultProps = {
     onSelect: () => null,
     onDeselect: () => null,
+    onReorder: () => null,
     selectedItems: [],
 };
 

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -202,7 +202,7 @@ class Periods extends Component {
                             onClearAll={this.onClearAll}
                             onPeriodDoubleClick={this.onSelectedPeriodDoubleClick}
                             onPeriodClick={this.props.toggleSelectedPeriod}
-                            onReorder={this.props.setSelectedPeriods}
+                            onReorder={this.props.onReorder}
                             onRemovePeriodClick={this.onSelectedPeriodRemove}
                         />
                     </div>
@@ -215,6 +215,7 @@ class Periods extends Component {
 Periods.propTypes = {
     onSelect: PropTypes.func.isRequired,
     onDeselect: PropTypes.func.isRequired,
+    onReorder: PropTypes.func.isRequired,
     selectedItems: PropTypes.array.isRequired,
     periodType: PropTypes.string.isRequired,
     offeredPeriods: PropTypes.object.isRequired,

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -57,6 +57,10 @@ class Periods extends Component {
         super(props);
 
         this.props.setSelectedPeriods(this.props.selectedItems);
+
+        this.state = {
+            offeredPeriodIds: [],
+        };
     }
 
     componentDidUpdate(prevProps) {
@@ -101,7 +105,7 @@ class Periods extends Component {
 
         this.props.onDeselect(removedPeriods);
         this.props.removeSelectedPeriods(removedPeriods);
-        this.props.addOfferedPeriods(removedPeriods);
+        this.addOfferedPeriods(removedPeriods);
     };
 
     onOfferedPeriodDoubleClick = (period) => {
@@ -117,21 +121,31 @@ class Periods extends Component {
 
         this.props.onDeselect(itemToAdd);
         this.props.removeSelectedPeriods(itemToAdd);
-        this.props.addOfferedPeriods(itemToAdd);
+        this.addOfferedPeriods(itemToAdd);
     };
 
-    onRemovePeriod = (removedPeriod) => {
+    onSelectedPeriodRemove= (removedPeriod) => {
         const itemToRemove = [removedPeriod];
 
         this.props.onDeselect(itemToRemove);
         this.props.removeSelectedPeriods(itemToRemove);
-        this.props.addOfferedPeriods(itemToRemove);
+        this.addOfferedPeriods(itemToRemove);
     };
 
     onClearAll = (removedPeriods) => {
         this.props.onDeselect(removedPeriods);
-        this.props.addOfferedPeriods(removedPeriods);
+        this.addOfferedPeriods(removedPeriods);
         this.props.setSelectedPeriods([]);
+    };
+
+    setOfferedPeriodIds = (periods) => {
+        this.setState({
+            offeredPeriodIds: periods.map(period => period.id),
+        });
+    };
+
+    addOfferedPeriods = (periods) => {
+        this.props.addOfferedPeriods(periods.filter(period => this.state.offeredPeriodIds.includes(period.id)));
     };
 
     renderPeriodTypeButtons = () => (
@@ -173,6 +187,7 @@ class Periods extends Component {
                             onPeriodDoubleClick={this.onOfferedPeriodDoubleClick}
                             onPeriodClick={this.props.toggleOfferedPeriod}
                             setOfferedPeriods={this.props.setOfferedPeriods}
+                            setOfferedPeriodIds={this.setOfferedPeriodIds}
                             addSelectedPeriods={this.props.addSelectedPeriods}
                             selectedItems={this.props.selectedItems}
                         />
@@ -186,8 +201,8 @@ class Periods extends Component {
                             onClearAll={this.onClearAll}
                             onPeriodDoubleClick={this.onSelectedPeriodDoubleClick}
                             onPeriodClick={this.props.toggleSelectedPeriod}
-                            onRemovePeriodClick={this.onRemovePeriod}
                             onReorder={this.props.setSelectedPeriods}
+                            onRemovePeriodClick={this.onSelectedPeriodRemove}
                         />
                     </div>
                 </div>

--- a/packages/period-selector-dialog/src/Periods.js
+++ b/packages/period-selector-dialog/src/Periods.js
@@ -124,7 +124,7 @@ class Periods extends Component {
         this.addOfferedPeriods(itemToAdd);
     };
 
-    onSelectedPeriodRemove= (removedPeriod) => {
+    onSelectedPeriodRemove = (removedPeriod) => {
         const itemToRemove = [removedPeriod];
 
         this.props.onDeselect(itemToRemove);
@@ -190,6 +190,7 @@ class Periods extends Component {
                             setOfferedPeriodIds={this.setOfferedPeriodIds}
                             addSelectedPeriods={this.props.addSelectedPeriods}
                             selectedItems={this.props.selectedItems}
+                            onSelect={this.props.onSelect}
                         />
                     </div>
                     <div className="block buttons">

--- a/packages/period-selector-dialog/src/PeriodsList.js
+++ b/packages/period-selector-dialog/src/PeriodsList.js
@@ -48,6 +48,7 @@ class PeriodsList extends Component {
 
         if (sortable) {
             return (<SortableList
+                helperClass="sortableHelper"
                 distance={3}
                 transitionDuration={200}
                 onSortEnd={this.onSortEnd}

--- a/packages/period-selector-dialog/src/PeriodsList.js
+++ b/packages/period-selector-dialog/src/PeriodsList.js
@@ -36,7 +36,7 @@ const SortableList = SortableContainer(
 class PeriodsList extends Component {
     onSortEnd = ({ oldIndex, newIndex }) => {
         this.props.onReorder(arrayMove(this.props.items, oldIndex, newIndex));
-    }
+    };
 
     render() {
         const {

--- a/packages/period-selector-dialog/src/RelativePeriods.js
+++ b/packages/period-selector-dialog/src/RelativePeriods.js
@@ -24,9 +24,8 @@ class RelativePeriods extends Component {
 
     componentDidMount = () => {
         const periods = this.generatePeriods(this.state.periodType);
-        const selectedIds = this.props.selectedItems.map(period => period.id);
 
-        this.props.setOfferedPeriods(periods.filter(period => !selectedIds.includes(period.id)));
+        this.setOfferedPeriods(periods);
     };
 
     onPeriodTypeChange = (event) => {
@@ -34,19 +33,25 @@ class RelativePeriods extends Component {
             periodType: event.target.value,
         });
 
-        this.props.setOfferedPeriods(this.generatePeriods(event.target.value));
+        this.setOfferedPeriods(this.generatePeriods(event.target.value));
+    };
+
+    setOfferedPeriods = (periods) => {
+        const selectedIds = this.props.selectedItems.map(period => period.id);
+
+        this.props.setOfferedPeriodIds(periods);
+        this.props.setOfferedPeriods(periods.filter(period => !selectedIds.includes(period.id)));
     };
 
     generatePeriods = (periodType) => {
         const generator = this.periodsGenerator.get(periodType);
-        const selectedIds = this.props.selectedItems.map(item => item.id);
 
-        return generator.generatePeriods().filter(item => !selectedIds.includes(item.id));
+        return generator.generatePeriods();
     };
 
     selectAll = () => {
         this.props.addSelectedPeriods(this.props.items);
-        this.props.setOfferedPeriods([]);
+        this.setOfferedPeriods([]);
     };
 
     renderOptions = () => (
@@ -96,6 +101,7 @@ RelativePeriods.propTypes = {
     items: PropTypes.array.isRequired,
     selectedItems: PropTypes.array.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
+    setOfferedPeriodIds: PropTypes.func.isRequired,
     addSelectedPeriods: PropTypes.func.isRequired,
     onPeriodDoubleClick: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,

--- a/packages/period-selector-dialog/src/RelativePeriods.js
+++ b/packages/period-selector-dialog/src/RelativePeriods.js
@@ -50,8 +50,8 @@ class RelativePeriods extends Component {
     };
 
     selectAll = () => {
-        this.props.addSelectedPeriods(this.props.items);
-        this.setOfferedPeriods([]);
+        this.props.onSelect(this.props.items);
+        this.props.setOfferedPeriods([]);
     };
 
     renderOptions = () => (
@@ -102,7 +102,7 @@ RelativePeriods.propTypes = {
     selectedItems: PropTypes.array.isRequired,
     setOfferedPeriods: PropTypes.func.isRequired,
     setOfferedPeriodIds: PropTypes.func.isRequired,
-    addSelectedPeriods: PropTypes.func.isRequired,
+    onSelect: PropTypes.func.isRequired,
     onPeriodDoubleClick: PropTypes.func.isRequired,
     onPeriodClick: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
Fixes TECH-124.

Changes proposed in this pull request:
- Filter periods that user is unselecting in order to keep offered periods list with correct options (TECH-124).
- Fix for deselect all click handler (previously it would just remove periods from selected list and not move them to offered one)
- Fix for reordering periods. Currently it only reorders periods within its own redux store.

Implementation for filtering periods on unselect (similar to approach used in data dimension):
On each periods generation create array of periods ids and keep it in component state.
Sync ids whenever user changes period type (from relative to fixed, or from weeks to months).

When user unselects periods, before putting them into offered list filter them (if period has its id in state) then it corresponds to actual period type. It means it goes to the list.
