### PR TITLE
Fix arrow handling in user list for mentions

### DIFF
--- a/packages/mentions-wrapper/src/MentionsWrapper.js
+++ b/packages/mentions-wrapper/src/MentionsWrapper.js
@@ -27,6 +27,7 @@ class MentionsWrapper extends Component {
             .get('users.json', {
                 query,
                 fields: 'id,displayName,userCredentials[username]',
+                order: 'displayName:iasc',
             })
             .then(response => {
                 this.setState({
@@ -81,6 +82,7 @@ class MentionsWrapper extends Component {
                         }
 
                         break;
+                    default:
                 }
             }
         }

--- a/packages/mentions-wrapper/src/UserList.js
+++ b/packages/mentions-wrapper/src/UserList.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItem from '@material-ui/core/ListItem';
 import List from '@material-ui/core/List';
-import sortBy from 'lodash/sortBy';
 
 import Popover from '@material-ui/core/Popover';
 import Typography from '@material-ui/core/Typography';
@@ -48,7 +47,7 @@ export const UserList = ({
 
         onSelect(user);
     };
-    
+
     return (
         <Popover
             open={open}
@@ -70,7 +69,7 @@ export const UserList = ({
                         </em>
                     </Typography>
                     <List dense disablePadding className={classes.list}>
-                        {sortBy(users, [userName => userName.displayName.toLowerCase()]).map(u => (
+                        {users.map(u => (
                             <ListItem
                                 button
                                 key={u.id}

--- a/packages/mentions-wrapper/src/__tests__/UserList.spec.js
+++ b/packages/mentions-wrapper/src/__tests__/UserList.spec.js
@@ -4,8 +4,6 @@ import ListItemText from '@material-ui/core/ListItemText';
 import ListItem from '@material-ui/core/ListItem';
 import List from '@material-ui/core/List';
 import Popover from '@material-ui/core/Popover';
-import sortBy from 'lodash/sortBy';
-
 
 import { UserList } from '../UserList';
 
@@ -20,13 +18,13 @@ describe('Mentions: MentionsWrapper > UserList component', () => {
         onSelect = jest.fn();
         onClose = jest.fn();
 
-        users =  [
-            { id: 'jc', displayName: 'Johnny Cash', userCredentials: { username: 'sue' } },
+        users = [
             {
                 id: 'ec',
                 displayName: 'Eric Clapton',
                 userCredentials: { username: 'slowhand' },
             },
+            { id: 'jc', displayName: 'Johnny Cash', userCredentials: { username: 'sue' } },
             { id: 'jj', displayName: 'Justin Johnson', userCredentials: { username: 'slide' } },
         ];
 
@@ -59,16 +57,17 @@ describe('Mentions: MentionsWrapper > UserList component', () => {
         ).toEqual('Eric Clapton (slowhand)');
     });
 
-    it('should sort the mentions in alphabetical order by firstname', () => {
+    it('should show the user list sorted in alphabetical order by firstname', () => {
         const sortedList = [
-            { displayName: 'Eric Clapton' },
+            { displayName: 'Eric Clapton' },
             { displayName: 'Johnny Cash' },
-            { displayName: 'Justin Johnson' }
+            { displayName: 'Justin Johnson' },
         ];
 
-        userList.find(ListItemText).forEach((node, i) => 
-            expect(
-                node.props().primary).toContain(sortedList[i].displayName)
+        userList
+            .find(ListItemText)
+            .forEach((node, i) =>
+                expect(node.props().primary).toContain(sortedList[i].displayName)
             );
     });
 


### PR DESCRIPTION
Related to DHIS2-5906.

Changes proposed in this pull request:

The sorting of the user list cannot be done only when rendering the
component, the user list in the component's state must have the same
order, otherwise the arrow selection - which is using the state's user
list as index reference - is jumping around the list.
Opted for requesting an ordered list from the API instead, since the
render uses the same object stored in the state.
