### PR TITLE
Refactor OrgUnitTree component

### DIFF
--- a/packages/org-unit-tree/src/OUCheckbox.component.js
+++ b/packages/org-unit-tree/src/OUCheckbox.component.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import Checkbox from '@material-ui/core/Checkbox';
+import CheckBoxIcon from '@material-ui/icons/CheckBox';
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import styles from './styles/OUCheckbox.component.styles';
+
+const OUCheckboxComponent = ({ checked, disabled, onClick, color }) => {
+    return (
+        <Checkbox
+            style={styles.checkbox}
+            checked={checked}
+            disabled={disabled}
+            onClick={onClick}
+            color={color}
+            icon={<CheckBoxOutlineBlankIcon style={styles.uncheckedCheckbox} />}
+            checkedIcon={<CheckBoxIcon style={{ fontSize: 15 }} />}
+        />
+    )
+};
+
+export default OUCheckboxComponent;

--- a/packages/org-unit-tree/src/OUFolderIcon.component.js
+++ b/packages/org-unit-tree/src/OUFolderIcon.component.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import FolderIcon from '@material-ui/icons/Folder';
+import FolderOpenIcon from '@material-ui/icons/FolderOpen';
+
+const OUFolderIconComponent = ({ isExpanded, styles }) => {
+    return isExpanded
+        ? <FolderOpenIcon style={styles} />
+        : <FolderIcon style={styles} />;
+};
+
+export default OUFolderIconComponent;

--- a/packages/org-unit-tree/src/styles/OUCheckbox.component.styles.js
+++ b/packages/org-unit-tree/src/styles/OUCheckbox.component.styles.js
@@ -1,0 +1,11 @@
+export default {
+    checkbox: {
+        position: 'relative',
+        bottom: 2,
+        padding: 0,
+    },
+    uncheckedCheckbox: {
+        fontSize: 15,
+        color: '#E0E0E0',
+    },
+}

--- a/packages/org-unit-tree/src/styles/OrgUnitTree.component.styles.js
+++ b/packages/org-unit-tree/src/styles/OrgUnitTree.component.styles.js
@@ -1,0 +1,40 @@
+export default {
+    progress: {
+        position: 'absolute',
+        display: 'inline-block',
+        width: '100%',
+        left: -8,
+    },
+    progressBar: {
+        height: 2,
+        backgroundColor: 'transparent',
+    },
+    spacer: {
+        position: 'relative',
+        display: 'inline-block',
+        width: '1.2rem',
+        height: '1rem',
+    },
+    label: {
+        display: 'inline-block',
+        outline: 'none',
+    },
+    ouContainer: {
+        borderColor: 'transparent',
+        borderStyle: 'solid',
+        borderWidth: '1px',
+        borderRightWidth: 0,
+        borderRadius: '3px 0 0 3px',
+        background: 'transparent',
+        paddingLeft: 2,
+        outline: 'none',
+    },
+    currentOuContainer: {
+        background: 'rgba(0,0,0,0.05)',
+        borderColor: 'rgba(0,0,0,0.1)',
+    },
+    memberCount: {
+        fontSize: '0.75rem',
+        marginLeft: 4,
+    },
+}

--- a/packages/org-unit-tree/src/utils.js
+++ b/packages/org-unit-tree/src/utils.js
@@ -4,7 +4,7 @@
  * @param path
  * @param op A callback that accepts one parameter: An org unit
  */
-export function forEachOnPath(root, path, op) {
+export const forEachOnPath = (root, path, op) => {
     op(root);
     if (path.length > 0 && (Array.isArray(root.children) || root.children.size > 0)) {
         if (root.children.has(path[0])) {
@@ -13,7 +13,7 @@ export function forEachOnPath(root, path, op) {
             forEachOnPath(root, path.slice(1), op);
         }
     }
-}
+};
 
 /**
  * Decrement the selected member count of of the specified org unit and all its ascendants in the org unit tree with the
@@ -21,9 +21,9 @@ export function forEachOnPath(root, path, op) {
  * @param root
  * @param orgUnit
  */
-export function decrementMemberCount(root, orgUnit) {
+export const decrementMemberCount = (root, orgUnit) => {
     forEachOnPath(root, orgUnit.path.substr(1).split('/').slice(1), ou => ou.memberCount--);
-}
+};
 
 /**
  * Increment the selected member count of of the specified org unit and all its ascendants in the org unit tree with the
@@ -31,16 +31,16 @@ export function decrementMemberCount(root, orgUnit) {
  * @param root The root org unit
  * @param orgUnit
  */
-export function incrementMemberCount(root, orgUnit) {
+export const incrementMemberCount = (root, orgUnit) => {
     forEachOnPath(root, orgUnit.path.substr(1).split('/').slice(1), ou => ou.memberCount++);
-}
+};
 
 /**
  * Merge the specified children into the org unit tree with the specified root
  * @param root
  * @param children
  */
-export function mergeChildren(root, children) {
+export const mergeChildren = (root, children) => {
     function assignChildren(root, path, children) {
         if (path.length === 0) {
             root.children = children;
@@ -53,5 +53,26 @@ export function mergeChildren(root, children) {
     const childPath = children.toArray()[0].path.substr(1).split('/');
     childPath.splice(-1, 1);
     return assignChildren(root, childPath.slice(1), children);
-}
+};
+
+/**
+ * Load children for org unit (root) node
+ * @param root
+ * @param displayNameProperty
+ * @param forceReloadChildren
+ * @returns {*}
+ */
+export const loadChildren = (root, displayNameProperty, forceReloadChildren) => {
+    const fields = [
+        'id',
+        `${displayNameProperty}~rename(displayName)`,
+        'children::isNotEmpty',
+        'path',
+        'parent',
+    ];
+
+    // d2.ModelCollectionProperty.load takes a second parameter `forceReload` and will just return
+    // the current valueMap unless either `this.hasUnloadedData` or `forceReload` are true
+    return root.children.load({ fields: fields.join(',') }, forceReloadChildren);
+};
 


### PR DESCRIPTION
Fixes DHIS2-5528.

Changes proposed in this pull request:
* move styles to a separate file
* pull the loading function into a separate util.js file
* the render function has a bunch of comments that are unnecessary
* the render function has a high (poor) complexity score. Any way to simplify it? (e.g., make a OUCheckbox component, OUFolderIcon component), pull the event handlers out to standalone functions with argument...
