### PR TITLE
chore: remove unused deps and fix lodash imports for treeshaking

### DIFF
--- a/packages/core/src/action/Action.js
+++ b/packages/core/src/action/Action.js
@@ -1,4 +1,4 @@
-import { isString } from 'lodash/fp';
+import isString from 'lodash/fp/isString';
 import { Observable, Subject } from 'rxjs';
 import log from 'loglevel';
 

--- a/packages/core/src/layout/SinglePanel.component.js
+++ b/packages/core/src/layout/SinglePanel.component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isArray } from 'lodash/fp';
+import isArray from 'lodash/fp/isArray';
 import log from 'loglevel';
 
 function SinglePanel(props) {
@@ -16,6 +16,7 @@ function SinglePanel(props) {
     };
 
     let childToRender;
+    
     if (isArray(children) && children.length) {
         childToRender = children[0];
         log.warn('You passed multiple children to the <SinglePanel /> component, this is not supported');

--- a/packages/core/src/layout/SinglePanel.component.js
+++ b/packages/core/src/layout/SinglePanel.component.js
@@ -16,7 +16,6 @@ function SinglePanel(props) {
     };
 
     let childToRender;
-    
     if (isArray(children) && children.length) {
         childToRender = children[0];
         log.warn('You passed multiple children to the <SinglePanel /> component, this is not supported');

--- a/packages/core/src/layout/TwoPanel.component.js
+++ b/packages/core/src/layout/TwoPanel.component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isArray } from 'lodash/fp';
+import isArray from 'lodash/fp/isArray';
 import log from 'loglevel';
 
 function TwoPanelSelector(props) {

--- a/packages/interpretations/package.json
+++ b/packages/interpretations/package.json
@@ -30,8 +30,8 @@
     "@dhis2/d2-i18n-extract": "^1.0.7",
     "@dhis2/d2-i18n-generate": "^1.0.18",
     "@dhis2/d2-ui-mentions-wrapper": "0.0.0-PLACEHOLDER",
-    "@dhis2/d2-ui-sharing-dialog": "0.0.0-PLACEHOLDER",
     "@dhis2/d2-ui-rich-text": "0.0.0-PLACEHOLDER",
+    "@dhis2/d2-ui-sharing-dialog": "0.0.0-PLACEHOLDER",
     "@material-ui/core": "^3.3.1",
     "@material-ui/icons": "^3.0.1",
     "babel-runtime": "^6.26.0",
@@ -39,9 +39,7 @@
     "husky": "^1.0.0-rc.8",
     "postcss-rtl": "^1.3.0",
     "prop-types": "^15.5.10",
-    "react-portal": "^4.1.5",
-    "recompose": "^0.26.0",
-    "rxjs": "^5.5.7"
+    "react-portal": "^4.1.5"
   },
   "devDependencies": {
     "sinon": "^6.0.0"

--- a/packages/interpretations/src/api/__tests__/helpers.spec.js
+++ b/packages/interpretations/src/api/__tests__/helpers.spec.js
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import merge from 'lodash/merge';
+import every from 'lodash/every';
 import { getFavoriteWithInterpretations } from '../helpers';
 import Interpretation from '../../models/interpretation';
 import { getStubContext } from '../../../config/test-context';
@@ -14,7 +15,7 @@ const initD2 = () => {
     getApiGetMock = jest.fn(() => Promise.resolve({views: mockedViews}));
     users.getMentions = jest.fn(() => Promise.resolve({allUsers: [], mostMentionedUsers: []}));
 
-    d2 = _.merge(context.d2, {
+    d2 = merge(context.d2, {
         models: {
             maps: {
                 get: jest.fn(() => map),
@@ -69,8 +70,7 @@ describe("getFavoriteWithInterpretations", () => {
 
         it("should have wrapped interpretations", () => {
             expect(favorite.interpretations).toHaveLength(favorite.interpretations.length);
-            _(favorite.interpretations)
-                .every(interpretation => expect(interpretation).toBeInstanceOf(Interpretation));
+            every(favorite.interpretations, interpretation => expect(interpretation).toBeInstanceOf(Interpretation));
         });
     });
 });

--- a/packages/interpretations/src/api/users.js
+++ b/packages/interpretations/src/api/users.js
@@ -1,6 +1,16 @@
 import { apiFetch } from './api';
-import { keyBy, map, flatMap, flow, groupBy, without } from 'lodash/fp';
-import { orderBy, concat, toPairs, at, differenceBy, compact } from 'lodash/fp';
+import keyBy from 'lodash/fp/keyBy';
+import map from 'lodash/fp/map';
+import flatMap from 'lodash/fp/flatMap';
+import flow from 'lodash/fp/flow';
+import groupBy from 'lodash/fp/groupBy';
+import without from 'lodash/fp/without';
+import concat from 'lodash/fp/concat';
+import orderBy from 'lodash/fp/orderBy';
+import toPairs from 'lodash/fp/toPairs';
+import at from 'lodash/fp/at';
+import differenceBy from 'lodash/fp/differenceBy';
+import compact from 'lodash/fp/compact';
 
 export async function getMentions(d2) {
     const allUsersResponse = await apiFetch(d2, "/users", "GET", {

--- a/packages/interpretations/src/components/Cards/__tests__/InterpretationsCard.spec.js
+++ b/packages/interpretations/src/components/Cards/__tests__/InterpretationsCard.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import _ from 'lodash';
+import merge from 'lodash/merge';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
 import { MuiThemeProvider } from '@material-ui/core/styles';
@@ -96,7 +96,7 @@ const renderComponent = (partialProps = {}, partialContext = {}) => {
     const props = {...baseProps, ...partialProps};
     const context = getStubContext();
     const muiTheme = getMuiTheme();
-    const fullContext = _.merge(context, partialContext);
+    const fullContext = merge(context, partialContext);
     return mount(
         <MuiThemeProvider theme={muiTheme}>
             <InterpretationsCard {...props} />

--- a/packages/interpretations/src/components/Interpretation/__tests__/Interpretation.spec.js
+++ b/packages/interpretations/src/components/Interpretation/__tests__/Interpretation.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import _ from 'lodash';
+import merge from 'lodash/merge';
 
 import { Interpretation } from '../Interpretation';
 import CommentsList from '../../Lists/CommentsList';
@@ -80,7 +80,7 @@ const renderComponent = (partialProps = {}, partialContext = {}) => {
 
     const props = { ...baseProps, ...partialProps };
     const context = getStubContext();
-    const fullContext = _.merge(context, partialContext);
+    const fullContext = merge(context, partialContext);
     return shallow(<Interpretation {...props} />, { context: fullContext });
 };
 

--- a/packages/interpretations/src/components/Lists/__tests__/CommentsList.spec.js
+++ b/packages/interpretations/src/components/Lists/__tests__/CommentsList.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import _ from 'lodash';
+import merge from 'lodash/merge';
 import { CommentsList } from '../CommentsList';
 import Comment from '../../Comment/Comment';
 import NewCommentField from '../../Comment/NewCommentField';
@@ -46,7 +46,7 @@ const renderComponent = (partialProps = {}, partialContext = {}) => {
     };
 
     const props = {...baseProps, ...partialProps};
-    const fullContext = _.merge(context, partialContext);
+    const fullContext = merge(context, partialContext);
     return shallow(<CommentsList {...props} />, { context: fullContext });
 };
 

--- a/packages/interpretations/src/models/interpretation.js
+++ b/packages/interpretations/src/models/interpretation.js
@@ -1,4 +1,5 @@
-import { pick, last } from 'lodash/fp';
+import pick from 'lodash/fp/pick';
+import last from 'lodash/fp/last';
 import { apiFetch, apiFetchWithResponse } from '../api/api';
 import Comment from './comment';
 

--- a/packages/org-unit-select/package.json
+++ b/packages/org-unit-select/package.json
@@ -27,9 +27,7 @@
     "@dhis2/d2-ui-core": "0.0.0-PLACEHOLDER",
     "babel-runtime": "^6.26.0",
     "material-ui": "^0.20.0",
-    "prop-types": "^15.5.10",
-    "recompose": "^0.26.0",
-    "rxjs": "^5.5.7"
+    "prop-types": "^15.5.10"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/org-unit-tree/package.json
+++ b/packages/org-unit-tree/package.json
@@ -28,9 +28,7 @@
     "@dhis2/d2-ui-core": "0.0.0-PLACEHOLDER",
     "@material-ui/core": "^3.3.1",
     "babel-runtime": "^6.26.0",
-    "prop-types": "^15.5.10",
-    "recompose": "^0.26.0",
-    "rxjs": "^5.5.7"
+    "prop-types": "^15.5.10"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -27,7 +27,6 @@
     "@material-ui/core": "^3.3.1",
     "@material-ui/icons": "^3.0.1",
     "babel-runtime": "^6.26.0",
-    "lodash": "^4.17.11",
     "prop-types": "^15.6.0"
   },
   "publishConfig": {

--- a/packages/translation-dialog/package.json
+++ b/packages/translation-dialog/package.json
@@ -31,7 +31,6 @@
     "d2-utilizr": "^0.2.15",
     "prop-types": "^15.5.10",
     "react-select": "^2.0.0",
-    "recompose": "^0.26.0",
     "rxjs": "^5.5.7"
   },
   "jest": {


### PR DESCRIPTION
* Removing unused dependencies that were probably carried over when d2-ui was split into multiple packages
* use import syntax for lodash that ensures treeshaking