### PR TITLE
chore/separate edit and parse functionality from React

### DIFF
--- a/examples/create-react-app/src/components/rich-text.js
+++ b/examples/create-react-app/src/components/rich-text.js
@@ -12,7 +12,7 @@ export default class RichText extends Component {
     constructor(props) {
         super(props);
         this.nativeInputRef = React.createRef();
-        this.nativePara = React.createRef();
+        this.nativeOutputRef = React.createRef();
         this.NativeMdParser = new ClassMdParser();
     }
     state = {
@@ -37,10 +37,10 @@ export default class RichText extends Component {
         convertCtrlKey(e, this.setNativeInputVal);
     }
 
-    nativeSetParsedVal = () => {
+    setNativeParsedVal = () => {
         const inputNode = this.nativeInputRef.current;
         const renderedVal = this.NativeMdParser.render(inputNode.value);
-        this.nativePara.current.innerHTML = renderedVal;
+        this.nativeOutputRef.current.innerHTML = renderedVal;
     }
 
     render() {
@@ -61,9 +61,9 @@ export default class RichText extends Component {
                 <div>
                     <p>Using RichText function and class</p>
                     <input ref={this.nativeInputRef} type="text" onKeyDown={this.nativeKeyDown} />
-                    <button type="button" onClick={this.nativeSetParsedVal}>Parse native</button>
+                    <button type="button" onClick={this.setNativeParsedVal}>Parse native</button>
                     <span>Result:</span>
-                    <p ref={this.nativePara} />
+                    <p ref={this.nativeOutputRef} />
                 </div>
             </div>
         );

--- a/examples/create-react-app/src/components/rich-text.js
+++ b/examples/create-react-app/src/components/rich-text.js
@@ -2,10 +2,19 @@ import React, { Component } from 'react';
 import { InputField } from '@dhis2/d2-ui-core';
 import {
     Parser as RichTextParser,
-    Editor as RichTextEditor
+    Editor as RichTextEditor,
+    ClassMdParser,
+    convertCtrlKey,
 } from '@dhis2/d2-ui-rich-text';
 
+
 export default class RichText extends Component {
+    constructor(props) {
+        super(props);
+        this.nativeInputRef = React.createRef();
+        this.nativePara = React.createRef();
+        this.NativeMdParser = new ClassMdParser();
+    }
     state = {
         newText: '',
         paraVal: '',
@@ -19,18 +28,43 @@ export default class RichText extends Component {
         this.setState({ newText });
     };
 
+    setNativeInputVal = val => {
+        const node = this.nativeInputRef.current;
+        node.value = val;
+    }
+
+    nativeKeyDown = e => {
+        convertCtrlKey(e, this.setNativeInputVal);
+    }
+
+    nativeSetParsedVal = () => {
+        const inputNode = this.nativeInputRef.current;
+        const renderedVal = this.NativeMdParser.render(inputNode.value);
+        this.nativePara.current.innerHTML = renderedVal;
+    }
+
     render() {
         return (
             <div>
-                <span>Input text to be converted:</span>
-                <RichTextEditor onEdit={this.updateNewText}>
-                    <InputField
-                        value={this.state.newText}
-                        onChange={this.updateNewText}
-                    />
-                </RichTextEditor>
-                <button type="button" onClick={this.setParagraphVal}>Parse</button>
-                <span>Result:</span><RichTextParser>{this.state.paraVal}</RichTextParser>
+                <div>
+                    <p>Using RichText react component wrapper:</p>
+                    <RichTextEditor onEdit={this.updateNewText}>
+                        <InputField
+                            value={this.state.newText}
+                            onChange={this.updateNewText}
+                        />
+                    </RichTextEditor>
+                    <button type="button" onClick={this.setParagraphVal}>Parse</button>
+                    <span>Result:</span>
+                    <RichTextParser>{this.state.paraVal}</RichTextParser>
+                </div>
+                <div>
+                    <p>Using RichText function and class</p>
+                    <input ref={this.nativeInputRef} type="text" onKeyDown={this.nativeKeyDown} />
+                    <button type="button" onClick={this.nativeSetParsedVal}>Parse native</button>
+                    <span>Result:</span>
+                    <p ref={this.nativePara} />
+                </div>
             </div>
         );
     }

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -2,6 +2,11 @@
 
 The rich text library contains a rich text editor and parser for handling rich text in input fields in dhis2 applications.
 
+For React applications, you can use the React wrappers Editor and Parser. For
+non-React applications (e.g., classic analytics apps like Pivot Table), you
+can access the edit and parsing functionality directly with convertCtrlKey and
+ClassMdParser exports.
+
 ## Installation
 
 ```
@@ -10,9 +15,20 @@ yarn add @dhis2/d2-ui-rich-text
 
 ## Usage
 
-Importing components
+Importing components for React applications
 
 ```
 import { Editor } from "@dhis2/d2-ui-rich-text";
 import { Parser } from "@dhis2/d2-ui-rich-text";
 ```
+
+Importing functions and classes for non-React applications
+
+```
+import { ClassMdParser } from "@dhis2/d2-ui-rich-text";
+import {  convertCtrlKey } from "@dhis2/d2-ui-rich-text";
+```
+
+See an example implementation for both types of implementations in [examples/create-react-app](https://github.com/dhis2/d2-ui/blob/master/examples/create-react-app/src/components/rich-text.js)
+
+

--- a/packages/rich-text/src/editor/Editor.js
+++ b/packages/rich-text/src/editor/Editor.js
@@ -1,79 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import convertCtrlKey from './convertCtrlKey';
 
 class Editor extends Component {
-    constructor(props) {
-        super(props);
-
-        this.defaultState = {
-            boldMode: false,
-            italicMode: false,
-        };
-
-        this.state = {
-            ...this.defaultState,
-            element: null,
-        };
-    }
-
     onKeyDown = (event) => {
-        const { key, ctrlKey, metaKey } = event;
-        const element = event.target;
-
-        this.setState({ element });
-
-        // bold
-        if (key === 'b' && (ctrlKey || metaKey)) {
-            this.insertMarkers('bold');
-            // italic
-        } else if (key === 'i' && (ctrlKey || metaKey)) {
-            this.insertMarkers('italic');
-        }
-    };
-
-    toggleMode = (mode) => {
-        const prop = `${mode}Mode`;
-
-        this.setState({ [prop]: !this.state[prop] });
-    };
-
-    insertMarkers = (mode) => {
-        const element = this.state.element;
-        const { selectionStart, selectionEnd, value } = element;
-
-        this.toggleMode(mode);
-
-        let marker;
-
-        switch (mode) {
-            case 'italic':
-                marker = '_';
-                break;
-            case 'bold':
-                marker = '*';
-                break;
-            default:
-                return;
-        }
-
-        let newValue;
-
-        if (selectionStart >= 0 && selectionStart === selectionEnd) {
-            newValue = `${value}${marker}`;
-        } else if (selectionStart >= 0) {
-            newValue = [
-                value.slice(0, selectionStart),
-                value.slice(selectionStart, selectionEnd),
-                value.slice(selectionEnd),
-            ].join(marker);
-
-            this.toggleMode(mode);
-        }
-
-        if (this.props.onEdit) {
-            this.props.onEdit(newValue);
-        }
-    };
+        convertCtrlKey(event, this.props.onEdit);
+    }
 
     render() {
         const { children } = this.props;
@@ -88,6 +20,10 @@ Editor.defaultProps = {
 
 Editor.propTypes = {
     onEdit: PropTypes.func,
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node,
+    ]),
 };
 
 export default Editor;

--- a/packages/rich-text/src/editor/__tests__/Editor.spec.js
+++ b/packages/rich-text/src/editor/__tests__/Editor.spec.js
@@ -1,13 +1,19 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-
 import Editor from '../Editor';
+import convertCtrlKey from '../convertCtrlKey';
+
+jest.mock('../convertCtrlKey');
 
 describe('RichText: Editor component', () => {
     let richTextEditor;
-    const props = {
+    const componentProps = {
         onEdit: jest.fn(),
     };
+
+    beforeEach(() => {
+        convertCtrlKey.mockClear();
+    });
 
     const renderComponent = props => {
         return shallow(
@@ -17,9 +23,15 @@ describe('RichText: Editor component', () => {
         );
     };
 
-    it('should have rendered a result', () => {
-        richTextEditor = renderComponent();
+    it('renders a result', () => {
+        richTextEditor = renderComponent(componentProps);
 
         expect(richTextEditor).toHaveLength(1);
+    });
+
+    it('calls convertCtrlKey on keydown', () => {
+        richTextEditor = renderComponent(componentProps);
+        richTextEditor.simulate('keyDown');
+        expect(convertCtrlKey).toHaveBeenCalled();
     });
 });

--- a/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
+++ b/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
@@ -1,0 +1,48 @@
+import convertCtrlKey from '../convertCtrlKey';
+
+describe('convertCtrlKey', () => {
+    it('does not trigger callback if no ctrl key', () => {
+        const cb = jest.fn();
+        const e = { key: 'j' };
+
+        convertCtrlKey(e, cb);
+
+        expect(cb).not.toHaveBeenCalled();
+    });
+
+    it('triggers callback with opening marker if ctrl key + "b"', () => {
+        const cb = jest.fn();
+        const e = {
+            key: 'b',
+            ctrlKey: true,
+            target: {
+                selectionStart: 0,
+                selectionEnd: 0,
+                value: '',
+            },
+        };
+
+        convertCtrlKey(e, cb);
+
+        expect(cb).toHaveBeenCalled();
+        expect(cb).toHaveBeenCalledWith('*');
+    });
+
+    it('triggers callback with closing marker if ctrl key + "b" + value', () => {
+        const cb = jest.fn();
+        const e = {
+            key: 'b',
+            metaKey: true,
+            target: {
+                selectionStart: 4,
+                selectionEnd: 4,
+                value: '*abc',
+            },
+        };
+
+        convertCtrlKey(e, cb);
+
+        expect(cb).toHaveBeenCalled();
+        expect(cb).toHaveBeenCalledWith('*abc*');
+    });
+});

--- a/packages/rich-text/src/editor/convertCtrlKey.js
+++ b/packages/rich-text/src/editor/convertCtrlKey.js
@@ -1,0 +1,59 @@
+const state = {
+    boldMode: false,
+    italicMode: false,
+    element: null,
+};
+
+const markerMap = {
+    italic: '_',
+    bold: '*',
+};
+
+const toggleMode = (mode) => {
+    const prop = `${mode}Mode`;
+
+    state[prop] = !state[prop];
+};
+
+const insertMarkers = (mode, cb) => {
+    toggleMode(mode);
+
+    const marker = markerMap[mode] || null;
+    if (!marker || !cb) {
+        return;
+    }
+
+    const element = state.element;
+    const { selectionStart, selectionEnd, value } = element;
+    let newValue;
+
+    if (selectionStart >= 0 && selectionStart === selectionEnd) {
+        newValue = `${value}${marker}`;
+    } else if (selectionStart >= 0) {
+        newValue = [
+            value.slice(0, selectionStart),
+            value.slice(selectionStart, selectionEnd),
+            value.slice(selectionEnd),
+        ].join(marker);
+
+        this.toggleMode(mode);
+    }
+
+    cb(newValue);
+};
+
+const convertCtrlKey = (event, cb) => {
+    const { key, ctrlKey, metaKey } = event;
+
+    const element = event.target;
+
+    state.element = element;
+
+    if (key === "b" && (ctrlKey || metaKey)) {
+        insertMarkers("bold", cb);
+    } else if (key === "i" && (ctrlKey || metaKey)) {
+        insertMarkers("italic", cb);
+    }
+}
+
+export default convertCtrlKey;

--- a/packages/rich-text/src/index.js
+++ b/packages/rich-text/src/index.js
@@ -1,2 +1,5 @@
 export { default as Editor } from './editor/Editor';
 export { default as Parser } from './parser/Parser';
+
+export { default as convertCtrlKey } from './editor/convertCtrlKey';
+export { default as ClassMdParser } from './parser/MdParser';

--- a/packages/rich-text/src/parser/MdParser.js
+++ b/packages/rich-text/src/parser/MdParser.js
@@ -1,0 +1,99 @@
+import MarkdownIt from "markdown-it";
+
+const emojiDb = {
+    ":-)": "\u{1F642}",
+    ":)": "\u{1F642}",
+    ":-(": "\u{1F641}",
+    ":(": "\u{1F641}",
+    ":+1": "\u{1F44D}",
+    ":-1": "\u{1F44E}"
+};
+
+const codes = {
+    bold: {
+        name: "bold",
+        char: "*",
+        domEl: "strong",
+        encodedChar: 0x2a,
+        regexString: "^\\*((?!\\s)[^*]+(?:[^\\s]))\\*",
+        contentFn: val => val,
+    },
+    italic: {
+        name: "italic",
+        char: "_",
+        domEl: "em",
+        encodedChar: 0x5f,
+        regexString: "^_((?!\\s)[^_]+(?:[^\\s]))_",
+        contentFn: val => val,
+    },
+    emoji: {
+        name: "emoji",
+        char: ":",
+        domEl: "span",
+        encodedChar: 0x3a,
+        regexString: "^(:-\\)|:\\)|:\\(|:-\\(|:\\+1|:-1)",
+        contentFn: val => emojiDb[val],
+    },
+};
+
+const parse = code => (state, silent) => {
+    if (silent) return false;
+
+    const start = state.pos;
+    const marker = state.src.charCodeAt(start);
+
+    // marker character: "_", "*", ":"
+    if (marker !== codes[code].encodedChar) {
+        return false;
+    }
+
+    const MARKER_REGEX = new RegExp(codes[code].regexString);
+    const token = state.src.slice(start);
+
+    if (MARKER_REGEX.test(token)) {
+        const markerMatch = token.match(MARKER_REGEX);
+        const text = markerMatch[1];
+
+        state.push(`${codes[code].domEl}_open`, codes[code].domEl, 1);
+
+        const t = state.push("text", "", 0);
+        t.content = codes[code].contentFn(text);
+
+        state.push(`${codes.bold.domEl}_close`, codes[code].domEl, -1);
+        state.pos += markerMatch[0].length;
+
+        return true;
+    }
+
+    return false;
+};
+
+let md;
+
+class MdParser {
+    constructor() {
+        // disable all rules, enable autolink for URLs and email addresses
+        md = new MarkdownIt("zero", { linkify: true });
+
+        // *bold* -> <strong>bold</strong>
+        md.inline.ruler.push("strong", parse(codes.bold.name));
+
+        // _italic_ -> <em>italic</em>
+        md.inline.ruler.push("italic", parse(codes.italic.name));
+
+        // :-) :) :-( :( :+1 :-1 -> <span>[unicode]</span>
+        md.inline.ruler.push("emoji", parse(codes.emoji.name));
+
+        md.enable(["linkify", "strong", "italic", "emoji"]);
+
+        return this;
+    }
+
+    render(text) {
+        // console.log('');
+
+        return md.renderInline(text);
+    }
+}
+
+export default MdParser;

--- a/packages/rich-text/src/parser/MdParser.js
+++ b/packages/rich-text/src/parser/MdParser.js
@@ -90,8 +90,6 @@ class MdParser {
     }
 
     render(text) {
-        // console.log('');
-
         return md.renderInline(text);
     }
 }

--- a/packages/rich-text/src/parser/Parser.js
+++ b/packages/rich-text/src/parser/Parser.js
@@ -1,99 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
-import MarkdownIt from 'markdown-it';
-
-const emojiDb = {
-    ':-)': '\u{1F642}',
-    ':)': '\u{1F642}',
-    ':-(': '\u{1F641}',
-    ':(': '\u{1F641}',
-    ':+1': '\u{1F44D}',
-    ':-1': '\u{1F44E}',
-};
-
-const codes = {
-    bold: {
-        name: 'bold',
-        char: '*',
-        domEl: 'strong',
-        encodedChar: 0x2a,
-        regexString: '^\\*((?!\\s)[^*]+(?:[^\\s]))\\*',
-        contentFn: val => val,
-    },
-    italic: {
-        name: 'italic',
-        char: '_',
-        domEl: 'em',
-        encodedChar: 0x5f,
-        regexString: '^_((?!\\s)[^_]+(?:[^\\s]))_',
-        contentFn: val => val,
-    },
-    emoji: {
-        name: 'emoji',
-        char: ':',
-        domEl: 'span',
-        encodedChar: 0x3a,
-        regexString: '^(:-\\)|:\\)|:\\(|:-\\(|:\\+1|:-1)',
-        contentFn: val => emojiDb[val],
-    },
-};
-
-const parse = code => (state, silent) => {
-    if (silent) return false;
-
-    const start = state.pos;
-    const marker = state.src.charCodeAt(start);
-
-    // marker character: "_", "*", ":"
-    if (marker !== codes[code].encodedChar) {
-        return false;
-    }
-
-    const MARKER_REGEX = new RegExp(codes[code].regexString);
-    const token = state.src.slice(start);
-
-    if (MARKER_REGEX.test(token)) {
-        const markerMatch = token.match(MARKER_REGEX);
-        const text = markerMatch[1];
-
-        state.push(`${codes[code].domEl}_open`, codes[code].domEl, 1);
-
-        const t = state.push('text', '', 0);
-        t.content = codes[code].contentFn(text);
-
-        state.push(`${codes.bold.domEl}_close`, codes[code].domEl, -1);
-        state.pos += markerMatch[0].length;
-
-        return true;
-    }
-
-    return false;
-};
-
-const initParser = () => {
-    // disable all rules, enable autolink for URLs and email addresses
-    const md = new MarkdownIt('zero', { linkify: true });
-
-    // *bold* -> <strong>bold</strong>
-    md.inline.ruler.push('strong', parse(codes.bold.name));
-
-    // _italic_ -> <em>italic</em>
-    md.inline.ruler.push('italic', parse(codes.italic.name));
-
-    // :-) :) :-( :( :+1 :-1 -> <span>[unicode]</span>
-    md.inline.ruler.push('emoji', parse(codes.emoji.name));
-
-    md.enable(['linkify', 'strong', 'italic', 'emoji']);
-
-    return md;
-};
+import MdParserClass from './MdParser';
 
 class Parser extends Component {
     constructor(props) {
         super(props);
 
-        this.parser = initParser();
+        this.MdParser = new MdParserClass();
     }
 
     render() {
@@ -103,7 +16,7 @@ class Parser extends Component {
             <p
                 style={style}
                 dangerouslySetInnerHTML={{
-                    __html: this.parser.renderInline(children),
+                    __html: this.MdParser.render(children),
                 }}
             />
         );
@@ -116,6 +29,10 @@ Parser.defaultProps = {
 
 Parser.propTypes = {
     style: PropTypes.object,
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node,
+    ]),
 };
 
 export default Parser;

--- a/packages/rich-text/src/parser/__tests__/MdParser.spec.js
+++ b/packages/rich-text/src/parser/__tests__/MdParser.spec.js
@@ -1,0 +1,48 @@
+import MdParser from '../MdParser';
+
+const Parser = new MdParser();
+
+describe('MdParser class', () => {
+    it('converts text into HTML', () => {
+        const tests = [
+            ['_italic_', '<em>italic</em>'],
+            ['*bold*', '<strong>bold</strong>'],
+            ['* not bold because there is a space *', '* not bold because there is a space *'],
+            ['_ not italic because there is a space _', '_ not italic because there is a space _'],
+            [':-)', '<span>\u{1F642}</span>'],
+            [':)', '<span>\u{1F642}</span>'],
+            [':-(', '<span>\u{1F641}</span>'],
+            [':(', '<span>\u{1F641}</span>'],
+            [':+1', '<span>\u{1F44D}</span>'],
+            [':-1', '<span>\u{1F44E}</span>'],
+            [
+                'mixed _italic_ *bold* and :+1',
+                'mixed <em>italic</em> <strong>bold</strong> and <span>\u{1F44D}</span>',
+            ],
+            ['_italic with * inside_', '<em>italic with * inside</em>'],
+            ['*bold with _ inside*', '<strong>bold with _ inside</strong>'],
+            // italic marker inside an italic string not allowed
+            ['_italic with _ inside_', '_italic with _ inside_'],
+            // bold marker inside a bold string not allowed
+            ['*bold with * inside*', '*bold with * inside*'],
+            [
+                '_multiple_ italic in the _same line_',
+                '<em>multiple</em> italic in the <em>same line</em>',
+            ],
+            // nested italic/bold combinations not allowed
+            ['_italic with *bold* inside_', '<em>italic with *bold* inside</em>'],
+            ['*bold with _italic_ inside*', '<strong>bold with _italic_ inside</strong>'],
+            ['text with : and :)', 'text with : and <span>\u{1F642}</span>'],
+            ['(parenthesis and :))', '(parenthesis and <span>\u{1F642}</span>)'],
+            [':((parenthesis:))', '<span>\u{1F641}</span>(parenthesis<span>\u{1F642}</span>)'],
+            [':+1+1', '<span>\u{1F44D}</span>+1'],
+            ['-1:-1', '-1<span>\u{1F44E}</span>'],
+        ];
+
+        tests.forEach((test) => {
+            const renderedText = Parser.render(test[0]);
+
+            expect(renderedText).toEqual(test[1]);
+        });
+    });
+});

--- a/packages/rich-text/src/parser/__tests__/Parser.spec.js
+++ b/packages/rich-text/src/parser/__tests__/Parser.spec.js
@@ -2,6 +2,13 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import Parser from '../Parser';
+import '../MdParser';
+
+jest.mock('../MdParser', () => {
+    return jest.fn().mockImplementation(() => {
+        return { render: () => 'converted text' };
+    });
+});
 
 describe('RichText: Parser component', () => {
     let richTextParser;
@@ -25,52 +32,9 @@ describe('RichText: Parser component', () => {
         expect(richTextParser.props().style).toEqual(defaultProps.style);
     });
 
-    it('should have rendered a plain text content', () => {
+    it('should have rendered content', () => {
         richTextParser = renderComponent({}, 'plain text');
 
-        expect(richTextParser.html()).toEqual('<p>plain text</p>');
-    });
-
-    it('should have rendered markdown converted into HTML', () => {
-        const tests = [
-            ['_italic_', '<em>italic</em>'],
-            ['*bold*', '<strong>bold</strong>'],
-            ['* not bold because there is a space *', '* not bold because there is a space *'],
-            ['_ not italic because there is a space _', '_ not italic because there is a space _'],
-            [':-)', '<span>\u{1F642}</span>'],
-            [':)', '<span>\u{1F642}</span>'],
-            [':-(', '<span>\u{1F641}</span>'],
-            [':(', '<span>\u{1F641}</span>'],
-            [':+1', '<span>\u{1F44D}</span>'],
-            [':-1', '<span>\u{1F44E}</span>'],
-            [
-                'mixed _italic_ *bold* and :+1',
-                'mixed <em>italic</em> <strong>bold</strong> and <span>\u{1F44D}</span>',
-            ],
-            ['_italic with * inside_', '<em>italic with * inside</em>'],
-            ['*bold with _ inside*', '<strong>bold with _ inside</strong>'],
-            // italic marker inside an italic string not allowed
-            ['_italic with _ inside_', '_italic with _ inside_'],
-            // bold marker inside a bold string not allowed
-            ['*bold with * inside*', '*bold with * inside*'],
-            [
-                '_multiple_ italic in the _same line_',
-                '<em>multiple</em> italic in the <em>same line</em>',
-            ],
-            // nested italic/bold combinations not allowed
-            ['_italic with *bold* inside_', '<em>italic with *bold* inside</em>'],
-            ['*bold with _italic_ inside*', '<strong>bold with _italic_ inside</strong>'],
-            ['text with : and :)', 'text with : and <span>\u{1F642}</span>'],
-            ['(parenthesis and :))', '(parenthesis and <span>\u{1F642}</span>)'],
-            [':((parenthesis:))', '<span>\u{1F641}</span>(parenthesis<span>\u{1F642}</span>)'],
-            [':+1+1', '<span>\u{1F44D}</span>+1'],
-            ['-1:-1', '-1<span>\u{1F44E}</span>'],
-        ];
-
-        tests.forEach(test => {
-            richTextParser = renderComponent({}, test[0]);
-
-            expect(richTextParser.html()).toEqual(`<p>${test[1]}</p>`);
-        });
+        expect(richTextParser.html()).toEqual('<p>converted text</p>');
     });
 });


### PR DESCRIPTION
Separate the React components from the edit and parse functionality, to make it possible to use that functionality in non-react applications (e.g, "classic" analytics apps)

Most of the changes are just moving the editing and parsing functionality into separate files and making that accessible as exports from the package