### PR TITLE
Dhis2 5938 periodpicker support for biweekly and periodtype change

### DIFF
--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -19,7 +19,7 @@
     "@dhis2/d2-ui-sharing-dialog": "v0.0.0-PLACEHOLDER",
     "@dhis2/d2-ui-table": "v0.0.0-PLACEHOLDER",
     "@dhis2/d2-ui-translation-dialog": "v0.0.0-PLACEHOLDER",
-    "d2": "~31.1",
+    "d2": "^31.4",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-scripts": "1.1.1"

--- a/examples/create-react-app/src/components/period-picker.js
+++ b/examples/create-react-app/src/components/period-picker.js
@@ -69,6 +69,7 @@ export default class PeriodPickerExample extends React.Component {
                                     <option>WeeklyThursday</option>
                                     <option>WeeklySaturday</option>
                                     <option>WeeklySunday</option>
+                                    <option>BiWeekly</option>
                                     <option>Monthly</option>
                                     <option>BiMonthly</option>
                                     <option>Quarterly</option>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "d2": "~31.1",
+    "d2": "~31.4",
     "lodash": "^4.17.10",
     "material-ui": "^0.20.0"
   },

--- a/packages/core/src/period-picker/PeriodPicker.component.js
+++ b/packages/core/src/period-picker/PeriodPicker.component.js
@@ -55,6 +55,12 @@ class PeriodPicker extends React.Component {
         this.getTranslation = i18n.getTranslation.bind(i18n);
     }
 
+    componentDidUpdate(prevProps) {
+        if(this.props.periodType !== prevProps.periodType) {
+           this.handleChange();
+        }
+    }
+
     getPeriod() {
         const week = this.props.periodType === 'BiWeekly' && this.state.biWeek 
             ? biWeekToWeek(this.state.biWeek)

--- a/packages/core/src/period-picker/PeriodPicker.component.js
+++ b/packages/core/src/period-picker/PeriodPicker.component.js
@@ -144,7 +144,6 @@ class PeriodPicker extends React.Component {
                 floatingLabelText={this.getTranslation(name)}
                 floatingLabelStyle={isInvalid ? { color: 'red' } : {}}
             >
-                <MenuItem key="" value={this.state[name]} primaryText="&nbsp;" />
                 {Object.keys(options).sort().map((value) => (
                     <MenuItem
                         key={value}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3455,6 +3455,13 @@ d2-utilizr@^0.2.15:
     lodash.isset "^4.3.0"
     lodash.isstring "^4.0.1"
 
+d2@^31.4, d2@~31.4:
+  version "31.4.0"
+  resolved "https://registry.yarnpkg.com/d2/-/d2-31.4.0.tgz#761e297d0f6a5b4b1d6043de176d887ee5faa09b"
+  integrity sha512-8Bw4W4XVc6jDlZ/+g2TJW6iuxcLAi8ii8Iv0tRBe1M+WjH+x6UWfQuMKxXL/hZtOaa0TNiRouyp50pVBuXawIw==
+  dependencies:
+    whatwg-fetch "^2.0.3"
+
 d2@~31.1:
   version "31.1.1"
   resolved "https://registry.yarnpkg.com/d2/-/d2-31.1.1.tgz#8c551077c27031de8ad2d8df0b575242a3080917"


### PR DESCRIPTION
Fixes DHIS2-5938.

**Changes proposed in this pull request:**
1. Add support for BiWeekly periods
2. Call `handleChange` when `this.props.periodType` changes, because the `this.props.onPickPeriod` callback might need to be triggered (i.e. when changing from _Monthly_ to _Yearly_)
3. Remove empty `MenuItem` from the `SelectField`. I can't imagine any scenario in which this would be useful

**Note:**
This PR depends on BiWeekly support in the d2 period parser which has not been merged into master yet at the time of writing. See https://github.com/dhis2/d2/pull/189