### PR TITLE
Rich-text editor: prevent default handler causing actions in Firefox

### DIFF
--- a/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
+++ b/packages/rich-text/src/editor/__tests__/convertCtrlKey.spec.js
@@ -3,7 +3,7 @@ import convertCtrlKey from '../convertCtrlKey';
 describe('convertCtrlKey', () => {
     it('does not trigger callback if no ctrl key', () => {
         const cb = jest.fn();
-        const e = { key: 'j' };
+        const e = { key: 'j', preventDefault: () => {} };
 
         convertCtrlKey(e, cb);
 
@@ -20,6 +20,7 @@ describe('convertCtrlKey', () => {
                 selectionEnd: 0,
                 value: '',
             },
+            preventDefault: () => {}
         };
 
         convertCtrlKey(e, cb);
@@ -38,6 +39,7 @@ describe('convertCtrlKey', () => {
                 selectionEnd: 4,
                 value: '*abc',
             },
+            preventDefault: () => {}
         };
 
         convertCtrlKey(e, cb);
@@ -56,6 +58,7 @@ describe('convertCtrlKey', () => {
                 selectionEnd: 12,
                 value: 'rainbow dash is purple',
             },
+            preventDefault: () => {}
         };
 
         convertCtrlKey(e, cb);

--- a/packages/rich-text/src/editor/convertCtrlKey.js
+++ b/packages/rich-text/src/editor/convertCtrlKey.js
@@ -50,8 +50,10 @@ const convertCtrlKey = (event, cb) => {
     state.element = element;
 
     if (key === "b" && (ctrlKey || metaKey)) {
+        event.preventDefault();
         insertMarkers("bold", cb);
     } else if (key === "i" && (ctrlKey || metaKey)) {
+        event.preventDefault();
         insertMarkers("italic", cb);
     }
 }


### PR DESCRIPTION
Fixes [DHIS2-5773]

Call preventDefault() to stop the default action in firefox (ctrl+b opens bookmark panel, ctrl+i opens page info)

Note that the menu bar still briefly highlights the main menu item that would have been relevant.

