### PR TITLE
add zIndex for interpretation button tooltips

### DIFF
--- a/packages/interpretations/src/components/Buttons/ActionButton.js
+++ b/packages/interpretations/src/components/Buttons/ActionButton.js
@@ -41,6 +41,7 @@ export class ActionButton extends Component {
 			anchorEl={document.getElementById(this.id)}
 			open={this.state.tooltipIsOpen}
 			placement="top"
+			style={styles.popper}
 		>
 			<Paper className={this.props.classes.tooltip}>
 				{this.props.tooltip || Icons[this.props.iconType].tooltip}

--- a/packages/interpretations/src/components/Buttons/styles/ActionButton.style.js
+++ b/packages/interpretations/src/components/Buttons/styles/ActionButton.style.js
@@ -18,4 +18,8 @@ export default {
         bottom: '2px',
     },
 
+    popper: {
+        zIndex: 1200
+    },
+
 };

--- a/packages/interpretations/src/components/Interpretation/Likes.js
+++ b/packages/interpretations/src/components/Interpretation/Likes.js
@@ -43,6 +43,7 @@ export class Likes extends Component {
             anchorEl={document.getElementById(this.id)}
             open={this.state.tooltipIsOpen}
             placement="top"
+            style={styles.popper}
         >
             <Paper className={this.props.classes.tooltip}>
                 <ul className={this.props.classes.tooltipList}>

--- a/packages/interpretations/src/components/Interpretation/Replies.js
+++ b/packages/interpretations/src/components/Interpretation/Replies.js
@@ -54,6 +54,7 @@ export class Replies extends Component {
             placement="top"
             open={this.state.tooltipIsOpen}
             anchorEl={document.getElementById(this.id)}
+            style={styles.popper}
         >
             <Paper className={this.props.classes.tooltip}>
                 <ul className={this.props.classes.tooltipList}>

--- a/packages/interpretations/src/components/Interpretation/styles/LikesAndReplies.style.js
+++ b/packages/interpretations/src/components/Interpretation/styles/LikesAndReplies.style.js
@@ -16,4 +16,8 @@ export default {
         position: 'relative',
         bottom: '2px',
     },
+
+    popper: {
+        zIndex: 1200
+    },
 };


### PR DESCRIPTION
Maps Interpretation panel uses zIndex 1190,
tooltips have assigned zIndex 1200 in order to be rendered on top of the panel.