### PR TITLE
fix: cancel create legends

### DIFF
--- a/src/legend/Legend.component.js
+++ b/src/legend/Legend.component.js
@@ -130,7 +130,11 @@ class Legend extends Component {
         this.setState({ warningDialogOpen: true });
     };
 
-    handleClose = () => {
+    handleCreateLegendsCancel = () => {
+        this.setState({ warningDialogOpen: false });
+    };
+
+    handleCreateLegendsConfirm = () => {
         this.setState(
             { warningDialogOpen: false },
             () => this.createLegendItems(), // Callback for after state update
@@ -142,12 +146,12 @@ class Legend extends Component {
             <FlatButton
                 label={this.i18n.getTranslation('cancel')}
                 secondary
-                onClick={this.handleClose}
+                onClick={this.handleCreateLegendsCancel}
             />,
             <FlatButton
                 label={this.i18n.getTranslation('proceed')}
                 primary
-                onClick={this.handleClose}
+                onClick={this.handleCreateLegendsConfirm}
             />,
         ];
 
@@ -216,7 +220,7 @@ class Legend extends Component {
                     actions={actions}
                     modal={false}
                     open={this.state.warningDialogOpen}
-                    onRequestClose={this.handleClose}
+                    onRequestClose={this.handleCreateLegendsCancel}
                     autoScrollBodyContent
                 >
                     {this.i18n.getTranslation('this_will_replace_the_current_legend_items')}


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-6353

The cancel button didn't cancel. Which makes sense, because it was exactly the same logic as the proceed button.