### PR TITLE
fix(rich-text): fix regexp in parser

### DIFF
--- a/packages/rich-text/src/parser/MdParser.js
+++ b/packages/rich-text/src/parser/MdParser.js
@@ -15,6 +15,7 @@ const codes = {
         char: "*",
         domEl: "strong",
         encodedChar: 0x2a,
+        // see https://regex101.com/r/evswdV/1 for explanation of regexp
         regexString: "(?:(?!\\S).|^)\\*((?!\\s)[^*]+(?:[^\\s]))\\*(?!\\S)",
         contentFn: val => val,
     },
@@ -23,6 +24,7 @@ const codes = {
         char: "_",
         domEl: "em",
         encodedChar: 0x5f,
+        // see https://regex101.com/r/evswdV/1 for explanation of regexp
         regexString: "(?:(?!\\S).|^)_((?!\\s)[^_]+(?:[^\\s]))_(?!\\S)",
         contentFn: val => val,
     },

--- a/packages/rich-text/src/parser/MdParser.js
+++ b/packages/rich-text/src/parser/MdParser.js
@@ -15,7 +15,7 @@ const codes = {
         char: "*",
         domEl: "strong",
         encodedChar: 0x2a,
-        regexString: "(?<!\\S)\\*((?!\\s)[^*]+(?:[^\\s]))\\*(?!\\S)",
+        regexString: "(?:(?!\\S).|^)\\*((?!\\s)[^*]+(?:[^\\s]))\\*(?!\\S)",
         contentFn: val => val,
     },
     italic: {
@@ -23,7 +23,7 @@ const codes = {
         char: "_",
         domEl: "em",
         encodedChar: 0x5f,
-        regexString: "(?<!\\S)_((?!\\s)[^_]+(?:[^\\s]))_(?!\\S)",
+        regexString: "(?:(?!\\S).|^)_((?!\\s)[^_]+(?:[^\\s]))_(?!\\S)",
         contentFn: val => val,
     },
     emoji: {


### PR DESCRIPTION
Not all browsers support lookbehind yet, only lookahead.
Replace the lookbehind with a non-capturing group match.

Explanation of regexp here: https://regex101.com/r/evswdV/1

