### PR TITLE
fix: fix rich text regexp to allow non-word characters after bold/italic

### DIFF
--- a/packages/rich-text/src/parser/MdParser.js
+++ b/packages/rich-text/src/parser/MdParser.js
@@ -15,8 +15,8 @@ const codes = {
         char: "*",
         domEl: "strong",
         encodedChar: 0x2a,
-        // see https://regex101.com/r/evswdV/1 for explanation of regexp
-        regexString: "(?:(?!\\S).|^)\\*((?!\\s)[^*]+(?:[^\\s]))\\*(?!\\S)",
+        // see https://regex101.com/r/evswdV/6 for explanation of regexp
+        regexString: "\\B\\*((?!\\s)[^*]+)\\b\\*\\B",
         contentFn: val => val,
     },
     italic: {
@@ -24,8 +24,8 @@ const codes = {
         char: "_",
         domEl: "em",
         encodedChar: 0x5f,
-        // see https://regex101.com/r/evswdV/1 for explanation of regexp
-        regexString: "(?:(?!\\S).|^)_((?!\\s)[^_]+(?:[^\\s]))_(?!\\S)",
+        // see https://regex101.com/r/p6LpjK/5 for explanation of regexp
+        regexString: "\\b_((?!\\s)[^_]+)\\B_\\b",
         contentFn: val => val,
     },
     emoji: {

--- a/packages/rich-text/src/parser/__tests__/MdParser.spec.js
+++ b/packages/rich-text/src/parser/__tests__/MdParser.spec.js
@@ -21,6 +21,14 @@ describe('MdParser class', () => {
             ],
             ['_italic with * inside_', '<em>italic with * inside</em>'],
             ['*bold with _ inside*', '<strong>bold with _ inside</strong>'],
+
+            // italic marker followed by : should work
+            ['_italic_:', '<em>italic</em>:'],
+            ['_italic_: some text, *bold*: some other text', '<em>italic</em>: some text, <strong>bold</strong>: some other text'],
+            // bold marker followed by : should work
+            ['*bold*:', '<strong>bold</strong>:'],
+            ['*bold*: some text, _italic_: some other text', '<strong>bold</strong>: some text, <em>italic</em>: some other text'],
+
             // italic marker inside an italic string not allowed
             ['_italic with _ inside_', '_italic with _ inside_'],
             // bold marker inside a bold string not allowed


### PR DESCRIPTION
Fixes DHIS2-7249.

Changes proposed in this pull request:

- allow non-word character right after a bold or italic text, ie. ":"

