### PR TITLE
Feat/period picker enhancements

### DIFF
--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -19,7 +19,7 @@
     "@dhis2/d2-ui-sharing-dialog": "v0.0.0-PLACEHOLDER",
     "@dhis2/d2-ui-table": "v0.0.0-PLACEHOLDER",
     "@dhis2/d2-ui-translation-dialog": "v0.0.0-PLACEHOLDER",
-    "d2": "^31.4",
+    "d2": "^31.7",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-scripts": "1.1.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "d2": "~31.4",
+    "d2": "~31.7",
     "lodash": "^4.17.10",
     "material-ui": "^0.20.0"
   },

--- a/packages/core/src/period-picker/PeriodPicker.component.js
+++ b/packages/core/src/period-picker/PeriodPicker.component.js
@@ -264,6 +264,13 @@ class PeriodPicker extends React.Component {
                     {this.renderOptionPicker('sixMonth', { 1: 'apr-sep', 2: 'oct-mar' })}
                 </div>
             );
+        case 'SixMonthlyNov':
+            return (
+                <div style={styles.line}>
+                    {this.renderYearPicker()}
+                    {this.renderOptionPicker('sixMonth', { 1: 'nov-apr', 2: 'may-oct' })}
+                </div>
+            );
         case 'Yearly':
         case 'FinancialApril':
         case 'FinancialJuly':
@@ -288,6 +295,7 @@ PeriodPicker.propTypes = {
         'Quarterly',
         'SixMonthly',
         'SixMonthlyApril',
+        'SixMonthlyNov',
         'Yearly',
         'FinancialApril',
         'FinancialJuly',

--- a/packages/core/src/period-picker/PeriodPicker.component.js
+++ b/packages/core/src/period-picker/PeriodPicker.component.js
@@ -18,7 +18,7 @@ const styles = {
     line: { marginTop: 0 },
 };
 
-const getYear = date => (new Date(date)).getFullYear();
+const getYear = date => (new Date(date)).getFullYear().toString();
 const getTwoDigitMonth = (date) => {
     const month = (new Date(date)).getMonth() + 1; // Month is 0 indexed
 

--- a/packages/core/src/period-picker/PeriodPicker.component.js
+++ b/packages/core/src/period-picker/PeriodPicker.component.js
@@ -110,6 +110,8 @@ class PeriodPicker extends React.Component {
             return this.state.year && this.state.sixMonth && `${this.state.year}S${this.state.sixMonth}`;
         case 'SixMonthlyApril':
             return this.state.year && this.state.sixMonth && `${this.state.year}AprilS${this.state.sixMonth}`;
+        case 'SixMonthlyNov':
+            return this.state.year && this.state.sixMonth && `${this.state.year}NovS${this.state.sixMonth}`;
         case 'Yearly':
             return this.state.year;
         case 'FinancialApril':

--- a/yarn.lock
+++ b/yarn.lock
@@ -3455,12 +3455,12 @@ d2-utilizr@^0.2.15:
     lodash.isset "^4.3.0"
     lodash.isstring "^4.0.1"
 
-d2@^31.4, d2@~31.4:
-  version "31.4.0"
-  resolved "https://registry.yarnpkg.com/d2/-/d2-31.4.0.tgz#761e297d0f6a5b4b1d6043de176d887ee5faa09b"
-  integrity sha512-8Bw4W4XVc6jDlZ/+g2TJW6iuxcLAi8ii8Iv0tRBe1M+WjH+x6UWfQuMKxXL/hZtOaa0TNiRouyp50pVBuXawIw==
+d2@^31.7:
+  version "31.7.0"
+  resolved "https://registry.yarnpkg.com/d2/-/d2-31.7.0.tgz#3a843240fecaafdf213da78b55aed9b8611ee22e"
+  integrity sha512-+ubKyPWKxUz90g5RHCYIt4KxKPzcCOBvDS7X0076XSycecfx4qvtkGBcKyFmXdz27iwTLUpNtruL9pUK9aTi/A==
   dependencies:
-    whatwg-fetch "^2.0.3"
+    isomorphic-fetch "^2.2.1"
 
 d2@~31.1:
   version "31.1.1"
@@ -3470,6 +3470,13 @@ d2@~31.1:
     babel-jest "^22.4.3"
     docdash "^0.4.0"
     jsdoc "^3.5.5"
+    whatwg-fetch "^2.0.3"
+
+d2@~31.4:
+  version "31.4.0"
+  resolved "https://registry.yarnpkg.com/d2/-/d2-31.4.0.tgz#761e297d0f6a5b4b1d6043de176d887ee5faa09b"
+  integrity sha512-8Bw4W4XVc6jDlZ/+g2TJW6iuxcLAi8ii8Iv0tRBe1M+WjH+x6UWfQuMKxXL/hZtOaa0TNiRouyp50pVBuXawIw==
+  dependencies:
     whatwg-fetch "^2.0.3"
 
 d3-array@^1.2.0:
@@ -6559,7 +6566,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=

--- a/yarn.lock
+++ b/yarn.lock
@@ -3455,7 +3455,7 @@ d2-utilizr@^0.2.15:
     lodash.isset "^4.3.0"
     lodash.isstring "^4.0.1"
 
-d2@^31.7:
+d2@^31.7, d2@~31.7:
   version "31.7.0"
   resolved "https://registry.yarnpkg.com/d2/-/d2-31.7.0.tgz#3a843240fecaafdf213da78b55aed9b8611ee22e"
   integrity sha512-+ubKyPWKxUz90g5RHCYIt4KxKPzcCOBvDS7X0076XSycecfx4qvtkGBcKyFmXdz27iwTLUpNtruL9pUK9aTi/A==
@@ -3470,13 +3470,6 @@ d2@~31.1:
     babel-jest "^22.4.3"
     docdash "^0.4.0"
     jsdoc "^3.5.5"
-    whatwg-fetch "^2.0.3"
-
-d2@~31.4:
-  version "31.4.0"
-  resolved "https://registry.yarnpkg.com/d2/-/d2-31.4.0.tgz#761e297d0f6a5b4b1d6043de176d887ee5faa09b"
-  integrity sha512-8Bw4W4XVc6jDlZ/+g2TJW6iuxcLAi8ii8Iv0tRBe1M+WjH+x6UWfQuMKxXL/hZtOaa0TNiRouyp50pVBuXawIw==
-  dependencies:
     whatwg-fetch "^2.0.3"
 
 d3-array@^1.2.0:


### PR DESCRIPTION
Adds support for new period type: `SixMonthlyNov`, and fixes bug when switching from "Daily" to "Yearly"

Changes proposed in this pull request:
- `getYear` returns a string so it value being passed to the d2 period-parser always has the `.match` method
- Add SixMonthlyNov to prop types
- Add SixMonthlyNov to `getPeriod`
- Render picker for SixMonthlyNov