### PR TITLE
Updates to rich-text editor to insert double markers, trim space and provide caret position

### DIFF
--- a/examples/create-react-app/src/components/rich-text.js
+++ b/examples/create-react-app/src/components/rich-text.js
@@ -74,7 +74,7 @@ export default class RichText extends Component {
 
     render() {
         return (
-            <div style={{marginLeft: 400}}>
+            <div>
                 <div>
                     <p>Using RichText react component wrapper:</p>
                     <RichTextEditor onEdit={this.updateNewText}>

--- a/examples/create-react-app/src/components/rich-text.js
+++ b/examples/create-react-app/src/components/rich-text.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { InputField } from '@dhis2/d2-ui-core';
 import {
     Parser as RichTextParser,
     Editor as RichTextEditor,
@@ -7,6 +6,30 @@ import {
     convertCtrlKey,
 } from '@dhis2/d2-ui-rich-text';
 
+/**
+ * This component just contains a native input field, but includes a React ref
+ * so that it is possible to call setSelectionRange. This should also be possible
+ * using Material-ui 3.0 or greater, since the api for TextField provides a handle
+ * to the native input.
+ */
+class InputField extends Component {
+    constructor(props) {
+        super(props);
+        this.input = React.createRef()
+    }
+    componentDidUpdate() {
+        if(this.props.caretPos) {
+            const node = this.input.current;
+            node.setSelectionRange(this.props.caretPos, this.props.caretPos);
+        }
+    }
+
+    render () {
+        return (
+            <input ref={this.input} type="text" value={this.props.value} onChange={this.props.onChange} />
+        );
+    }
+}
 
 export default class RichText extends Component {
     constructor(props) {
@@ -17,6 +40,7 @@ export default class RichText extends Component {
     }
     state = {
         newText: '',
+        caretPos: null,
         paraVal: '',
     };
 
@@ -24,13 +48,18 @@ export default class RichText extends Component {
         this.setState({ paraVal: this.state.newText });
     };
 
-    updateNewText = (newText) => {
-        this.setState({ newText });
+    updateNewText = (newText, caretPos) => {
+        this.setState({ newText, caretPos });
     };
 
-    setNativeInputVal = val => {
+    onInputChange = e => {
+        this.updateNewText(e.target.value);
+    }
+
+    setNativeInputVal = (val, caretPos) => {
         const node = this.nativeInputRef.current;
         node.value = val;
+        node.setSelectionRange(caretPos, caretPos);
     }
 
     nativeKeyDown = e => {
@@ -45,14 +74,11 @@ export default class RichText extends Component {
 
     render() {
         return (
-            <div>
+            <div style={{marginLeft: 400}}>
                 <div>
                     <p>Using RichText react component wrapper:</p>
                     <RichTextEditor onEdit={this.updateNewText}>
-                        <InputField
-                            value={this.state.newText}
-                            onChange={this.updateNewText}
-                        />
+                        <InputField value={this.state.newText} caretPos={this.state.caretPos} onChange={this.onInputChange} />
                     </RichTextEditor>
                     <button type="button" onClick={this.setParagraphVal}>Parse</button>
                     <span>Result:</span>

--- a/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
+++ b/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
@@ -19,14 +19,14 @@ describe('convertCtrlKey', () => {
                 target: {
                     selectionStart: 0,
                     selectionEnd: 0,
-                    value: '',
+                    value: 'rainbow dash',
                 },
             };
-    
+
             convertCtrlKey(e, cb);
-    
+
             expect(cb).toHaveBeenCalled();
-            expect(cb).toHaveBeenCalledWith('**', 1);
+            expect(cb).toHaveBeenCalledWith('** rainbow dash', 1);
         });
 
         it('triggers callback with open/close markers and caret pos in between (end of text)', () => {
@@ -40,13 +40,13 @@ describe('convertCtrlKey', () => {
                     value: 'rainbow dash is purple',
                 },
             };
-    
+
             convertCtrlKey(e, cb);
-    
+
             expect(cb).toHaveBeenCalled();
             expect(cb).toHaveBeenCalledWith('rainbow dash is purple **', 24);
         });
-    
+
         it('triggers callback with open/close markers mid-text with surrounding spaces (1)', () => {
             const cb = jest.fn();
             const e = {
@@ -58,9 +58,9 @@ describe('convertCtrlKey', () => {
                     value: 'the quick brown fox',
                 },
             };
-    
+
             convertCtrlKey(e, cb);
-    
+
             expect(cb).toHaveBeenCalled();
             expect(cb).toHaveBeenCalledWith('the ** quick brown fox', 5);
         });
@@ -76,9 +76,9 @@ describe('convertCtrlKey', () => {
                     value: 'the quick brown fox',
                 },
             };
-    
+
             convertCtrlKey(e, cb);
-    
+
             expect(cb).toHaveBeenCalled();
             expect(cb).toHaveBeenCalledWith('the ** quick brown fox', 5);
         });
@@ -95,13 +95,13 @@ describe('convertCtrlKey', () => {
                         value: 'rainbow dash is purple',
                     },
                 };
-        
+
                 convertCtrlKey(e, cb);
-        
+
                 expect(cb).toHaveBeenCalled();
                 expect(cb).toHaveBeenCalledWith('rainb *ow da* sh is purple', 13);
             });
-    
+
             it('triggers callback with open/close markers around text when starting at beginning of line', () => {
                 const cb = jest.fn();
                 const e = {
@@ -113,13 +113,13 @@ describe('convertCtrlKey', () => {
                         value: 'rainbow dash is purple',
                     },
                 };
-        
+
                 convertCtrlKey(e, cb);
-        
+
                 expect(cb).toHaveBeenCalled();
                 expect(cb).toHaveBeenCalledWith('*rainbow* dash is purple', 9);
             });
-    
+
             it('triggers callback with open/close markers around text when ending at end of line', () => {
                 const cb = jest.fn();
                 const e = {
@@ -131,13 +131,13 @@ describe('convertCtrlKey', () => {
                         value: 'rainbow dash is purple',
                     },
                 };
-        
+
                 convertCtrlKey(e, cb);
-        
+
                 expect(cb).toHaveBeenCalled();
                 expect(cb).toHaveBeenCalledWith('rainbow dash is *purple*', 24);
             });
-    
+
             it('triggers callback with open/close markers around word', () => {
                 const cb = jest.fn();
                 const e = {
@@ -149,15 +149,33 @@ describe('convertCtrlKey', () => {
                         value: 'rainbow dash is purple',
                     },
                 };
-        
+
                 convertCtrlKey(e, cb);
-        
+
+                expect(cb).toHaveBeenCalled();
+                expect(cb).toHaveBeenCalledWith('rainbow *dash* is purple', 14);
+            });
+
+            it('triggers callback with leading/trailing spaces trimmed from selection', () => {
+                const cb = jest.fn();
+                const e = {
+                    key: 'b',
+                    metaKey: true,
+                    target: {
+                        selectionStart: 8, // " dash " is selected (note leading and trailing space)
+                        selectionEnd: 13,
+                        value: 'rainbow dash is purple',
+                    },
+                };
+
+                convertCtrlKey(e, cb);
+
                 expect(cb).toHaveBeenCalled();
                 expect(cb).toHaveBeenCalledWith('rainbow *dash* is purple', 14);
             });
         });
-    
-    
+
+
     });
 
     describe('when ctrl key + "i" pressed', () => {
@@ -172,9 +190,9 @@ describe('convertCtrlKey', () => {
                     value: '',
                 },
             };
-    
+
             convertCtrlKey(e, cb);
-    
+
             expect(cb).toHaveBeenCalled();
             expect(cb).toHaveBeenCalledWith('__', 1);
         });

--- a/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
+++ b/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
@@ -46,6 +46,25 @@ describe('convertCtrlKey', () => {
         expect(cb).toHaveBeenCalledWith('*abc*');
     });
 
+    it('triggers callback with marker not at end of value', () => {
+        const cb = jest.fn();
+        const e = {
+            key: 'b',
+            metaKey: true,
+            target: {
+                selectionStart: 4,
+                selectionEnd: 4,
+                value: 'the quick brown fox',
+            },
+        };
+
+        convertCtrlKey(e, cb);
+
+        expect(cb).toHaveBeenCalled();
+        expect(cb).toHaveBeenCalledWith('the *quick brown fox');
+    });
+
+
     it('triggers callback with opening and closing marker when text is selected', () => {
         const cb = jest.fn();
         const e = {

--- a/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
+++ b/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
@@ -10,76 +10,173 @@ describe('convertCtrlKey', () => {
         expect(cb).not.toHaveBeenCalled();
     });
 
-    it('triggers callback with opening marker if ctrl key + "b"', () => {
-        const cb = jest.fn();
-        const e = {
-            key: 'b',
-            ctrlKey: true,
-            target: {
-                selectionStart: 0,
-                selectionEnd: 0,
-                value: '',
-            },
-        };
+    describe('when ctrl key + "b" pressed', () => {
+        it('triggers callback with open/close markers and caret pos in between', () => {
+            const cb = jest.fn();
+            const e = {
+                key: 'b',
+                ctrlKey: true,
+                target: {
+                    selectionStart: 0,
+                    selectionEnd: 0,
+                    value: '',
+                },
+            };
+    
+            convertCtrlKey(e, cb);
+    
+            expect(cb).toHaveBeenCalled();
+            expect(cb).toHaveBeenCalledWith('**', 1);
+        });
 
-        convertCtrlKey(e, cb);
+        it('triggers callback with open/close markers and caret pos in between (end of text)', () => {
+            const cb = jest.fn();
+            const e = {
+                key: 'b',
+                ctrlKey: true,
+                target: {
+                    selectionStart: 22,
+                    selectionEnd: 22,
+                    value: 'rainbow dash is purple',
+                },
+            };
+    
+            convertCtrlKey(e, cb);
+    
+            expect(cb).toHaveBeenCalled();
+            expect(cb).toHaveBeenCalledWith('rainbow dash is purple **', 24);
+        });
+    
+        it('triggers callback with open/close markers mid-text with surrounding spaces (1)', () => {
+            const cb = jest.fn();
+            const e = {
+                key: 'b',
+                metaKey: true,
+                target: {
+                    selectionStart: 4, // caret located just before "quick"
+                    selectionEnd: 4,
+                    value: 'the quick brown fox',
+                },
+            };
+    
+            convertCtrlKey(e, cb);
+    
+            expect(cb).toHaveBeenCalled();
+            expect(cb).toHaveBeenCalledWith('the ** quick brown fox', 5);
+        });
 
-        expect(cb).toHaveBeenCalled();
-        expect(cb).toHaveBeenCalledWith('*');
+        it('triggers callback with open/close markers mid-text with surrounding spaces (2)', () => {
+            const cb = jest.fn();
+            const e = {
+                key: 'b',
+                metaKey: true,
+                target: {
+                    selectionStart: 3, // caret located just after "the"
+                    selectionEnd: 3,
+                    value: 'the quick brown fox',
+                },
+            };
+    
+            convertCtrlKey(e, cb);
+    
+            expect(cb).toHaveBeenCalled();
+            expect(cb).toHaveBeenCalledWith('the ** quick brown fox', 5);
+        });
+
+        describe('selected text', () => {
+            it('triggers callback with open/close markers around text and caret pos after closing marker', () => {
+                const cb = jest.fn();
+                const e = {
+                    key: 'b',
+                    metaKey: true,
+                    target: {
+                        selectionStart: 5, // "ow da" is selected
+                        selectionEnd: 10,
+                        value: 'rainbow dash is purple',
+                    },
+                };
+        
+                convertCtrlKey(e, cb);
+        
+                expect(cb).toHaveBeenCalled();
+                expect(cb).toHaveBeenCalledWith('rainb *ow da* sh is purple', 13);
+            });
+    
+            it('triggers callback with open/close markers around text when starting at beginning of line', () => {
+                const cb = jest.fn();
+                const e = {
+                    key: 'b',
+                    metaKey: true,
+                    target: {
+                        selectionStart: 0, // "rainbow" is selected
+                        selectionEnd: 7,
+                        value: 'rainbow dash is purple',
+                    },
+                };
+        
+                convertCtrlKey(e, cb);
+        
+                expect(cb).toHaveBeenCalled();
+                expect(cb).toHaveBeenCalledWith('*rainbow* dash is purple', 9);
+            });
+    
+            it('triggers callback with open/close markers around text when ending at end of line', () => {
+                const cb = jest.fn();
+                const e = {
+                    key: 'b',
+                    metaKey: true,
+                    target: {
+                        selectionStart: 16, // "purple" is selected
+                        selectionEnd: 22,
+                        value: 'rainbow dash is purple',
+                    },
+                };
+        
+                convertCtrlKey(e, cb);
+        
+                expect(cb).toHaveBeenCalled();
+                expect(cb).toHaveBeenCalledWith('rainbow dash is *purple*', 24);
+            });
+    
+            it('triggers callback with open/close markers around word', () => {
+                const cb = jest.fn();
+                const e = {
+                    key: 'b',
+                    metaKey: true,
+                    target: {
+                        selectionStart: 8, // "dash" is selected
+                        selectionEnd: 12,
+                        value: 'rainbow dash is purple',
+                    },
+                };
+        
+                convertCtrlKey(e, cb);
+        
+                expect(cb).toHaveBeenCalled();
+                expect(cb).toHaveBeenCalledWith('rainbow *dash* is purple', 14);
+            });
+        });
+    
+    
     });
 
-    it('triggers callback with closing marker if ctrl key + "b" + value', () => {
-        const cb = jest.fn();
-        const e = {
-            key: 'b',
-            metaKey: true,
-            target: {
-                selectionStart: 4,
-                selectionEnd: 4,
-                value: '*abc',
-            },
-        };
-
-        convertCtrlKey(e, cb);
-
-        expect(cb).toHaveBeenCalled();
-        expect(cb).toHaveBeenCalledWith('*abc*');
+    describe('when ctrl key + "i" pressed', () => {
+        it('triggers callback with open/close italics markers and caret pos in between', () => {
+            const cb = jest.fn();
+            const e = {
+                key: 'i',
+                ctrlKey: true,
+                target: {
+                    selectionStart: 0,
+                    selectionEnd: 0,
+                    value: '',
+                },
+            };
+    
+            convertCtrlKey(e, cb);
+    
+            expect(cb).toHaveBeenCalled();
+            expect(cb).toHaveBeenCalledWith('__', 1);
+        });
     });
-
-    it('triggers callback with marker not at end of value', () => {
-        const cb = jest.fn();
-        const e = {
-            key: 'b',
-            metaKey: true,
-            target: {
-                selectionStart: 4,
-                selectionEnd: 4,
-                value: 'the quick brown fox',
-            },
-        };
-
-        convertCtrlKey(e, cb);
-
-        expect(cb).toHaveBeenCalled();
-        expect(cb).toHaveBeenCalledWith('the *quick brown fox');
-    });
-
-
-    it('triggers callback with opening and closing marker when text is selected', () => {
-        const cb = jest.fn();
-        const e = {
-            key: 'b',
-            metaKey: true,
-            target: {
-                selectionStart: 8,
-                selectionEnd: 12,
-                value: 'rainbow dash is purple',
-            },
-        };
-
-        convertCtrlKey(e, cb);
-
-        expect(cb).toHaveBeenCalled();
-        expect(cb).toHaveBeenCalledWith('rainbow *dash* is purple');
-    })
 });

--- a/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
+++ b/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
@@ -83,6 +83,24 @@ describe('convertCtrlKey', () => {
             expect(cb).toHaveBeenCalledWith('the ** quick brown fox', 5);
         });
 
+        it('triggers callback with correct double markers and padding', () => {
+            const cb = jest.fn();
+            const e = {
+                key: 'b',
+                metaKey: true,
+                target: {
+                    selectionStart: 9, // between the underscores
+                    selectionEnd: 9,
+                    value: 'rainbow __',
+                },
+            };
+
+            convertCtrlKey(e, cb);
+
+            expect(cb).toHaveBeenCalled();
+            expect(cb).toHaveBeenCalledWith('rainbow _**_', 10);
+        })
+
         describe('selected text', () => {
             it('triggers callback with open/close markers around text and caret pos after closing marker', () => {
                 const cb = jest.fn();

--- a/packages/rich-text/src/editor/convertCtrlKey.js
+++ b/packages/rich-text/src/editor/convertCtrlKey.js
@@ -9,6 +9,13 @@ const markerMap = {
     bold: '*',
 };
 
+const trim = str => {
+    const leftSpaces = /^\s+/;
+    const rightSpaces = /\s+$/;
+
+    return str.replace(leftSpaces, '').replace(rightSpaces, '');
+}
+
 const toggleMode = (mode) => {
     const prop = `${mode}Mode`;
 
@@ -27,55 +34,37 @@ const insertMarkers = (mode, cb) => {
     let newValue;
     let caretPos = end + 1;
 
-    if (start === end) {
-        const markersWithPadding = () => {
-            let insertChars = `${marker}${marker}`;
-    
-            // add padding if needed
-            if (value.length && value[start - 1] !== ' ') {
-                insertChars = ` ${insertChars}`;
-                ++caretPos;
-            }
-    
-            if (value.length && end !== value.length && value[start] !== ' ') {
-                insertChars = `${insertChars} `
-            }
-    
-            return insertChars;
+    const padMarkers = text => {
+        if (value.length && start > 0 && value[start - 1] !== ' ') {
+            text = ` ${text}`;
+            ++caretPos;
         }
-    
+
+        if (value.length && end !== value.length && value[end] !== ' ') {
+            text = `${text} `
+        }
+
+        return text;
+    }
+
+    if (start === end) { //no text
         const valueArr = value.split('');
-        valueArr.splice(start, 0, markersWithPadding());
+
+        valueArr.splice(start, 0, padMarkers(`${marker}${marker}`));
         newValue = valueArr.join('');
     } else {
-        const valueWithMarkers = val => {
-            ++caretPos;
+        const text = value.slice(start, end);
+        const trimmedText = trim(text);
 
-            let leading;
-            let trailing;
-
-            if (start === 0 || value[start - 1] === ' ') {
-                leading = marker;
-            } else {
-                leading = ` ${marker}`;
-                ++caretPos;
-            }
-
-            if (end === value.length || value[end] === ' ') {
-                trailing = marker;
-            } else {
-                trailing = `${marker} `;
-            }
-
-            return `${leading}${val}${trailing}`;
-        }
+        // adjust caretPos based on trimmed text selection
+        caretPos = caretPos - (text.length - trimmedText.length) + 1;
 
         newValue = [
             value.slice(0, start),
-            valueWithMarkers(value.slice(start, end)),
+            padMarkers(`${marker}${trimmedText}${marker}`),
             value.slice(end),
         ].join('');
- 
+
         toggleMode(mode);
     }
 

--- a/packages/rich-text/src/editor/convertCtrlKey.js
+++ b/packages/rich-text/src/editor/convertCtrlKey.js
@@ -28,7 +28,9 @@ const insertMarkers = (mode, cb) => {
     let newValue;
 
     if (selectionStart >= 0 && selectionStart === selectionEnd) {
-        newValue = `${value}${marker}`;
+        const valueArr = value.split('');
+        valueArr.splice(selectionStart, 0, marker);
+        newValue = valueArr.join('');
     } else if (selectionStart >= 0) {
         newValue = [
             value.slice(0, selectionStart),

--- a/packages/rich-text/src/editor/convertCtrlKey.js
+++ b/packages/rich-text/src/editor/convertCtrlKey.js
@@ -35,6 +35,14 @@ const insertMarkers = (mode, cb) => {
     let caretPos = end + 1;
 
     const padMarkers = text => {
+        // is caret between two markers (i.e., "**" or "__")? Then do not add padding
+        if (start === end && value.length && start > 0) {
+            if ((value[start-1] === markerMap.bold && value[start] === markerMap.bold) ||
+                (value[start-1] === markerMap.italic && value[start] === markerMap.italic)) {
+                return text;
+            }
+        }
+
         if (value.length && start > 0 && value[start - 1] !== ' ') {
             text = ` ${text}`;
             ++caretPos;


### PR DESCRIPTION
Fixes [DHIS2-5819]

- when user select ctrl+b (or ctrl+i), then the double marker is added. The desired caret position is between the markers and is returned in the callback.
- when user selects text and then hits ctrl+b/i, then the text is wrapped in markers, and space added before/after the marker if there was none. The returned caret position is after the closing marker. Also, if leading/trailing spaces were part of the selection, they are trimmed.

See unit tests that describe expected behavior.

