### PR TITLE
[WIP] refactor/interpretations component [DHIS2-5470]

### DIFF
--- a/packages/interpretations/src/components/CollapsibleCard.js
+++ b/packages/interpretations/src/components/CollapsibleCard.js
@@ -11,7 +11,6 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 const styles = theme => ({
     card: {
-        maxWidth: 400,
         margin: 4,
         marginBottom: 6,
         position: 'relative',

--- a/packages/interpretations/src/components/Interpretations.js
+++ b/packages/interpretations/src/components/Interpretations.js
@@ -8,6 +8,7 @@ import { getFavoriteWithInterpretations } from '../models/helpers';
 import DetailsCard from './details/DetailsCard';
 import InterpretationsCard from './interpretations/InterpretationsCard';
 import i18n from '../locales';
+import styles from './interpretations/InterpretationsStyles';
 
 function configI18n(d2) {
     const locale = d2.currentUser.userSettings.settings.keyUiLocale;
@@ -62,7 +63,7 @@ class Interpretations extends React.Component {
         if (!model) return <CircularProgress />;
 
         return (
-            <div>
+            <div style={styles.interpretationsContainer}>
                 <DetailsCard model={model} onChange={this.onChange} />
 
                 <InterpretationsCard

--- a/packages/interpretations/src/components/interpretations/Interpretation.js
+++ b/packages/interpretations/src/components/interpretations/Interpretation.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ThumbUpIcon from '@material-ui/icons/ThumbUp';
 import i18n from '@dhis2/d2-i18n';
 import SharingDialog from '@dhis2/d2-ui-sharing-dialog';
 import some from 'lodash/fp/some';
 import InterpretationComments from './InterpretationComments';
 import InterpretationDialog from './InterpretationDialog';
-import { Link, ActionSeparator, getUserLink } from './misc';
+import InterpretationIcon from './InterpretationIcon';
+import { getUserLink } from './misc';
 import { userCanManage } from '../../util/auth';
-import styles from './InterpretationsStyles.js';
 import CommentModel from '../../models/comment';
 import { formatDate } from '../../util/i18n';
+import styles from './InterpretationsStyles';
 
 class Interpretation extends React.Component {
     state = {
@@ -117,10 +117,7 @@ class Interpretation extends React.Component {
         const showActions = extended;
         const showComments = extended;
         const likedBy = interpretation.likedBy || [];
-        const likedByTooltip = likedBy
-            .map(user => user.displayName)
-            .sort()
-            .join('\n');
+
         const currentUserLikesInterpretation = some(user => user.id === d2.currentUser.id, likedBy);
 
         return (
@@ -163,66 +160,70 @@ class Interpretation extends React.Component {
                         </div>
                     </div>
 
+                    <div style={styles.interpretationCommentArea}>
+                        <span style={styles.intepretationLikes}>{interpretation.likes} {i18n.t('likes')}</span>
+                        <span>{`${interpretation.comments.length} ${i18n.t('replies')}`}</span>
+                    </div>
                     <div>
                         {showActions ? (
                             <div className="actions" style={styles.actions}>
-                                <Link label={i18n.t('Exit view')} onClick={this.exitView} />
-
-                                <ActionSeparator />
-
+                                <InterpretationIcon 
+                                        iconType={'visibilityOff'} 
+                                        tooltip={i18n.t('Exit View')} 
+                                        onClick={this.exitView}
+                                />
                                 {currentUserLikesInterpretation ? (
-                                    <Link label={i18n.t('Unlike')} onClick={this.unlike} />
+                                    <InterpretationIcon 
+                                        iconType={'like'} 
+                                        tooltip={i18n.t('Unlike')} 
+                                        onClick={this.unlike}
+                                    />
                                 ) : (
-                                    <Link label={i18n.t('Like')} onClick={this.like} />
+                                    <InterpretationIcon 
+                                        iconType={'unlike'} 
+                                        tooltip={i18n.t('Like')} 
+                                        onClick={this.like}
+                                    />
                                 )}
 
-                                <ActionSeparator />
-
-                                <Link label={i18n.t('Reply')} onClick={this.reply} />
+                                <InterpretationIcon 
+                                    iconType={'reply'} 
+                                    tooltip={i18n.t('Reply')} 
+                                    onClick={this.reply}
+                                />
 
                                 {userCanManage(d2, interpretation) && (
-                                    <span className="owner-actions">
-                                        <ActionSeparator />
-                                        <Link
-                                            label={i18n.t('Edit')}
-                                            onClick={this.openInterpretationDialog}
-                                        />
-                                        <ActionSeparator />
-                                        <Link
-                                            label={i18n.t('Share')}
+                                    <div style={styles.userActions} className="owner-actions">
+                                        
+                                        <InterpretationIcon 
+                                            iconType={'edit'} 
+                                            tooltip={i18n.t('Edit')} 
+                                            onClick={this.openInterpretationDialog} //TODO
+                                        />      
+
+                                        <InterpretationIcon 
+                                            iconType={'share'} 
+                                            tooltip={i18n.t('Share')} 
                                             onClick={this.openSharingDialog}
                                         />
-                                        <ActionSeparator />
-                                        <Link
-                                            label={i18n.t('Delete')}
+
+                                        <InterpretationIcon 
+                                            iconType={'delete'} 
+                                            tooltip={i18n.t('Delete')} 
                                             onClick={this.deleteInterpretation}
                                         />
-                                    </span>
+                                    </div>
                                 )}
                             </div>
                         ) : (
                             <div className="actions" style={styles.actions}>
-                                <Link label={i18n.t('View')} onClick={this.view} />
+                                <InterpretationIcon 
+                                    iconType={'visibility'} 
+                                    tooltip={i18n.t('View')}  
+                                    onClick={this.view}
+                                />
                             </div>
                         )}
-
-                        <div style={styles.interpretationCommentArea}>
-                            <div style={styles.likeArea}>
-                                <ThumbUpIcon style={styles.likeIcon} />
-
-                                <span
-                                    style={{ color: '#22A' }}
-                                    className="liked-by"
-                                    title={likedByTooltip}
-                                >
-                                    {interpretation.likes} {i18n.t('people like this')}
-                                </span>
-
-                                <ActionSeparator />
-
-                                {`${interpretation.comments.length} ${i18n.t('people commented')}`}
-                            </div>
-
                             {showComments && (
                                 <InterpretationComments
                                     d2={d2}
@@ -235,7 +236,6 @@ class Interpretation extends React.Component {
                         </div>
                     </div>
                 </div>
-            </div>
         );
     }
 }

--- a/packages/interpretations/src/components/interpretations/InterpretationIcon.js
+++ b/packages/interpretations/src/components/interpretations/InterpretationIcon.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react';
+import Popper from '@material-ui/core/Popper';
+import Paper from '@material-ui/core/Paper';
+
+import { Icons } from './misc';
+import styles from './InterpretationsStyles';
+
+export class InterpretationIcon extends Component {
+    state = { anchorEl: null }
+
+    showTooltip = event => this.setState({ anchorEl: event.currentTarget });
+
+    hideTooltip = () => this.setState({ anchorEl: null });
+
+    renderTooltip = () => (
+		<Popper
+			anchorEl={this.state.anchorEl}
+			open={Boolean(this.state.anchorEl)}
+			placement="top"
+		>
+			<Paper style={styles.tooltip}>
+				{this.props.tooltip}
+			</Paper>
+		</Popper>
+	);
+
+    render() {
+        const Icon = Icons[this.props.iconType];
+        const Tooltip =  this.renderTooltip();
+
+        return (
+			<div 
+				style={styles.iconContainer}
+				onMouseEnter={this.showTooltip} 
+				onMouseLeave={this.hideTooltip} 
+				onClick={this.props.onClick} 
+			>
+                {Icon}
+                {Tooltip}
+            </div>
+        
+        );
+        
+    }; 
+};
+
+export default InterpretationIcon;

--- a/packages/interpretations/src/components/interpretations/InterpretationsStyles.js
+++ b/packages/interpretations/src/components/interpretations/InterpretationsStyles.js
@@ -2,6 +2,12 @@ export default {
     body: {
         padding: 0
     },
+    
+    interpretationsContainer: {
+        display: 'flex',
+        flexFlow: 'column nowrap',
+        flex: '1 1 100%',
+    },
 
     commentArea: {
         border: "1px solid #ccc",
@@ -36,6 +42,7 @@ export default {
     },
 
     actions: {
+        display: 'flex',
         marginBottom: 5
     },
 
@@ -62,7 +69,12 @@ export default {
 
     interpretationCommentArea: {
         fontSize: 12,
-        margin: "2px 0 5px 0px"
+        margin: "2px 0 5px 0px",
+        color: 'grey',
+    },
+
+    intepretationLikes: {
+        paddingRight: '5px',
     },
 
     interpretationDescSection: {
@@ -75,7 +87,8 @@ export default {
     },
 
     interpretationName: {
-        display: "inline-block"
+        display: "flex",
+        justifyContent: 'space-between',
     },
 
     interpretationText: {
@@ -191,5 +204,46 @@ export default {
         fontWeight: "bold",
         width: 32,
         height: 32
-    }
+    },
+
+    userActions: {
+        display: 'flex',
+    },
+    
+    defaulThumbUp: {
+        fill: '#E0E0E0',
+    },
+
+    likedThumbUp: {
+        fill: '#000000',
+    },
+
+    iconContainer: {
+        cursor: 'pointer',
+    },
+
+    viewIcon: {
+        height: '16px',
+        width: '16px',
+        marginRight: '10px',
+    },
+
+    interpretationCommentIcon: {
+        height: '16px',
+        width: '16px',
+        margin: '0 10px',
+    },
+
+    tooltip: {
+        fontFamily: 'roboto',
+        fontSize: '12px',
+        whiteSpace:'noWrap',
+        padding: '7px 9px',
+        color: 'white',
+        backgroundColor: '#4a4a4a',
+        boxShadow: 'none',
+        borderRadius: '3px',
+        position: 'relative',
+        bottom: '2px',
+    },
 };

--- a/packages/interpretations/src/components/interpretations/misc.js
+++ b/packages/interpretations/src/components/interpretations/misc.js
@@ -1,5 +1,12 @@
 import React from 'react';
 import Avatar from '@material-ui/core/Avatar';
+import Visibility from '@material-ui/icons/Visibility';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
+import ThumbUpIcon from '@material-ui/icons/ThumbUp';
+import Reply from '@material-ui/icons/Reply';
+import Create from '@material-ui/icons/Create';
+import Share from '@material-ui/icons/Share';
+import Delete from '@material-ui/icons/Delete';
 import styles from './InterpretationsStyles.js';
 
 export const getUserLink = (d2, user) => {
@@ -44,3 +51,14 @@ export const WithAvatar = ({ user, children }) => (
         </div>
     </div>
 );
+
+export const Icons = {
+	visibility: <Visibility style={styles.viewIcon}/>,
+	visibilityOff: <VisibilityOff style={styles.viewIcon} />,
+    like: <ThumbUpIcon style={{...styles.likedThumbUp, ...styles.interpretationCommentIcon}}/>,
+    unlike: <ThumbUpIcon style={{...styles.defaulThumbUp, ...styles.interpretationCommentIcon}} />,
+	reply: <Reply style={styles.interpretationCommentIcon}/>,
+	edit: <Create style={styles.interpretationCommentIcon} />,
+	share: <Share style={styles.interpretationCommentIcon}/>,
+	delete: <Delete style={styles.interpretationCommentIcon} />,
+}


### PR DESCRIPTION
This PR is opened to attach discussion and feedback for potential re-factor steps and review on added changes - it will not be merged immediately:

I have added 1 new file InterpretationIcon.js to render icons with onHover tooltip text according to the [quick-suggestion provided from Joe](https://jira.dhis2.org/browse/DHIS2-5470) 

It is not entirely identical (The View/Exit View link is replaced with the visibility Icon), 

What i have done as of yet: 

* I have removed the maxWidth on CollapsibleCard and added `flex: '1 1 100%` to the root container such that the component can use the available space in DV / Maps / Dashboard.

* The Date are flexed to the right end of the interpretation.

*  the " x likes and x replies " are rendered in grey text.

* Removed some unused code.

Before i continue with changes i can suggest:
* add styles folders with styles files for each component ( similar to  DV ) as some stylings are declared in-line, some have the interpretationStyle.js file, and some have stylings through withStyles above its class component ( CollapsibleCard.js )

* use arrowFunction and remove bindings in the constructor ( will reduce some lines but i found a comment from [Dan Abramov that binding provides more stability](https://github.com/facebook/react/issues/9851) )


The added flex property on the root containers does not break the DV app as it has a div wrapper around it, and it will allow the component to use the available space underneath the AOs in the dashboard.