### PR TITLE
fix(richtext): skip parsing text in links

### DIFF
--- a/packages/rich-text/src/parser/__tests__/MdParser.spec.js
+++ b/packages/rich-text/src/parser/__tests__/MdParser.spec.js
@@ -37,6 +37,15 @@ describe('MdParser class', () => {
             [':((parenthesis:))', '<span>\u{1F641}</span>(parenthesis<span>\u{1F642}</span>)'],
             [':+1+1', '<span>\u{1F44D}</span>+1'],
             ['-1:-1', '-1<span>\u{1F44E}</span>'],
+
+            // links
+            ['example.com/path', '<a href="http://example.com/path">example.com/path</a>'],
+
+            // italic marker inside links not converted
+            ['example.com/path_with_underscore', '<a href="http://example.com/path_with_underscore">example.com/path_with_underscore</a>'],
+            ['_italic_ and *bold* with a example.com/link_with_underscore', '<em>italic</em> and <strong>bold</strong> with a <a href="http://example.com/link_with_underscore">example.com/link_with_underscore</a>'],
+            ['example.com/path with *bold* after :)', '<a href="http://example.com/path">example.com/path</a> with <strong>bold</strong> after <span>\u{1F642}</span>'],
+            ['_before_ example.com/path_with_underscore *after* :)', '<em>before</em> <a href="http://example.com/path_with_underscore">example.com/path_with_underscore</a> <strong>after</strong> <span>\u{1F642}</span>'],
         ];
 
         tests.forEach((test) => {


### PR DESCRIPTION
Fixes DHIS2-6821.

Changes proposed in this pull request:

If links are detected in the text, skip parsing emphasis and emoji in
them.
A list of link is generated and during parsing the current position of
the marker is checked against the start and end position of links.
If the marker's position falls in any of the links' range, skip parsing.
