### PR TITLE
Remove non-existent "this" from code

### DIFF
--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -6,7 +6,7 @@
   "license": "BSD-3-Clause",
   "author": "Edoardo Sabadelli <edoardo@dhis2.org>",
   "scripts": {
-    "coverage": "jest --coverage",
+    "coverage": "jest --coverage --config=../../jest.config.js packages/rich-text",
     "test-ci": "jest --config=../../jest.config.js packages/rich-text",
     "lint": "eslint src/",
     "prebuild": "npm run lint && rimraf ./build/*",

--- a/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
+++ b/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
@@ -45,4 +45,22 @@ describe('convertCtrlKey', () => {
         expect(cb).toHaveBeenCalled();
         expect(cb).toHaveBeenCalledWith('*abc*');
     });
+
+    it('triggers callback with opening and closing marker when text is selected', () => {
+        const cb = jest.fn();
+        const e = {
+            key: 'b',
+            metaKey: true,
+            target: {
+                selectionStart: 8,
+                selectionEnd: 12,
+                value: 'rainbow dash is purple',
+            },
+        };
+
+        convertCtrlKey(e, cb);
+
+        expect(cb).toHaveBeenCalled();
+        expect(cb).toHaveBeenCalledWith('rainbow *dash* is purple');
+    })
 });

--- a/packages/rich-text/src/editor/convertCtrlKey.js
+++ b/packages/rich-text/src/editor/convertCtrlKey.js
@@ -36,7 +36,7 @@ const insertMarkers = (mode, cb) => {
             value.slice(selectionEnd),
         ].join(marker);
 
-        this.toggleMode(mode);
+        toggleMode(mode);
     }
 
     cb(newValue);


### PR DESCRIPTION
Undefined "this" was causing a javascript error and was obviously resulting in the rich text feature not working when using shortcut keys on a selected text. 

Unit test added. Also fixed the npm coverage script so that it has the needed configuration.
