### PR TITLE
Fix/org units dialog styles

### DIFF
--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -22,7 +22,6 @@ import Legend from './components/legend';
 import PeriodPicker from './components/period-picker';
 import PeriodSelector from './components/period-selector';
 import OrgUnitDialog from './components/org-unit-dialog';
-import OrgUnitSelector from './components/org-unit-selector';
 import SelectField from './components/select-field';
 import Sidebar from './components/sidebar';
 import SvgIcon from './components/svg-icon';
@@ -159,9 +158,6 @@ class App extends Component {
 
                     <h2>Org unit dialog</h2>
                     <OrgUnitDialog d2={this.state.d2} />
-
-                    <h2>Org unit selector</h2>
-                    <OrgUnitSelector d2={this.state.d2} />
 
                     <div style={{ clear: 'both' }}>
                         <h2>TreeViews</h2>

--- a/examples/create-react-app/src/components/org-unit-dialog.js
+++ b/examples/create-react-app/src/components/org-unit-dialog.js
@@ -192,9 +192,12 @@ export default class OrgUnitDialogExample extends Component {
                     handleUserOrgUnitClick={this.handleUserOrgUnitClick}
                     handleOrgUnitClick={this.handleOrgUnitClick}
                     handleMultipleOrgUnitsSelect={this.handleMultipleOrgUnitsSelect}
+                    deselectAllTooltipBackgroundColor="#E0E0E0"
+                    deselectAllTooltipFontColor="#000000"
                     onClose={this.toggleDialog}
                     onUpdate={this.onOrgUnitSelect}
-                    checkboxColor="primary"
+                    checkboxColor="secondary"
+                    maxWidth="lg"
                 />
             }
             <Snackbar

--- a/packages/org-unit-dialog/src/GridControl.js
+++ b/packages/org-unit-dialog/src/GridControl.js
@@ -1,36 +1,45 @@
 import React from 'react';
 import FormControl from '@material-ui/core/FormControl';
 import Grid from '@material-ui/core/Grid';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select/Select';
 import styles from './styles/GridControl.style';
 
-const GridControl = ({ id, title, options, ...selectProps }) => (
-    <Grid
-        item
-        xs={4}
-        style={styles.gridContainer.gridItem}
-    >
-        <FormControl style={{ width: '100%' }}>
-            <InputLabel htmlFor={id}>{title}</InputLabel>
-            <Select
-                input={<Input id={id} />}
-                {...selectProps}
-                fullWidth
-            >
-                {options.map(option => (
-                    <MenuItem
-                        key={option.id}
-                        value={option.id}
-                    >
-                        {option.displayName}
-                    </MenuItem>
-                ))}
-            </Select>
-        </FormControl>
-    </Grid>
-);
+const GridControl = ({ label, placeholder, options, ...selectProps }) => {
+    const renderValue = (selected) => {
+        if (selected.length === 0) {
+            return <span style={styles.placeholder}>{placeholder}</span>;
+        }
+
+        return selectProps.renderValue(selected);
+    };
+
+    return (
+        <Grid
+            style={styles.gridItem}
+            xs={4}
+            item
+        >
+            <FormControl style={{ width: '100%' }}>
+                <span style={styles.label}>{label}</span>
+                <Select
+                    {...selectProps}
+                    renderValue={renderValue}
+                    displayEmpty
+                    fullWidth
+                >
+                    {options.map(option => (
+                        <MenuItem
+                            key={option.id}
+                            value={option.id}
+                        >
+                            {option.displayName}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
+        </Grid>
+    );
+}
 
 export default GridControl;

--- a/packages/org-unit-dialog/src/OrgUnitDialog.js
+++ b/packages/org-unit-dialog/src/OrgUnitDialog.js
@@ -37,6 +37,8 @@ class OrgUnitDialog extends React.PureComponent {
                     handleUserOrgUnitClick={this.props.handleUserOrgUnitClick}
                     checkboxColor={this.props.checkboxColor}
                     handleMultipleOrgUnitsSelect={this.props.handleMultipleOrgUnitsSelect}
+                    deselectAllTooltipFontColor={this.props.deselectAllTooltipFontColor}
+                    deselectAllTooltipBackgroundColor={this.props.deselectAllTooltipBackgroundColor}
                 />
             </DialogContent>
             <DialogActions>
@@ -57,6 +59,8 @@ OrgUnitDialog.defaultProps = {
     levelOptions: [],
     groupOptions: [],
     checkboxColor: 'primary',
+    deselectAllTooltipFontColorgi: 'white',
+    deselectAllTooltipBackgroundColor: 'gray',
 
     // dialog related props
     open: false,
@@ -138,6 +142,16 @@ OrgUnitDialog.propTypes = {
      * Checkbox color in org unit tree
      */
     checkboxColor: PropTypes.string,
+
+    /**
+     * Font color for text in deselect all tooltip
+     */
+    deselectAllTooltipFontColor: PropTypes.string,
+
+    /**
+     * Font color for background in deselect all tooltip
+     */
+    deselectAllTooltipBackgroundColor: PropTypes.string,
 
     // Dialog related props
     onClose: PropTypes.func.isRequired,

--- a/packages/org-unit-dialog/src/OrgUnitSelector.js
+++ b/packages/org-unit-dialog/src/OrgUnitSelector.js
@@ -132,14 +132,11 @@ class OrgUnitSelector extends Component {
     };
 
     renderOptionsPanel = () => (
-        <div style={styles.footer.index}>
-            <Grid
-                style={styles.footer.gridContainer}
-                container
-            >
+        <div style={styles.footer}>
+            <Grid container>
                 <GridControl
-                    id="level-select"
-                    title={i18n.t('Level')}
+                    label={i18n.t('Level')}
+                    placeholder={i18n.t('Select a level')}
                     value={this.props.level}
                     onChange={this.props.onLevelChange}
                     options={this.props.levelOptions}
@@ -148,8 +145,8 @@ class OrgUnitSelector extends Component {
                     multiple
                 />
                 <GridControl
-                    id="group-select"
-                    title={i18n.t('Group')}
+                    label={i18n.t('Group')}
+                    placeholder={i18n.t('Select a group')}
                     value={this.props.group}
                     onChange={this.props.onGroupChange}
                     options={this.props.groupOptions}
@@ -161,67 +158,76 @@ class OrgUnitSelector extends Component {
         </div>
     );
 
-    render = () => (
-        <Fragment>
-            <div style={styles.orgUnitsContainer}>
-                <div style={styles.scrollableContainer.index}>
-                    <UserOrgUnitsPanel
-                        selected={this.props.selected}
-                        styles={styles.userOrgUnits}
-                        userOrgUnits={this.props.userOrgUnits}
-                        handleUserOrgUnitClick={this.props.handleUserOrgUnitClick}
-                    />
-                    <div style={styles.scrollableContainer.overlayContainer}>
-                        {this.props.userOrgUnits.length > 0 && (
-                            <div style={styles.scrollableContainer.overlay} />
-                        )}
-                        <OrgUnitTree
-                            root={this.props.root}
-                            selected={this.props.selected.map(orgUnit => orgUnit.path)}
-                            initiallyExpanded={this.state.initiallyExpanded}
-                            onSelectClick={this.props.handleOrgUnitClick}
-                            onExpand={this.onExpand}
-                            onCollapse={this.onCollapse}
-                            onContextMenuClick={this.onContextMenuClick}
-                            treeStyle={styles.orgUnitTree.treeStyle}
-                            labelStyle={styles.orgUnitTree.labelStyle}
-                            selectedLabelStyle={styles.orgUnitTree.selectedLabelStyle}
+    render = () => {
+        const tooltipStyles = {
+            ...styles.orgUnitsContainer.tooltip,
+            backgroundColor: this.props.deselectAllTooltipBackgroundColor,
+            color: this.props.deselectAllTooltipFontColor,
+        };
+
+        return (
+            <Fragment>
+                <div style={styles.orgUnitsContainer}>
+                    <div style={styles.scrollableContainer.index}>
+                        <UserOrgUnitsPanel
+                            selected={this.props.selected}
+                            styles={styles.userOrgUnits}
+                            userOrgUnits={this.props.userOrgUnits}
+                            handleUserOrgUnitClick={this.props.handleUserOrgUnitClick}
                             checkboxColor={this.props.checkboxColor}
-                            showFolderIcon
-                            disableSpacer
                         />
-                        <Menu
-                            anchorEl={this.state.menuAnchorElement}
-                            open={Boolean(this.state.menuAnchorElement)}
-                            onClose={this.closeContextMenu}
-                        >
-                            <MenuItem
-                                onClick={this.selectChildren}
-                                disabled={this.state.loadingChildren}
-                                dense
+                        <div style={styles.scrollableContainer.overlayContainer}>
+                            {this.props.userOrgUnits.length > 0 && (
+                                <div style={styles.scrollableContainer.overlay}/>
+                            )}
+                            <OrgUnitTree
+                                root={this.props.root}
+                                selected={this.props.selected.map(orgUnit => orgUnit.path)}
+                                initiallyExpanded={this.state.initiallyExpanded}
+                                onSelectClick={this.props.handleOrgUnitClick}
+                                onExpand={this.onExpand}
+                                onCollapse={this.onCollapse}
+                                onContextMenuClick={this.onContextMenuClick}
+                                treeStyle={styles.orgUnitTree.treeStyle}
+                                labelStyle={styles.orgUnitTree.labelStyle}
+                                selectedLabelStyle={styles.orgUnitTree.selectedLabelStyle}
+                                checkboxColor={this.props.checkboxColor}
+                                showFolderIcon
+                                disableSpacer
+                            />
+                            <Menu
+                                anchorEl={this.state.menuAnchorElement}
+                                open={Boolean(this.state.menuAnchorElement)}
+                                onClose={this.closeContextMenu}
                             >
-                                {i18n.t('Select children')}
-                            </MenuItem>
-                        </Menu>
+                                <MenuItem
+                                    onClick={this.selectChildren}
+                                    disabled={this.state.loadingChildren}
+                                    dense
+                                >
+                                    {i18n.t('Select children')}
+                                </MenuItem>
+                            </Menu>
+                        </div>
+                    </div>
+                    <div style={styles.orgUnitsContainer.tooltipContainer}>
+                        {this.props.selected.length > 0 && (
+                            <div style={tooltipStyles}>
+                                {this.props.selected.length} {i18n.t('selected')} -
+                                <button
+                                    onClick={this.props.onDeselectAllClick}
+                                    style={styles.orgUnitsContainer.tooltip.link}
+                                >
+                                    {i18n.t('Deselect all')}
+                                </button>
+                            </div>
+                        )}
                     </div>
                 </div>
-                <div style={styles.orgUnitsContainer.tooltipContainer}>
-                    {this.props.selected.length > 0 && (
-                        <div style={styles.orgUnitsContainer.tooltip}>
-                            {this.props.selected.length} {i18n.t('selected')}.
-                            <button
-                                onClick={this.props.onDeselectAllClick}
-                                style={styles.orgUnitsContainer.tooltip.link}
-                            >
-                                {i18n.t('Deselect all')}
-                            </button>
-                        </div>
-                    )}
-                </div>
-            </div>
-            <div>{this.renderOptionsPanel()}</div>
-        </Fragment>
-    )
+                <div>{this.renderOptionsPanel()}</div>
+            </Fragment>
+        );
+    };
 }
 
 OrgUnitSelector.propTypes = {
@@ -294,6 +300,16 @@ OrgUnitSelector.propTypes = {
     root: PropTypes.object.isRequired,
 
     /**
+     * Font color for text in deselect all tooltip
+     */
+    deselectAllTooltipFontColor: PropTypes.string,
+
+    /**
+     * Font color for background in deselect all tooltip
+     */
+    deselectAllTooltipBackgroundColor: PropTypes.string,
+
+    /**
      * Checkbox color in org unit tree
      */
     checkboxColor: PropTypes.string,
@@ -307,6 +323,8 @@ OrgUnitSelector.defaultProps = {
     levelOptions: [],
     groupOptions: [],
     checkboxColor: 'primary',
+    deselectAllTooltipFontColor: 'white',
+    deselectAllTooltipBackgroundColor: 'gray',
 };
 
 export default OrgUnitSelector;

--- a/packages/org-unit-dialog/src/UserOrgUnitsPanel.js
+++ b/packages/org-unit-dialog/src/UserOrgUnitsPanel.js
@@ -19,6 +19,7 @@ const UserOrgUnitsPanel = props => (
             {userOrgUnits.map(orgUnitType => (
                 <Grid
                     key={orgUnitType.id}
+                    style={styles.gridItem}
                     item
                 >
                     <Checkbox
@@ -28,9 +29,9 @@ const UserOrgUnitsPanel = props => (
                             id: orgUnitType.id,
                             name: orgUnitType.id,
                         }}
-                        checkedIcon={<CheckBoxIcon style={styles.checkbox} />}
                         icon={<CheckBoxOutlineBlankIcon style={styles.checkbox} />}
-                        color="primary"
+                        checkedIcon={<CheckBoxIcon style={styles.checkboxChecked} />}
+                        color={props.checkboxColor}
                     />
                     <InputLabel htmlFor={orgUnitType.id}>
                         <StopIcon style={styles.stopIcon} />
@@ -43,6 +44,7 @@ const UserOrgUnitsPanel = props => (
 );
 
 UserOrgUnitsPanel.propTypes = {
+    checkboxColor: PropTypes.string.isRequired,
     selected: PropTypes.array.isRequired,
     userOrgUnits: PropTypes.array.isRequired,
     handleUserOrgUnitClick: PropTypes.func.isRequired,

--- a/packages/org-unit-dialog/src/styles/GridControl.style.js
+++ b/packages/org-unit-dialog/src/styles/GridControl.style.js
@@ -1,7 +1,15 @@
 export default {
     gridContainer: {
-        gridItem: {
-            marginRight: 15,
-        },
+        marginTop: 6,
+    },
+    gridItem: {
+        marginRight: 15,
+    },
+    label: {
+        marginBottom: 5,
+        fontSize: 12,
+    },
+    placeholder: {
+        color: 'rgba(0, 0, 0, 0.38)',
     },
 };

--- a/packages/org-unit-dialog/src/styles/OrgUnitSelector.style.js
+++ b/packages/org-unit-dialog/src/styles/OrgUnitSelector.style.js
@@ -13,9 +13,8 @@ export default {
         tooltip: {
             display: 'inline-block',
             borderRadius: 3,
-            background: 'rgba(83, 83, 83, 0.9)',
-            padding: 10,
-            color: '#fff',
+            padding: 7,
+            fontSize: 14,
 
             link: {
                 outline: 'none',
@@ -100,10 +99,8 @@ export default {
         },
     },
     footer: {
-        index: {
-            marginTop: 10,
-            width: '100%',
-            position: 'relative',
-        },
+        marginTop: 14,
+        width: '100%',
+        position: 'relative',
     },
 };

--- a/packages/org-unit-dialog/src/styles/UserOrgUnitsPanel.js
+++ b/packages/org-unit-dialog/src/styles/UserOrgUnitsPanel.js
@@ -1,5 +1,6 @@
 export default {
     container: {
+        paddingLeft: 18,
         background: '#F4F5F8',
         margin: '0 0px 10px',
         WebkitUserSelect: 'none',
@@ -8,20 +9,35 @@ export default {
         MsUserSelect: 'none',
         UserSelect: 'none',
     },
-    itemContainer: {
-        cursor: 'pointer',
+    gridItem: {
+        marginRight: 40,
     },
     checkbox: {
-        fontSize: 16,
+        fontSize: 10,
+        position: 'relative',
+        top: 2,
+        color: 'transparent',
+        background: 'white',
+        border: '1px solid #dedede',
+        borderRadius: 3,
+    },
+    checkboxChecked: {
+        fontSize: 14,
+        marginBottom: -2,
+        marginRight: -2,
+        position: 'relative',
+        top: 1,
+        right: 1,
     },
     stopIcon: {
         position: 'relative',
-        top: '4px',
-        color: '#9e9e9e',
-        fontSize: '15px',
-        margin: '0 3px 0 -10px',
+        top: 5,
+        color: '#a6a7a6',
+        fontSize: '14px',
+        margin: '0px 3px 0px -9px',
     },
     text: {
+        fontSize: '90%',
         cursor: 'pointer',
         color: '#000',
         position: 'relative',


### PR DESCRIPTION
Fixes DHIS2-5493.

Changes proposed in this pull request related to org units selector component:
- More space between the relative orgunits on the top bar
- Green color for checked checkboxes
- For the Level dropdown: Placeholder saying "Select a level" + the "Level" label above the field
- Same as above, for the Group dropdown

For the div with "deselect all" and number of selected items (not in the sketch, but confirmed with Joe):
- padding: 7px
- font-size: 14px
- background-color: colors.greyLight
- color: colors.black
- label: replace the dot with a dash, e.g. "4 selected - Deselect all"


