### PR TITLE
DHIS2-6207 - fix legend cancel bug

### DIFF
--- a/src/legend/Legend.component.js
+++ b/src/legend/Legend.component.js
@@ -78,18 +78,21 @@ class Legend extends Component {
     };
 
     updateItem = (existingItems) => {
-        let updatedItems = [];
-
+        let updatedItems = existingItems;
         const currentItem = legendItemStore.getState() && legendItemStore.getState().model;
-        const isNewItem = existingItems.every(item => item.id !== currentItem.id);
 
-        if (isNewItem) {
-            updatedItems = [...existingItems, currentItem];
-        } else {
-            updatedItems = existingItems.map((item) => {
-                const shouldBeUpdated = item.id === currentItem.id;
-                return shouldBeUpdated ? currentItem : item;
-            });
+        // Only update if we got a valid model from getState
+        if (currentItem) {
+            updatedItems = [...existingItems];
+            const idx = updatedItems.findIndex(item => item.id === currentItem.id);
+
+            if (idx === -1) {
+                // Add item if it's a new item
+                updatedItems.push(currentItem);
+            } else {
+                // Replace old item with changed item
+                updatedItems[idx] = currentItem;
+            }
         }
 
         return this.props.onItemsChange(updatedItems);

--- a/src/legend/Legend.component.js
+++ b/src/legend/Legend.component.js
@@ -77,14 +77,22 @@ class Legend extends Component {
         this.props.onItemsChange(newItems);
     };
 
-    updateItem = (newItems) => {
-        const modelToUpdate = legendItemStore.getState() && legendItemStore.getState().model;
-        const isNewLegendItem = newItems.every(model => model !== modelToUpdate);
+    updateItem = (existingItems) => {
+        let updatedItems = [];
 
-        return this.props.onItemsChange([].concat(
-            newItems,
-            isNewLegendItem ? modelToUpdate : [],
-        ));
+        const currentItem = legendItemStore.getState() && legendItemStore.getState().model;
+        const isNewItem = existingItems.every(item => item.id !== currentItem.id);
+
+        if (isNewItem) {
+            updatedItems = [...existingItems, currentItem];
+        } else {
+            updatedItems = existingItems.map((item) => {
+                const shouldBeUpdated = item.id === currentItem.id;
+                return shouldBeUpdated ? currentItem : item;
+            });
+        }
+
+        return this.props.onItemsChange(updatedItems);
     };
 
     // Check if end value is bigger than start value

--- a/src/legend/LegendItem.store.js
+++ b/src/legend/LegendItem.store.js
@@ -72,10 +72,10 @@ const formFieldsConfigs = [{
     }), ColorPicker),
 }];
 
-
 // Called when a field is changed
 export function onFieldChange(fieldName, value) {
-    const model = legendItemStore.getState().model;
+    // Shallow clone model, so the assignment below doesn't mutate the original
+    const model = { ...legendItemStore.getState().model };
 
     model[fieldName] = value;
 


### PR DESCRIPTION
fixes 6207 (https://jira.dhis2.org/browse/DHIS2-6207)

See the issue for more detail. Basically the assignment [here](https://github.com/dhis2/d2-ui/pull/401/files#diff-d8934815beb930fd28b94669c1debc61R80) was mutating state (not react state, but a custom store implementation). This didn't trigger a rerender, but would be visible when it rerendered for different reasons (like clicking the ellipsis to trigger the popup).

To fix this I shallow cloned the model so the assignment doesn't mutate the original. This however, caused a new bug because of the `Legend.component` `updateItem` method. This method compares the object references, so a clone is seen as a new item.

To fix that I changed `updateItem` to compare on the `id` prop, and not references. I'm being very conservative in my approach here, and not mutating the input array as I'm not sure if the input (which comes from [here](https://github.com/dhis2/maintenance-app/blob/master/src/config/field-overrides/legendSet.js#L25)) is safe to mutate. I also modified the naming slightly, as the way I read it the naming was off (`newItems` is actually `existingItems`).

### Test

Tested this by building d2-ui and copying `./lib` to the maintenance-app's `node_modules/d2-ui`, not ideal, but symlinking messed things up. On macos with the latest chrome and firefox the bug is resolved.