### PR TITLE
Task/sort mentions list [DHIS2-5473]

### DIFF
--- a/examples/create-react-app/src/components/mentions-wrapper.js
+++ b/examples/create-react-app/src/components/mentions-wrapper.js
@@ -12,13 +12,15 @@ class MentionsWrapperExample extends Component {
     };
 
     render() {
-        return (<MentionsWrapper d2={this.props.d2} onUserSelect={this.updateNewText}>
-            <InputField
-                value={this.state.newText}
-                placeholder="Type some text. @ triggers the mentions suggestions"
-                onChange={this.updateNewText}
-            />
-        </MentionsWrapper>);
+        return (
+            <MentionsWrapper d2={this.props.d2} onUserSelect={this.updateNewText}>
+                <InputField
+                    value={this.state.newText}
+                    placeholder="Type some text. @ triggers the mentions suggestions"
+                    onChange={this.updateNewText}
+                />
+            </MentionsWrapper>
+        );
     }
 }
 

--- a/packages/mentions-wrapper/src/MentionsWrapper.js
+++ b/packages/mentions-wrapper/src/MentionsWrapper.js
@@ -13,7 +13,7 @@ const defaultState = {
     selectedUserIndex: 0,
 };
 
-class MentionsWrapper extends Component {
+export class MentionsWrapper extends Component {
     constructor(props) {
         super(props);
 

--- a/packages/mentions-wrapper/src/MentionsWrapper.js
+++ b/packages/mentions-wrapper/src/MentionsWrapper.js
@@ -13,7 +13,7 @@ const defaultState = {
     selectedUserIndex: 0,
 };
 
-export class MentionsWrapper extends Component {
+class MentionsWrapper extends Component {
     constructor(props) {
         super(props);
 

--- a/packages/mentions-wrapper/src/UserList.js
+++ b/packages/mentions-wrapper/src/UserList.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItem from '@material-ui/core/ListItem';
 import List from '@material-ui/core/List';
-import sortBy from 'lodash-es/sortBy';
+import sortBy from 'lodash/sortBy';
 
 import Popover from '@material-ui/core/Popover';
 import Typography from '@material-ui/core/Typography';
@@ -48,7 +48,7 @@ export const UserList = ({
 
         onSelect(user);
     };
-
+    
     const sortedUsers = sortBy(users, [userName => userName.displayName]);
 
     return (

--- a/packages/mentions-wrapper/src/UserList.js
+++ b/packages/mentions-wrapper/src/UserList.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItem from '@material-ui/core/ListItem';
 import List from '@material-ui/core/List';
+import sortBy from 'lodash-es/sortBy';
 
 import Popover from '@material-ui/core/Popover';
 import Typography from '@material-ui/core/Typography';
@@ -48,6 +49,8 @@ export const UserList = ({
         onSelect(user);
     };
 
+    const sortedUsers = sortBy(users, [userName => userName.displayName]);
+
     return (
         <Popover
             open={open}
@@ -63,13 +66,13 @@ export const UserList = ({
         >
             {users.length ? (
                 <Fragment>
-                    <Typography variant="subheading">
+                    <Typography variant="subtitle1">
                         <em className={classes.filter}>
                             {i18n.t('Searching for "{{filter}}"', { filter })}
                         </em>
                     </Typography>
                     <List dense disablePadding className={classes.list}>
-                        {users.map(u => (
+                        {sortedUsers.map(u => (
                             <ListItem
                                 button
                                 key={u.id}

--- a/packages/mentions-wrapper/src/UserList.js
+++ b/packages/mentions-wrapper/src/UserList.js
@@ -49,8 +49,6 @@ export const UserList = ({
         onSelect(user);
     };
     
-    const sortedUsers = sortBy(users, [userName => userName.displayName]);
-
     return (
         <Popover
             open={open}
@@ -72,7 +70,7 @@ export const UserList = ({
                         </em>
                     </Typography>
                     <List dense disablePadding className={classes.list}>
-                        {sortedUsers.map(u => (
+                        {sortBy(users, [userName => userName.displayName.toLowerCase()]).map(u => (
                             <ListItem
                                 button
                                 key={u.id}

--- a/packages/mentions-wrapper/src/__tests__/UserList.spec.js
+++ b/packages/mentions-wrapper/src/__tests__/UserList.spec.js
@@ -4,6 +4,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import ListItem from '@material-ui/core/ListItem';
 import List from '@material-ui/core/List';
 import Popover from '@material-ui/core/Popover';
+import sortBy from 'lodash/sortBy';
 
 
 import { UserList } from '../UserList';
@@ -56,15 +57,25 @@ describe('Mentions: MentionsWrapper > UserList component', () => {
                 .find(ListItemText)
                 .first()
                 .props().primary
-        ).toEqual('Johnny Cash (sue)');
+        ).toEqual('Eric Clapton (slowhand)');
+    });
+
+    it('should sort the mentions in alphabetical order by firstname', () => {
+        const sortedUsers = sortBy(props.users, [userName => userName.displayName]);
+        
+        userList.find(ListItemText).forEach((node, i) => 
+            expect(
+                node.props().primary).toContain(sortedUsers[i].displayName
+                )
+            );
     });
 
     it('should trigger the onSelect callback when an item in the list is clicked', () => {
         const listItem = userList.find(ListItem).first();
-
+        const sortedUsers = sortBy(props.users, [userName => userName.displayName]);
         listItem.simulate('click');
 
         expect(onSelect).toHaveBeenCalledTimes(1);
-        expect(onSelect).toHaveBeenCalledWith(props.users[0]);
+        expect(onSelect).toHaveBeenCalledWith(sortedUsers[0]);
     });
 });

--- a/packages/mentions-wrapper/src/__tests__/UserList.spec.js
+++ b/packages/mentions-wrapper/src/__tests__/UserList.spec.js
@@ -14,27 +14,26 @@ describe('Mentions: MentionsWrapper > UserList component', () => {
     let onSelect;
     let onClose;
     let props;
+    let users;
 
     beforeEach(() => {
         onSelect = jest.fn();
         onClose = jest.fn();
 
+        users =  [
+            { id: 'jc', displayName: 'Johnny Cash', userCredentials: { username: 'sue' } },
+            {
+                id: 'ec',
+                displayName: 'Eric Clapton',
+                userCredentials: { username: 'slowhand' },
+            },
+            { id: 'jj', displayName: 'Justin Johnson', userCredentials: { username: 'slide' } },
+        ];
+
         props = {
             classes: { selected: { backgroundColor: 'lightgrey' } },
-            users: [
-                { id: 'jc', displayName: 'Johnny Cash', userCredentials: { username: 'sue' } },
-                {
-                    id: 'ec',
-                    displayName: 'Eric Clapton',
-                    userCredentials: { username: 'slowhand' },
-                },
-                { id: 'jj', displayName: 'Justin Johnson', userCredentials: { username: 'slide' } },
-            ],
-            selectedUser: {
-                id: 'jj',
-                displayName: 'Justin Johnson',
-                userCredentials: { username: 'slide' },
-            },
+            users,
+            selectedUser: users[2],
             onSelect,
             onClose,
         };
@@ -61,21 +60,29 @@ describe('Mentions: MentionsWrapper > UserList component', () => {
     });
 
     it('should sort the mentions in alphabetical order by firstname', () => {
-        const sortedUsers = sortBy(props.users, [userName => userName.displayName]);
-        
+        const sortedList = [
+            { displayName: 'Eric Clapton' },
+            { displayName: 'Johnny Cash' },
+            { displayName: 'Justin Johnson' }
+        ];
+
         userList.find(ListItemText).forEach((node, i) => 
             expect(
-                node.props().primary).toContain(sortedUsers[i].displayName
-                )
+                node.props().primary).toContain(sortedList[i].displayName)
             );
     });
 
     it('should trigger the onSelect callback when an item in the list is clicked', () => {
         const listItem = userList.find(ListItem).first();
-        const sortedUsers = sortBy(props.users, [userName => userName.displayName]);
         listItem.simulate('click');
 
+        const expectedResult = {
+            id: 'ec',
+            displayName: 'Eric Clapton',
+            userCredentials: { username: 'slowhand' },
+        };
+
         expect(onSelect).toHaveBeenCalledTimes(1);
-        expect(onSelect).toHaveBeenCalledWith(sortedUsers[0]);
+        expect(onSelect).toHaveBeenCalledWith(expectedResult);
     });
 });


### PR DESCRIPTION
This PR includes:
using ´lodash/sortBy` to sort available mentions by displayName.

![image](https://user-images.githubusercontent.com/13645152/50214524-cbb75e00-0380-11e9-8fc0-36bd666ae955.png)

Capital letters are prioritized, i checked the source code and it uses array.sort(), and MDN documentation states that:
```
The default sort order is built upon converting the elements into strings, then comparing their sequences of UTF-16 code units values.
```
This means that displayName with capital letters will be sorted first, and then displayNames without capital letters.

I confirmed this with concating the users with:
`
users.concat({id: 'testId', displayName: 'alain Traore', userCredentials: { username: 'traori' }})
`

I can change it to sort by `displayName.toLowerCase()`:

![image](https://user-images.githubusercontent.com/13645152/50215648-eccd7e00-0383-11e9-9c03-10bcc65cfcfb.png)


Additional info:
I've also updated the Typograhpy `variant` prop to use the new version as this was causing a warning.

* Test cases have been adjusted now that `UserList`  is rendering a sorted list.

* Added 1 test case to verify that the list is rendered in a sorted fashion.
 