### PR TITLE
Fix legend item sorting v29

### DIFF
--- a/src/legend/LegendItems.component.js
+++ b/src/legend/LegendItems.component.js
@@ -45,7 +45,7 @@ class LegendItems extends Component {
             },
         };
 
-        const orderedItems = props.items.sort((left, right) => Number(left.startValue) > Number(right.startValue));
+        const orderedItems = props.items.sort((left, right) => Number(left.startValue) - Number(right.startValue));
 
         return (
             <div style={styles.component}>


### PR DESCRIPTION
Fixes https://jira.dhis2.org/browse/DHIS2-6354 and addresses a point in https://jira.dhis2.org/browse/DHIS2-6365