### PR TITLE
Build commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "postinstall": "packages link",
-    "build": "packages build",
+    "build": "cross-env BABEL_ENV=commonjs packages build",
     "watch": "packages exec yarn watch",
     "lint": "packages exec yarn lint",
     "test": "jest"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,9 +9,7 @@
     "coverage": "jest --coverage",
     "lint": "eslint src/",
     "prebuild": "npm run lint && rimraf ./build/* && mkdirp ./build",
-    "build": "npm run build:sass && npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:sass && babel src --out-dir build --ignore spec.js",
     "build:sass": "node-sass ./scss --output ./build/css",
     "watch": "npm run build -- --watch",
     "test-ci": "jest --config=../../jest.config.js packages/core"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,8 +9,9 @@
     "coverage": "jest --coverage",
     "lint": "eslint src/",
     "prebuild": "npm run lint && rimraf ./build/* && mkdirp ./build",
-    "build": "npm run build:sass && npm run build:es",
+    "build": "npm run build:sass && npm run build:es && npm run build:cjs",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "build:sass": "node-sass ./scss --output ./build/css",
     "watch": "npm run build -- --watch",
     "test-ci": "jest --config=../../jest.config.js packages/core"

--- a/packages/expression-manager/package.json
+++ b/packages/expression-manager/package.json
@@ -9,9 +9,7 @@
     "coverage": "jest --coverage",
     "lint": "eslint src/",
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/expression-manager"
   },

--- a/packages/expression-manager/package.json
+++ b/packages/expression-manager/package.json
@@ -9,7 +9,9 @@
     "coverage": "jest --coverage",
     "lint": "eslint src/",
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/expression-manager"
   },

--- a/packages/favorites-dialog/package.json
+++ b/packages/favorites-dialog/package.json
@@ -15,7 +15,9 @@
   },
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/favorites-dialog"

--- a/packages/favorites-dialog/package.json
+++ b/packages/favorites-dialog/package.json
@@ -15,9 +15,7 @@
   },
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/favorites-dialog"

--- a/packages/file-menu/package.json
+++ b/packages/file-menu/package.json
@@ -12,7 +12,9 @@
   },
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run localize && cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run localize && npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build -- --watch",
     "test-ci": "jest --config=../../jest.config.js packages/file-menu",

--- a/packages/file-menu/package.json
+++ b/packages/file-menu/package.json
@@ -12,9 +12,7 @@
   },
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run localize && npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "npm run localize && babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build -- --watch",
     "test-ci": "jest --config=../../jest.config.js packages/file-menu",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -9,7 +9,9 @@
     "coverage": "jest --coverage",
     "lint": "eslint src/",
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/forms"
   },

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -9,9 +9,7 @@
     "coverage": "jest --coverage",
     "lint": "eslint src/",
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/forms"
   },

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -18,7 +18,9 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/formula-editor"

--- a/packages/formula-editor/package.json
+++ b/packages/formula-editor/package.json
@@ -18,9 +18,7 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/formula-editor"

--- a/packages/group-editor/package.json
+++ b/packages/group-editor/package.json
@@ -18,7 +18,9 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/group-editor"

--- a/packages/group-editor/package.json
+++ b/packages/group-editor/package.json
@@ -18,9 +18,7 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/group-editor"

--- a/packages/header-bar/package.json
+++ b/packages/header-bar/package.json
@@ -25,7 +25,9 @@
   },
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/header-bar"

--- a/packages/header-bar/package.json
+++ b/packages/header-bar/package.json
@@ -25,9 +25,7 @@
   },
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/header-bar"

--- a/packages/icon-picker/package.json
+++ b/packages/icon-picker/package.json
@@ -18,9 +18,7 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/icon-picker"

--- a/packages/icon-picker/package.json
+++ b/packages/icon-picker/package.json
@@ -18,7 +18,9 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/icon-picker"

--- a/packages/interpretations/i18n/en.pot
+++ b/packages/interpretations/i18n/en.pot
@@ -5,16 +5,25 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-01-25T17:15:09.737Z\n"
-"PO-Revision-Date: 2019-01-25T17:15:09.737Z\n"
+"POT-Creation-Date: 2019-02-27T09:42:27.795Z\n"
+"PO-Revision-Date: 2019-02-27T09:42:27.795Z\n"
 
 msgid "Pivot Tables"
+msgstr ""
+
+msgid "Table details"
 msgstr ""
 
 msgid "Visualizer"
 msgstr ""
 
+msgid "Chart details"
+msgstr ""
+
 msgid "Maps"
+msgstr ""
+
+msgid "Map details"
 msgstr ""
 
 msgid "Event Reports"
@@ -71,16 +80,22 @@ msgstr ""
 msgid "Confirm"
 msgstr ""
 
-msgid "No description"
+msgid "_No description_"
+msgstr ""
+
+msgid "Show "
+msgstr ""
+
+msgid "less"
+msgstr ""
+
+msgid "more"
 msgstr ""
 
 msgid "Unsubscribe from this {{object}} and stop receiving notifications"
 msgstr ""
 
 msgid "Subscribe to this {{object}} and start receiving notifications"
-msgstr ""
-
-msgid "Favorite details"
 msgstr ""
 
 msgid "Owner"
@@ -102,6 +117,9 @@ msgid "Delete interpretation"
 msgstr ""
 
 msgid "Are you sure you want to delete this interpretation?"
+msgstr ""
+
+msgid "Access restricted"
 msgstr ""
 
 msgid "likes"
@@ -128,22 +146,22 @@ msgstr ""
 msgid "View more replies"
 msgstr ""
 
-msgid "No interpretations"
-msgstr ""
-
 msgid "Hide"
 msgstr ""
 
 msgid "Show"
 msgstr ""
 
+msgid "No interpretations"
+msgstr ""
+
 msgid "external access"
 msgstr ""
 
-msgid " and public access. "
+msgid ", public access"
 msgstr ""
 
-msgid "public access. "
+msgid "public access"
 msgstr ""
 
 msgid "None. "
@@ -162,6 +180,9 @@ msgid "Unknown"
 msgstr ""
 
 msgid "Public"
+msgstr ""
+
+msgid "Users"
 msgstr ""
 
 msgid "user groups"

--- a/packages/interpretations/package.json
+++ b/packages/interpretations/package.json
@@ -13,9 +13,7 @@
   "contributors": [],
   "scripts": {
     "prebuild": "npm run lint && rm -rf ./build",
-    "build": "yarn localize && npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "npm run localize && babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build -- --watch",
     "extract-pot": "d2-i18n-extract -p src/ -o i18n/",

--- a/packages/interpretations/package.json
+++ b/packages/interpretations/package.json
@@ -13,7 +13,9 @@
   "contributors": [],
   "scripts": {
     "prebuild": "npm run lint && rm -rf ./build",
-    "build": "yarn localize && cross-env BABEL_ENV=es babel src --copy-files --out-dir build --ignore spec.js",
+    "build": "yarn localize && npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build -- --watch",
     "extract-pot": "d2-i18n-extract -p src/ -o i18n/",

--- a/packages/legend/package.json
+++ b/packages/legend/package.json
@@ -18,9 +18,7 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/legend"

--- a/packages/legend/package.json
+++ b/packages/legend/package.json
@@ -18,7 +18,9 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/legend"

--- a/packages/mentions-wrapper/package.json
+++ b/packages/mentions-wrapper/package.json
@@ -12,7 +12,9 @@
   },
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "yarn localize && cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "yarn localize && npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "yarn build -- --watch",
     "test-ci": "jest --config=../../jest.config.js packages/mentions-wrapper",

--- a/packages/mentions-wrapper/package.json
+++ b/packages/mentions-wrapper/package.json
@@ -12,9 +12,7 @@
   },
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "yarn localize && npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "npm run localize && babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "yarn build -- --watch",
     "test-ci": "jest --config=../../jest.config.js packages/mentions-wrapper",

--- a/packages/org-unit-dialog/package.json
+++ b/packages/org-unit-dialog/package.json
@@ -12,9 +12,7 @@
   "author": "Ilya Nee <ilya@dhis2.org>",
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run localize && npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "npm run localize && babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/org-unit-dialog",

--- a/packages/org-unit-dialog/package.json
+++ b/packages/org-unit-dialog/package.json
@@ -12,7 +12,9 @@
   "author": "Ilya Nee <ilya@dhis2.org>",
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run localize && cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run localize && npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/org-unit-dialog",

--- a/packages/org-unit-select/package.json
+++ b/packages/org-unit-select/package.json
@@ -18,9 +18,7 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/org-unit-select"

--- a/packages/org-unit-select/package.json
+++ b/packages/org-unit-select/package.json
@@ -18,7 +18,9 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/org-unit-select"

--- a/packages/org-unit-tree/package.json
+++ b/packages/org-unit-tree/package.json
@@ -19,9 +19,7 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/org-unit-tree"

--- a/packages/org-unit-tree/package.json
+++ b/packages/org-unit-tree/package.json
@@ -19,7 +19,9 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/org-unit-tree"

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -14,9 +14,7 @@
   },
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/* && mkdirp ./build",
-    "build": "npm run build:css && npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:css && babel src --out-dir build --ignore spec.js",
     "build:css": "cp -R ./css/* ./build/",
     "lint": "eslint src/",
     "watch": "npm run build -- --watch",

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -14,7 +14,9 @@
   },
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/* && mkdirp ./build",
-    "build": "npm run build:css && cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:css && npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "build:css": "cp -R ./css/* ./build/",
     "lint": "eslint src/",
     "watch": "npm run build -- --watch",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -10,9 +10,7 @@
     "test-ci": "jest --config=../../jest.config.js packages/rich-text",
     "lint": "eslint src/",
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "watch": "yarn build --  --watch"
   },
   "repository": {

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -10,7 +10,9 @@
     "test-ci": "jest --config=../../jest.config.js packages/rich-text",
     "lint": "eslint src/",
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "watch": "yarn build --  --watch"
   },
   "repository": {

--- a/packages/sharing-dialog/package.json
+++ b/packages/sharing-dialog/package.json
@@ -18,7 +18,9 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/sharing-dialog"

--- a/packages/sharing-dialog/package.json
+++ b/packages/sharing-dialog/package.json
@@ -18,9 +18,7 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/sharing-dialog"

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -18,7 +18,9 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/table"

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -18,9 +18,7 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/table"

--- a/packages/translation-dialog/package.json
+++ b/packages/translation-dialog/package.json
@@ -18,9 +18,7 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "npm run build:es && npm run build:cjs",
-    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
+    "build": "babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/translation-dialog"

--- a/packages/translation-dialog/package.json
+++ b/packages/translation-dialog/package.json
@@ -18,7 +18,9 @@
   ],
   "scripts": {
     "prebuild": "npm run lint && rimraf ./build/*",
-    "build": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build": "npm run build:es && npm run build:cjs",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir build --ignore spec.js",
+    "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir build --ignore spec.js",
     "lint": "eslint src/",
     "watch": "npm run build --  --watch",
     "test-ci": "jest --config=../../jest.config.js packages/translation-dialog"


### PR DESCRIPTION
Fixes Jest runtime issues.

Changes proposed in this pull request:

- Let the root `package.json` build specify the the `BABEL_ENV`, which determines if a `commonjs` or `es` build is being produced
- The packages themselves don't specify a `BABEL_ENV` in their build step, but "inherit" this from the root