### PR TITLE
feat: add epi weeks to period selector dialog [DHIS2-6983]

### DIFF
--- a/packages/period-selector-dialog/src/modules/FixedPeriodsGenerator.js
+++ b/packages/period-selector-dialog/src/modules/FixedPeriodsGenerator.js
@@ -73,14 +73,14 @@ function WeeklyPeriodType(formatYyyyMmDd, weekObj, fnFilter) {
             date.setDate(date.getDate() + 1);
 
             week += 1;
-        };
+        }
 
         periods = isFilter ? fnFilter(periods) : periods;
         periods = isReverse ? periods.reverse() : periods;
 
         return periods;
     };
-};
+}
 
 function BiWeeklyPeriodType(formatYyyyMmDd, fnFilter) {
     this.generatePeriods = config => {

--- a/packages/period-selector-dialog/src/modules/FixedPeriodsGenerator.js
+++ b/packages/period-selector-dialog/src/modules/FixedPeriodsGenerator.js
@@ -28,59 +28,11 @@ function DailyPeriodType(formatYyyyMmDd, fnFilter) {
     };
 }
 
-/*
-function WeeklyPeriodType(formatYyyyMmDd, fnFilter) {
-    this.generatePeriods = config => {
-        let periods = [];
-        const offset = parseInt(config.offset, 10);
-        const isFilter = config.filterFuturePeriods;
-        const isReverse = config.reversePeriods;
-        const year = new Date(Date.now()).getFullYear() + offset;
-        const date = new Date(`01 Jan ${year}`);
-        const day = date.getDay();
-        let week = 1;
-
-        if (day <= 4) {
-            date.setDate(date.getDate() - (day - 1));
-        } else {
-            date.setDate(date.getDate() + (8 - day));
-        }
-
-        while (date.getFullYear() <= year) {
-            const period = {};
-            period.startDate = formatYyyyMmDd(date);
-            period.iso = `${year}W${week}`;
-            period.id = period.iso;
-            date.setDate(date.getDate() + 6);
-            period.endDate = formatYyyyMmDd(date);
-            period.name = `W${week} - ${period.startDate} - ${period.endDate}`;
-
-            // if end date is Jan 4th or later, week belongs to next year
-            if (date.getFullYear() > year && date.getDate() >= 4) {
-                break;
-            }
-
-            periods.push(period);
-
-            date.setDate(date.getDate() + 1);
-
-            week += 1;
-        }
-
-        periods = isFilter ? fnFilter(periods) : periods;
-        periods = isReverse ? periods.reverse() : periods;
-
-        return periods;
-    };
-}*/
-
-
 function WeeklyPeriodType(formatYyyyMmDd, weekObj, fnFilter) {
     // Calculate the first date of an EPI year base on ISO standard  ( first week always contains 4th Jan )
     const getEpiWeekStartDay = (year, startDayOfWeek) => {
         const jan4 = new Date(year, 0, 4);
         const jan4DayOfWeek = jan4.getDay();
-    
         const startDate = jan4;
         const dayDiff = jan4DayOfWeek - startDayOfWeek;
     
@@ -106,12 +58,13 @@ function WeeklyPeriodType(formatYyyyMmDd, weekObj, fnFilter) {
         while (date.getFullYear() <= year) {
             const period = {};
             period.startDate = formatYyyyMmDd(date);
+            period.iso = `${year}${weekObj.shortName}W${week}`;
+            period.id = period.iso;
             date.setDate(date.getDate() + 6);
             period.endDate = formatYyyyMmDd(date);
             period.name = `Week ${week} - ${period.startDate} - ${period.endDate}`;
-            period.iso = `${year}${weekObj.shortName}W${week}`;
-            period.id = period.iso;
 
+            // if end date is Jan 4th or later, week belongs to next year
             if (date.getFullYear() > year && date.getDate() >= 4) {
                 break;
             }
@@ -119,7 +72,7 @@ function WeeklyPeriodType(formatYyyyMmDd, weekObj, fnFilter) {
             periods.push(period);
             date.setDate(date.getDate() + 1);
 
-            week++;
+            week += 1;
         };
 
         periods = isFilter ? fnFilter(periods) : periods;

--- a/packages/period-selector-dialog/src/modules/FixedPeriodsGenerator.js
+++ b/packages/period-selector-dialog/src/modules/FixedPeriodsGenerator.js
@@ -28,6 +28,7 @@ function DailyPeriodType(formatYyyyMmDd, fnFilter) {
     };
 }
 
+/*
 function WeeklyPeriodType(formatYyyyMmDd, fnFilter) {
     this.generatePeriods = config => {
         let periods = [];
@@ -71,7 +72,62 @@ function WeeklyPeriodType(formatYyyyMmDd, fnFilter) {
 
         return periods;
     };
-}
+}*/
+
+
+function WeeklyPeriodType(formatYyyyMmDd, weekObj, fnFilter) {
+    // Calculate the first date of an EPI year base on ISO standard  ( first week always contains 4th Jan )
+    const getEpiWeekStartDay = (year, startDayOfWeek) => {
+        const jan4 = new Date(year, 0, 4);
+        const jan4DayOfWeek = jan4.getDay();
+    
+        const startDate = jan4;
+        const dayDiff = jan4DayOfWeek - startDayOfWeek;
+    
+        if (dayDiff > 0) {
+            startDate.setDate(jan4.getDate() - dayDiff);
+        } else if (dayDiff < 0) {
+            startDate.setDate(jan4.getDate() - dayDiff);
+            startDate.setDate(startDate.getDate() - 7);
+        }
+    
+        return startDate;
+    };
+   
+    this.generatePeriods = (config) => {
+        let periods = [];
+        const offset = parseInt(config.offset, 10);
+        const isFilter = config.filterFuturePeriods;
+        const isReverse = config.reversePeriods;
+        const year = new Date(Date.now()).getFullYear() + offset;
+        const date = getEpiWeekStartDay(year, weekObj.startDay);
+        let week = 1;
+
+        while (date.getFullYear() <= year) {
+            const period = {};
+            period.startDate = formatYyyyMmDd(date);
+            date.setDate(date.getDate() + 6);
+            period.endDate = formatYyyyMmDd(date);
+            period.name = `Week ${week} - ${period.startDate} - ${period.endDate}`;
+            period.iso = `${year}${weekObj.shortName}W${week}`;
+            period.id = period.iso;
+
+            if (date.getFullYear() > year && date.getDate() >= 4) {
+                break;
+            }
+
+            periods.push(period);
+            date.setDate(date.getDate() + 1);
+
+            week++;
+        };
+
+        periods = isFilter ? fnFilter(periods) : periods;
+        periods = isReverse ? periods.reverse() : periods;
+
+        return periods;
+    };
+};
 
 function BiWeeklyPeriodType(formatYyyyMmDd, fnFilter) {
     this.generatePeriods = config => {
@@ -121,59 +177,6 @@ function BiWeeklyPeriodType(formatYyyyMmDd, fnFilter) {
         return periods;
     };
 }
-
-function EpiWeeklyPeriodType(formatYyyyMmDd, weekObj, fnFilter) {
-    // Calculate the first date of an EPI year base on ISO standard  ( first week always contains 4th Jan )
-    const getEpiWeekStartDay = (year, startDayOfWeek) => {
-        const jan4 = new Date(year, 0, 4);
-        const jan4DayOfWeek = jan4.getDay();
-    
-        const startDate = jan4;
-        const dayDiff = jan4DayOfWeek - startDayOfWeek;
-    
-        if (dayDiff > 0) {
-            startDate.setDate(jan4.getDate() - dayDiff);
-        } else if (dayDiff < 0) {
-            startDate.setDate(jan4.getDate() - dayDiff);
-            startDate.setDate(startDate.getDate() - 7);
-        }
-    
-        return startDate;
-    };
-   
-    this.generatePeriods = (config) => {
-        let periods = [];
-        const offset = parseInt(config.offset, 10);
-        const isFilter = config.filterFuturePeriods;
-        const isReverse = config.reversePeriods;
-        const year = new Date(Date.now()).getFullYear() + offset;
-        const startDate = getEpiWeekStartDay(year, weekObj.startDay);
-        const endDate = startDate;
-
-        for (let week = 1; week < 200; week++) {
-            const period = {};
-
-            period.startDate = formatYyyyMmDd(startDate);
-            endDate.setDate(startDate.getDate() + 6);
-            period.endDate = formatYyyyMmDd(endDate);
-            period.name = `Week ${week} - ${period.startDate} - ${period.endDate}`;
-            period.iso = `${year}${weekObj.shortName}W${week}`;
-            period.id = period.iso;
-
-            periods.push(period);
-            startDate.setDate(endDate.getDate() + 1);
-
-            if (startDate.getMonth() === 0 && week > 50) {
-                break;
-            }
-        };
-
-        periods = isFilter ? fnFilter(periods) : periods;
-        periods = isReverse ? periods.reverse() : periods;
-
-        return periods;
-    };
-};
 
 function MonthlyPeriodType(formatYyyyMmDd, monthNames, fnFilter) {
     const formatIso = date => {
@@ -551,26 +554,31 @@ function PeriodType() {
     );
     periodTypes.Weekly = new WeeklyPeriodType(
         formatYyyyMmDd,
+        { shortName: '', startDay: 1 },
         filterFuturePeriods
     );
     periodTypes['Bi-weekly'] = new BiWeeklyPeriodType(
         formatYyyyMmDd,
         filterFuturePeriods
     );
-    periodTypes['Weekly (Start Wednesday)'] = new EpiWeeklyPeriodType(
-        formatYyyyMmDd, { shortName: 'Wed', startDay: 3 },
+    periodTypes['Weekly (Start Wednesday)'] = new WeeklyPeriodType(
+        formatYyyyMmDd,
+        { shortName: 'Wed', startDay: 3 },
         filterFuturePeriods
     );
-    periodTypes['Weekly (Start Thursday)'] = new EpiWeeklyPeriodType(
-        formatYyyyMmDd, { shortName: 'Thu', startDay: 4 },
+    periodTypes['Weekly (Start Thursday)'] = new WeeklyPeriodType(
+        formatYyyyMmDd,
+        { shortName: 'Thu', startDay: 4 },
         filterFuturePeriods
     );
-    periodTypes['Weekly (Start Saturday)'] = new EpiWeeklyPeriodType(
-        formatYyyyMmDd, { shortName: 'Sat', startDay: 6 },
+    periodTypes['Weekly (Start Saturday)'] = new WeeklyPeriodType(
+        formatYyyyMmDd,
+        { shortName: 'Sat', startDay: 6 },
         filterFuturePeriods
     );
-    periodTypes['Weekly (Start Sunday)'] = new EpiWeeklyPeriodType(
-        formatYyyyMmDd, { shortName: 'Sun', startDay: 7 },
+    periodTypes['Weekly (Start Sunday)'] = new WeeklyPeriodType(
+        formatYyyyMmDd,
+        { shortName: 'Sun', startDay: 7 },
         filterFuturePeriods
     );
     periodTypes.Monthly = new MonthlyPeriodType(

--- a/packages/period-selector-dialog/src/modules/__tests__/FixedPeriodsGenerator.spec.js
+++ b/packages/period-selector-dialog/src/modules/__tests__/FixedPeriodsGenerator.spec.js
@@ -93,7 +93,7 @@ describe('FixedPeriodsGenerator class', () => {
             expect(periods[0]).toEqual({
                 startDate: '2008-12-29',
                 endDate: '2009-01-04',
-                name: 'W1 - 2008-12-29 - 2009-01-04',
+                name: 'Week 1 - 2008-12-29 - 2009-01-04',
                 iso: '2009W1',
                 id: '2009W1',
             });
@@ -103,53 +103,11 @@ describe('FixedPeriodsGenerator class', () => {
             expect(periods[52]).toEqual({
                 startDate: '2009-12-28',
                 endDate: '2010-01-03',
-                name: 'W53 - 2009-12-28 - 2010-01-03',
+                name: 'Week 53 - 2009-12-28 - 2010-01-03',
                 iso: '2009W53',
                 id: '2009W53',
             });
         });
-    });
-
-    describe('Bi-weekly period generator', () => {
-        let periods;
-
-        beforeAll(() => {
-            const generator = periodsGenerator.get('Bi-weekly');
-
-            periods = generator.generatePeriods({
-                offset: 2019 - new Date().getFullYear(),
-                filterFuturePeriods: false,
-                reversePeriods: false,
-            });
-        });
-
-        it('should return the correct number of bi-weeks in 2019', () => {
-            expect(periods.length).toEqual(26);
-        });
-
-        it('should return the correct object for bi-week 1', () => {
-            expect(periods[0]).toEqual({
-                startDate: '2018-12-31',
-                endDate: '2019-01-13',
-                name: 'Bi-Week 1 - 2018-12-31 - 2019-01-13',
-                iso: '2019BiW1',
-                id: '2019BiW1',
-            });
-        });
-
-        it('should return the correct object for bi-week 26', () => {
-            expect(periods[25]).toEqual({
-                startDate: '2019-12-16',
-                endDate: '2019-12-29',
-                name: 'Bi-Week 26 - 2019-12-16 - 2019-12-29',
-                iso: '2019BiW26',
-                id: '2019BiW26',
-            });
-        });
-    });
-
-    describe('EpiWeekly period generator', () => {
-        let periods;
 
         describe('-> Weekly Wednesday', () => {
             beforeAll(() => {
@@ -200,6 +158,44 @@ describe('FixedPeriodsGenerator class', () => {
                     iso: '2019SatW10',
                     id: '2019SatW10',
                 });
+            });
+        });
+    });
+
+    describe('Bi-weekly period generator', () => {
+        let periods;
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get('Bi-weekly');
+
+            periods = generator.generatePeriods({
+                offset: 2019 - new Date().getFullYear(),
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            });
+        });
+
+        it('should return the correct number of bi-weeks in 2019', () => {
+            expect(periods.length).toEqual(26);
+        });
+
+        it('should return the correct object for bi-week 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2018-12-31',
+                endDate: '2019-01-13',
+                name: 'Bi-Week 1 - 2018-12-31 - 2019-01-13',
+                iso: '2019BiW1',
+                id: '2019BiW1',
+            });
+        });
+
+        it('should return the correct object for bi-week 26', () => {
+            expect(periods[25]).toEqual({
+                startDate: '2019-12-16',
+                endDate: '2019-12-29',
+                name: 'Bi-Week 26 - 2019-12-16 - 2019-12-29',
+                iso: '2019BiW26',
+                id: '2019BiW26',
             });
         });
     });

--- a/packages/period-selector-dialog/src/modules/__tests__/FixedPeriodsGenerator.spec.js
+++ b/packages/period-selector-dialog/src/modules/__tests__/FixedPeriodsGenerator.spec.js
@@ -13,7 +13,23 @@ describe('FixedPeriodsGenerator class', () => {
             const periods = periodsGenerator.getOptions();
 
             expect(periods).toEqual([
-                'Daily', 'Weekly', 'Bi-weekly', 'Monthly', 'Bi-monthly', 'Quarterly', 'Six-monthly', 'Six-monthly April', 'Yearly', 'Financial year (Start November)', 'Financial year (Start October)', 'Financial year (Start July)', 'Financial year (Start April)'
+                'Daily',
+                'Weekly',
+                'Bi-weekly',
+                'Weekly (Start Wednesday)',
+                'Weekly (Start Thursday)',
+                'Weekly (Start Saturday)',
+                'Weekly (Start Sunday)',
+                'Monthly',
+                'Bi-monthly',
+                'Quarterly',
+                'Six-monthly',
+                'Six-monthly April',
+                'Yearly',
+                'Financial year (Start November)',
+                'Financial year (Start October)',
+                'Financial year (Start July)',
+                'Financial year (Start April)'
             ]);
         });
 
@@ -129,6 +145,62 @@ describe('FixedPeriodsGenerator class', () => {
                 name: 'Bi-Week 27 - 2019-12-30 - 2020-01-12',
                 iso: '2019BiW27',
                 id: '2019BiW27',
+            });
+        });
+    });
+
+    describe('EpiWeekly period generator', () => {
+        let periods;
+
+        describe('-> Weekly Wednesday', () => {
+            beforeAll(() => {
+                const generator = periodsGenerator.get('Weekly (Start Wednesday)');
+    
+                periods = generator.generatePeriods({
+                    offset: 2019 - (new Date()).getFullYear(),
+                    filterFuturePeriods: false,
+                    reversePeriods: false,
+                });
+            });
+
+            it('should return the correct number of weekly wednesday in 2019', () => {
+                expect(periods.length).toEqual(52);
+            });
+
+            it('should return the correct object for weekly wednesday 27', () => {
+                expect(periods[26]).toEqual({
+                    startDate: '2019-07-03',
+                    endDate: '2019-07-09',
+                    name: 'Week 27 - 2019-07-03 - 2019-07-09',
+                    iso: '2019WedW27',
+                    id: '2019WedW27',
+                });
+            });
+        });
+
+        describe('-> Weekly Saturday', () => {
+            beforeAll(() => {
+                const generator = periodsGenerator.get('Weekly (Start Saturday)');
+    
+                periods = generator.generatePeriods({
+                    offset: 2019 - (new Date()).getFullYear(),
+                    filterFuturePeriods: false,
+                    reversePeriods: false,
+                });
+            });
+
+            it('should return the correct number of weekly saturdays in 2019', () => {
+                expect(periods.length).toEqual(53);
+            });
+
+            it('should return the correct object for weekly saturday 10', () => {
+                expect(periods[9]).toEqual({
+                    startDate: '2019-03-02',
+                    endDate: '2019-03-08',
+                    name: 'Week 10 - 2019-03-02 - 2019-03-08',
+                    iso: '2019SatW10',
+                    id: '2019SatW10',
+                });
             });
         });
     });

--- a/packages/period-selector-dialog/src/modules/__tests__/FixedPeriodsGenerator.spec.js
+++ b/packages/period-selector-dialog/src/modules/__tests__/FixedPeriodsGenerator.spec.js
@@ -112,7 +112,7 @@ describe('FixedPeriodsGenerator class', () => {
         describe('-> Weekly Wednesday', () => {
             beforeAll(() => {
                 const generator = periodsGenerator.get('Weekly (Start Wednesday)');
-    
+
                 periods = generator.generatePeriods({
                     offset: 2019 - (new Date()).getFullYear(),
                     filterFuturePeriods: false,
@@ -135,10 +135,36 @@ describe('FixedPeriodsGenerator class', () => {
             });
         });
 
+        describe('-> Weekly Thursday', () => {
+            beforeAll(() => {
+                const generator = periodsGenerator.get('Weekly (Start Thursday)');
+
+                periods = generator.generatePeriods({
+                    offset: 2019 - (new Date()).getFullYear(),
+                    filterFuturePeriods: false,
+                    reversePeriods: false,
+                });
+            });
+
+            it('should return the correct number of weekly thursday in 2019', () => {
+                expect(periods.length).toEqual(52);
+            });
+
+            it('should return the correct object for weekly thursday 27', () => {
+                expect(periods[26]).toEqual({
+                    startDate: '2019-07-04',
+                    endDate: '2019-07-10',
+                    name: 'Week 27 - 2019-07-04 - 2019-07-10',
+                    iso: '2019ThuW27',
+                    id: '2019ThuW27',
+                });
+            });
+        });
+
         describe('-> Weekly Saturday', () => {
             beforeAll(() => {
                 const generator = periodsGenerator.get('Weekly (Start Saturday)');
-    
+
                 periods = generator.generatePeriods({
                     offset: 2019 - (new Date()).getFullYear(),
                     filterFuturePeriods: false,
@@ -157,6 +183,32 @@ describe('FixedPeriodsGenerator class', () => {
                     name: 'Week 10 - 2019-03-02 - 2019-03-08',
                     iso: '2019SatW10',
                     id: '2019SatW10',
+                });
+            });
+        });
+
+        describe('-> Weekly Sunday', () => {
+            beforeAll(() => {
+                const generator = periodsGenerator.get('Weekly (Start Sunday)');
+
+                periods = generator.generatePeriods({
+                    offset: 2019 - (new Date()).getFullYear(),
+                    filterFuturePeriods: false,
+                    reversePeriods: false,
+                });
+            });
+
+            it('should return the correct number of weekly sundays in 2019', () => {
+                expect(periods.length).toEqual(52);
+            });
+
+            it('should return the correct object for weekly sunday 10', () => {
+                expect(periods[10]).toEqual({
+                    startDate: '2019-03-10',
+                    endDate: '2019-03-16',
+                    name: 'Week 11 - 2019-03-10 - 2019-03-16',
+                    iso: '2019SunW11',
+                    id: '2019SunW11',
                 });
             });
         });


### PR DESCRIPTION
This PR includes Epidemiological weeks for the Period Selector, related to ticket no. [6983](https://jira.dhis2.org/browse/DHIS2-6983).

1 new function `EpiWeeklyPeriodType` have been added.
The code is extracted and modified from the scripts available through [dhis-web-commons](https://play.dhis2.org/2.31.3/dhis-web-commons/javascripts/dhis2/dhis2.period.js?_=1561546342706).

Extracted fns:
```
dhis2.period.WeeklyWednesdayGenerator
dhis2.period.WeeklyThursdayGenerator
dhis2.period.WeeklySaturdayGenerator
dhis2.period.WeeklySundayGenerator
```

The previous `WeeklyPeriodType` generator have been modified to generate regular weekly intervals as well as epi-weeks.
