### PR TITLE
DHIS2-5861 - Fix colorpicker display bug

### DIFF
--- a/src/legend/ColorPicker.component.js
+++ b/src/legend/ColorPicker.component.js
@@ -55,22 +55,40 @@ class ColorPicker extends Component {
                 left: 0,
             },
             picker: {
-                position: 'absolute',
-                top: -207,
-                left: 120,
+                position: 'fixed',
+                top: '50%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+                zIndex: 1000,
             },
         };
 
         return (
             <div style={styles.wrapper}>
-                <div style={styles.color} onClick={this.handleOpen}>{color}</div>
-
-                {this.state.open ? <div is="popover">
-                    <div style={styles.cover} onClick={this.handleClose} />
-                    <div style={styles.picker}>
-                        <ChromePicker color={this.state.color} onChange={this.handleChange} />
+                <div
+                    style={styles.color}
+                    role="button"
+                    onClick={this.handleOpen}
+                    tabIndex={0}
+                >
+                    {color}
+                </div>
+                {this.state.open &&
+                    <div>
+                        <div
+                            style={styles.cover}
+                            role="button"
+                            onClick={this.handleClose}
+                            tabIndex={0}
+                        />
+                        <div style={styles.picker}>
+                            <ChromePicker
+                                color={this.state.color}
+                                onChange={this.handleChange}
+                            />
+                        </div>
                     </div>
-                </div> : null}
+                }
             </div>
         );
     }


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-5861
Related: https://github.com/dhis2/maintenance-app/pull/633

For the reviewers, I don't like the arbitrary z-index. However, there's no central area where all the z-indexes are defined. Or I couldn't find it at least. Maybe that'd be a good thing to tackle in a separate issue eventually.

The aria roles and tabindexes are mainly to satisfy eslint. A proper, accessible way to design this interface would be to not use divs as buttons in my opinion. Because even though they're focusable and tabbable now, they don't respond to keypresses, so it's still not accessible or very semantic.

I also removed the `is="popover"` attribute from the wrapping div (introduced in [this commit](https://github.com/dhis2/d2-ui/commit/ae13030601334d96787c3f2dc4b16741e4d59a94)). As far as I know that's not a valid attribute, but correct me if I'm wrong.

Relies on the changes made in the maintenance app as well (see above link to PR)