### PR TITLE
Small refactor

### DIFF
--- a/packages/interpretations/src/models/interpretation.js
+++ b/packages/interpretations/src/models/interpretation.js
@@ -33,7 +33,7 @@ export default class Interpretation {
             const sharingUrl = `/sharing?type=interpretation&id=${interpretationId}`;
 
             const sharingPayload = this.sharing
-                ? { object: { ...this.sharing, id: this.id } }
+                ? { object: { ...this.sharing, id: interpretationId } }
                 : { object: pick(Interpretation.sharingFields, this._parent) };
 
             this.sharing = null;

--- a/packages/interpretations/src/models/interpretation.js
+++ b/packages/interpretations/src/models/interpretation.js
@@ -4,6 +4,7 @@ import Comment from './comment';
 
 function getInterpretationIdFromResponse(response)  {
     const location = response.headers.get('location');
+
     if (location) {
         return last(location.split('/'));
     } else {
@@ -24,42 +25,40 @@ export default class Interpretation {
         const modelId = this._parent.id;
         const modelName = this._parent.modelDefinition.name;
         const isNewInterpretation = !this.id;
-        
+
         if (isNewInterpretation) {
             // Set initial sharing of interpretation from the parent object
-            
-            return await apiFetchWithResponse(d2, `/interpretations/${modelName}/${modelId}`, "POST", this.text)
-                .then(getInterpretationIdFromResponse)
-                .then(interpretationId => {
-                    this.id = interpretationId;
-                    const sharingPayload = this.sharing 
-                        ? { object: {...this.sharing, id: this.id} } 
-                        : { object: pick(Interpretation.sharingFields, this._parent) };
+            const response = await apiFetchWithResponse(d2, `/interpretations/${modelName}/${modelId}`, "POST", this.text);
+            const interpretationId = getInterpretationIdFromResponse(response);
+            const sharingUrl = `/sharing?type=interpretation&id=${interpretationId}`;
 
-                    this.sharing = null;
-                    const sharingUrl = `/sharing?type=interpretation&id=${interpretationId}`;
-                    return apiFetch(d2, sharingUrl, "PUT", sharingPayload).then(() =>  this);
-                });
+            const sharingPayload = this.sharing
+                ? { object: { ...this.sharing, id: this.id } }
+                : { object: pick(Interpretation.sharingFields, this._parent) };
+
+            this.sharing = null;
+            this.id = interpretationId;
+
+            return apiFetch(d2, sharingUrl, "PUT", sharingPayload)
         } else {
-            return await apiFetch(d2, `/interpretations/${this.id}`, "PUT", this.text)
-                .then(() => {
-                    if (this.sharing) {
-                        const sharingPayload =  { object: {...this.sharing, id: this.id}};
-                        this.sharing = null;
+            // interpretation already exists in DB
+            await apiFetch(d2, `/interpretations/${this.id}`, "PUT", this.text);
 
-                    const sharingUrl = `/sharing?type=interpretation&id=${this.id}`;
-                    return apiFetch(d2, sharingUrl, "PUT", sharingPayload).then(() =>  this);
-                }
-            })
-            .then(() => this);
+            if (this.sharing) {
+                const sharingPayload =  { object: {...this.sharing, id: this.id}};
+                const sharingUrl = `/sharing?type=interpretation&id=${this.id}`;
+                this.sharing = null;
+
+                return apiFetch(d2, sharingUrl, "PUT", sharingPayload);
+            }
         }
     }
 
-    async delete(d2) {
-        return await apiFetch(d2, `/interpretations/${this.id}`, "DELETE");
+    delete(d2) {
+        return apiFetch(d2, `/interpretations/${this.id}`, "DELETE");
     }
 
-    async like(d2, value) {
-        return await apiFetch(d2, `/interpretations/${this.id}/like`, value ? "POST" : "DELETE");
+    like(d2, value) {
+        return apiFetch(d2, `/interpretations/${this.id}/like`, value ? "POST" : "DELETE");
     }
 }


### PR DESCRIPTION
This PR contains small code refactoring in `packages/interpretations/src/models/Interpretation.js`

Changes proposed in this pull request:
- Remove redundant async/await from delete/like methods
- Remove redundant .then(() => this)
- Return promise of the second request as a result in `save()` method