### PR TITLE
fix: interpretation input field, caretPos for rich-text hotkeys

### DIFF
--- a/packages/interpretations/src/components/Comment/NewCommentField.js
+++ b/packages/interpretations/src/components/Comment/NewCommentField.js
@@ -38,9 +38,10 @@ export class NewCommentField extends React.Component {
         this.setState({ text: newValue });
     };
 
-    setNativeInputVal = val => {
+    setNativeInputVal = (val, caretPos) => {
         const node = this.textarea.current;
         node.value = val;
+        node.setSelectionRange(caretPos, caretPos)
     };
 
     onKeyDown = event => {

--- a/packages/interpretations/src/components/Interpretation/NewInterpretationField.js
+++ b/packages/interpretations/src/components/Interpretation/NewInterpretationField.js
@@ -54,9 +54,10 @@ export class NewInterpretationField extends Component {
         this.setState({ text: newValue });
     };
 
-    setNativeInputVal = val => {
+    setNativeInputVal = (val, caretPos) => {
         const node = this.textarea.current;
         node.value = val;
+        node.setSelectionRange(caretPos, caretPos)
     };
 
     onKeyDown = event => {


### PR DESCRIPTION
This PR includes passing the caret pos and setting the node's selection range after pressing the hotkey `Ctrl + b` or `Ctrl + i`.
With this fix the caret pos will be placed in between the rich text symbols.