### PR TITLE
fix: rich-text parser, validate children before render

### DIFF
--- a/packages/rich-text/src/parser/Parser.js
+++ b/packages/rich-text/src/parser/Parser.js
@@ -12,14 +12,14 @@ class Parser extends Component {
     render() {
         const { children, style } = this.props;
 
-        return (
+        return children ? (
             <p
                 style={style}
                 dangerouslySetInnerHTML={{
                     __html: this.MdParser.render(children),
                 }}
             />
-        );
+        ) : null;
     }
 }
 

--- a/packages/rich-text/src/parser/__tests__/Parser.spec.js
+++ b/packages/rich-text/src/parser/__tests__/Parser.spec.js
@@ -37,4 +37,10 @@ describe('RichText: Parser component', () => {
 
         expect(richTextParser.html()).toEqual('<p>converted text</p>');
     });
+
+    it('should return null if no children is passed', () => {
+        richTextParser = renderComponent({}, undefined);
+        expect(richTextParser.html()).toBe(null)
+
+    });
 });


### PR DESCRIPTION
This PR includes validating that the passed children is not undefined/null before invoking the render method.
Passing undefined / null to the parser causes the app to crash.