### PR TITLE
patch: add overflow hidden to avatarBoxContent div

### DIFF
--- a/packages/interpretations/src/components/Avatar/styles/Avatar.style.js
+++ b/packages/interpretations/src/components/Avatar/styles/Avatar.style.js
@@ -19,5 +19,6 @@ export default {
 
     avatarBoxContent: {
         flex: '1',
+        overflow: 'hidden',
     },
 };


### PR DESCRIPTION
add overflow:hidden to interpretations inner div, to keep content inside the grey div in maps app.