### PR TITLE
fix: set menu prop disableAutoFocusItem to true by default

### DIFF
--- a/packages/core/src/theme/mui3.theme.js
+++ b/packages/core/src/theme/mui3.theme.js
@@ -88,6 +88,11 @@ export const theme = {
     spacing: {
         unit: spacingUnit,
     },
+    props: {
+        MuiMenu: {
+            disableAutoFocusItem: true,
+        },
+    },
     overrides: {
         MuiDivider: {
             light: {
@@ -164,9 +169,6 @@ export const theme = {
                     borderBottom: `1px solid ${colors.greyLight}`,
                 },
             },
-        },
-        MuiMenu: {
-            disableAutoFocusItem: true,
         },
         MuiMenuItem: {
             root: {

--- a/packages/core/src/theme/mui3.theme.js
+++ b/packages/core/src/theme/mui3.theme.js
@@ -165,6 +165,9 @@ export const theme = {
                 },
             },
         },
+        MuiMenu: {
+            disableAutoFocusItem: true,
+        },
         MuiMenuItem: {
             root: {
                 paddingTop: spacingUnit,


### PR DESCRIPTION
Fixes https://jira.dhis2.org/browse/DHIS2-6616 and https://jira.dhis2.org/browse/DHIS2-6654

Changes proposed in this pull request:

- Set Menu prop "disableAutoFocusItem" to true by default, ref https://material-ui.com/api/menu
