### PR TITLE
Respect display name property in org units tree and options

### DIFF
--- a/examples/create-react-app/src/components/org-unit-dialog.js
+++ b/examples/create-react-app/src/components/org-unit-dialog.js
@@ -4,6 +4,8 @@ import Snackbar from '@material-ui/core/Snackbar';
 import PropTypes from 'prop-types';
 import OrgUnitDialog from '@dhis2/d2-ui-org-unit-dialog';
 
+const DISPLAY_NAME_PROPERTY = 'displayShortName';
+
 export const defaultState = {
     orgUnitDialog: {
         open: false,
@@ -40,7 +42,7 @@ export default class OrgUnitDialogExample extends Component {
             .list({
                 paging: false,
                 level: 1,
-                fields: 'id,path,displayName,children::isNotEmpty',
+                fields: `id,path,${DISPLAY_NAME_PROPERTY}~rename(displayName),children::isNotEmpty`,
             })
             .then(rootLevel => rootLevel.toArray()[0])
             .then((loadRootUnit) => {
@@ -110,7 +112,10 @@ export default class OrgUnitDialogExample extends Component {
             .d2
             .models
             .organisationUnitGroups
-            .list({ paging: false })
+            .list({
+                fields: `id,${DISPLAY_NAME_PROPERTY}~rename(displayName)`,
+                paging: false,
+            })
             .then(collection => collection.toArray())
             .then(groupOptions => this.setState({ groupOptions }));
     };
@@ -194,6 +199,7 @@ export default class OrgUnitDialogExample extends Component {
                     handleMultipleOrgUnitsSelect={this.handleMultipleOrgUnitsSelect}
                     deselectAllTooltipBackgroundColor="#E0E0E0"
                     deselectAllTooltipFontColor="#000000"
+                    displayNameProperty={DISPLAY_NAME_PROPERTY}
                     onClose={this.toggleDialog}
                     onUpdate={this.onOrgUnitSelect}
                     checkboxColor="secondary"

--- a/packages/org-unit-dialog/i18n/en.pot
+++ b/packages/org-unit-dialog/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-11-27T11:20:47.020Z\n"
-"PO-Revision-Date: 2018-11-27T11:20:47.020Z\n"
+"POT-Creation-Date: 2018-12-05T14:02:39.745Z\n"
+"PO-Revision-Date: 2018-12-05T14:02:39.745Z\n"
 
 msgid "Organisation units"
 msgstr ""
@@ -20,10 +20,22 @@ msgstr ""
 msgid "Level"
 msgstr ""
 
+msgid "Select a level"
+msgstr ""
+
 msgid "Group"
 msgstr ""
 
+msgid "Select a group"
+msgstr ""
+
 msgid "Select children"
+msgstr ""
+
+msgid "selected"
+msgstr ""
+
+msgid "Deselect all"
 msgstr ""
 
 msgid "User organisation unit"

--- a/packages/org-unit-dialog/src/OrgUnitDialog.js
+++ b/packages/org-unit-dialog/src/OrgUnitDialog.js
@@ -39,6 +39,7 @@ class OrgUnitDialog extends React.PureComponent {
                     handleMultipleOrgUnitsSelect={this.props.handleMultipleOrgUnitsSelect}
                     deselectAllTooltipFontColor={this.props.deselectAllTooltipFontColor}
                     deselectAllTooltipBackgroundColor={this.props.deselectAllTooltipBackgroundColor}
+                    displayNameProperty={this.props.displayNameProperty}
                 />
             </DialogContent>
             <DialogActions>
@@ -52,6 +53,7 @@ class OrgUnitDialog extends React.PureComponent {
 }
 
 OrgUnitDialog.defaultProps = {
+    displayNameProperty: 'displayName',
     selected: [],
     userOrgUnits: [],
     level: [],
@@ -69,6 +71,11 @@ OrgUnitDialog.defaultProps = {
 };
 
 OrgUnitDialog.propTypes = {
+    /**
+     * Display name property taken from user settings
+     */
+    displayNameProperty: PropTypes.string,
+
     /**
     * Array of objects with required param id
     */

--- a/packages/org-unit-dialog/src/OrgUnitSelector.js
+++ b/packages/org-unit-dialog/src/OrgUnitSelector.js
@@ -178,7 +178,7 @@ class OrgUnitSelector extends Component {
                         />
                         <div style={styles.scrollableContainer.overlayContainer}>
                             {this.props.userOrgUnits.length > 0 && (
-                                <div style={styles.scrollableContainer.overlay}/>
+                                <div style={styles.scrollableContainer.overlay} />
                             )}
                             <OrgUnitTree
                                 root={this.props.root}
@@ -192,6 +192,7 @@ class OrgUnitSelector extends Component {
                                 labelStyle={styles.orgUnitTree.labelStyle}
                                 selectedLabelStyle={styles.orgUnitTree.selectedLabelStyle}
                                 checkboxColor={this.props.checkboxColor}
+                                displayNameProperty={this.props.displayNameProperty}
                                 showFolderIcon
                                 disableSpacer
                             />
@@ -231,6 +232,11 @@ class OrgUnitSelector extends Component {
 }
 
 OrgUnitSelector.propTypes = {
+    /**
+     * Display name property taken from user settings
+     */
+    displayNameProperty: PropTypes.string,
+
     /**
      * Array of objects with required param id
      */
@@ -316,6 +322,7 @@ OrgUnitSelector.propTypes = {
 };
 
 OrgUnitSelector.defaultProps = {
+    displayNameProperty: 'displayName',
     selected: [],
     userOrgUnits: [],
     level: [],

--- a/packages/org-unit-tree/src/OrgUnitTree.component.js
+++ b/packages/org-unit-tree/src/OrgUnitTree.component.js
@@ -147,7 +147,15 @@ class OrgUnitTree extends React.Component {
                 // d2.ModelCollectionProperty.load takes a second parameter `forceReload` and will just return
                 // the current valueMap unless either `this.hasUnloadedData` or `forceReload` are true
                 root.children.load(
-                    { fields: 'id,displayName,children::isNotEmpty,path,parent' },
+                    {
+                        fields: [
+                            'id',
+                            `${this.props.displayNameProperty}~rename(displayName)`,
+                            'children::isNotEmpty',
+                            'path',
+                            'parent',
+                        ].join(','),
+                    },
                     this.props.forceReloadChildren,
                 ).then((children) => {
                     resolve(children);
@@ -210,6 +218,7 @@ class OrgUnitTree extends React.Component {
                     showFolderIcon={this.props.showFolderIcon}
                     disableSpacer={this.props.disableSpacer}
                     checkboxColor={this.props.checkboxColor}
+                    displayNameProperty={this.props.displayNameProperty}
                 />
             );
         }
@@ -373,6 +382,11 @@ OrgUnitTree.propTypes = {
     root: PropTypes.instanceOf(ModelBase).isRequired,
 
     /**
+     * Display name property
+     */
+    displayNameProperty: PropTypes.string,
+
+    /**
      * An array of paths of selected OUs
      *
      * The path of an OU is the UIDs of the OU and all its parent OUs separated by slashes (/)
@@ -506,6 +520,7 @@ OrgUnitTree.propTypes = {
 };
 
 OrgUnitTree.defaultProps = {
+    displayNameProperty: 'displayName',
     selected: [],
     initiallyExpanded: [],
     onSelectClick: undefined,


### PR DESCRIPTION
Fixes DHIS2-5495.

Changes proposed in this pull request:
- Respect displayNameProperty prop for displaying org units/groups names

