### PR TITLE
fix: remove apply button sharingdialog [DHIS2-6250]

### DIFF
--- a/packages/sharing-dialog/src/Sharing.component.js
+++ b/packages/sharing-dialog/src/Sharing.component.js
@@ -114,7 +114,7 @@ class Sharing extends React.Component {
                 <Heading text={displayName} level={2} />
                 <CreatedBy author={user} />
                 <div style={styles.titleBodySpace} />
-                <Typography variant="subheading">{this.context.d2.i18n.getTranslation('who_has_access')}</Typography>
+                <Typography variant="subtitle1">{this.context.d2.i18n.getTranslation('who_has_access')}</Typography>
                 <Divider />
                 <div style={styles.rules} ref={this.setAccessListRef}>
                     <PublicAccess

--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -169,11 +169,9 @@ class SharingDialog extends React.Component {
     addId = object => ({ ...object, id: this.props.id });
 
     closeDialog = () => {
-        this.props.onRequestClose(this.addId(this.state.sharedObject.object, this.props.id));
-    }
-
-    confirmAndCloseDialog = () => {
-        this.props.onConfirm(this.addId(this.state.sharedObject.object, this.props.id));
+        this.props.doNotPost
+            ? this.props.onConfirm(this.addId(this.state.sharedObject.object, this.props.id))
+            : this.props.onRequestClose(this.addId(this.state.sharedObject.object, this.props.id));
     }
 
     translate = s => this.props.d2.i18n.getTranslation(s);
@@ -197,23 +195,6 @@ class SharingDialog extends React.Component {
         const dataShareable = this.state.dataShareableTypes.indexOf(this.props.type) !== -1;
         const errorOccurred = this.state.errorMessage !== '';
         const isLoading = !this.state.sharedObject && this.props.open && !errorOccurred;
-        const sharingDialogActions = [
-            <Button key="closeonly" color="primary" onClick={this.closeDialog}>{this.translate('close')}</Button>,
-        ];
-
-        if (this.props.doNotPost) {
-            sharingDialogActions.push(
-                <Button
-                    key="confirmandclose"
-                    variant="contained"
-                    color="primary"
-                    style={{ marginLeft: '8px' }}
-                    onClick={this.confirmAndCloseDialog}
-                >
-                    {this.translate('apply')}
-                </Button>,
-            );
-        }
 
         return (
             <div>
@@ -240,7 +221,7 @@ class SharingDialog extends React.Component {
                         }
                     </DialogContent>
                     <DialogActions>
-                        {sharingDialogActions}
+                        <Button key="closeonly" color="primary" onClick={this.closeDialog}>{this.translate('close')}</Button>,
                     </DialogActions>
                 </Dialog>
             </div>

--- a/packages/sharing-dialog/src/__tests__/SharingDialog.component.spec.js
+++ b/packages/sharing-dialog/src/__tests__/SharingDialog.component.spec.js
@@ -110,10 +110,25 @@ describe('Sharing: SharingDialog component', () => {
             sharingDialogComponent.instance().closeDialog();
             expect(onRequestClose).toHaveBeenCalledTimes(1);
         });
+    });
 
-        it('triggers onConfirm from the props when the confirmAndCloseDialog is called', () => {
-            sharingDialogComponent.instance().confirmAndCloseDialog();
+    describe('when prop doNotPost is true', () => {
+        beforeEach(() => {
+            onRequestClose = jest.fn();
+            onConfirm = jest.fn();
+            sharingDialogComponent = renderComponent({
+                ...sharingDialogProps,
+                d2: context.d2,
+                onRequestClose,
+                onConfirm,
+                doNotPost: true,
+            });
+        });
+
+        it('triggers onConfirm from the props when the closeDialog is called', () => {
+            sharingDialogComponent.instance().closeDialog();
             expect(onConfirm).toHaveBeenCalledTimes(1);
+            expect(onRequestClose).toHaveBeenCalledTimes(0);
         });
     });
 


### PR DESCRIPTION
This PR Includes removal of the apply button in `<SharingDialog>` when prop doNotPost is true.
Fix for [DHIS-6250](https://jira.dhis2.org/browse/DHIS2-6250)

Instead of calling prop `onConfirm` through the apply button, it is invoked through `closeDialog()` fn (added conditional check).

Additionally, the prop for typography have been updated to remove the warning.

Test cases have been adjusted.