### PR TITLE
Include org unit code when loading org unit children

### DIFF
--- a/packages/org-unit-tree/src/utils.js
+++ b/packages/org-unit-tree/src/utils.js
@@ -66,6 +66,7 @@ export const loadChildren = (root, displayNameProperty, forceReloadChildren) => 
     const fields = [
         'id',
         `${displayNameProperty}~rename(displayName)`,
+        'code',
         'children::isNotEmpty',
         'path',
         'parent',


### PR DESCRIPTION
In the new capture app, we are using the org unit tree from d2-ui. When expanding an org unit in the tree, and selecting a child, the child's org unit code is not included. We need this code to process program rules. 

Changes proposed in this pull request:

- Include org unit code when loading org unit children

