### PR TITLE
fix: support multiple ou roots in OrgUnitSelector component

### DIFF
--- a/packages/org-unit-dialog/src/OrgUnitSelector.js
+++ b/packages/org-unit-dialog/src/OrgUnitSelector.js
@@ -227,6 +227,9 @@ class OrgUnitSelector extends Component {
                                 }
                                 showFolderIcon
                                 disableSpacer
+                                useUserDataViewFallback={
+                                    this.props.useUserDataViewFallback
+                                }
                             />
                             <Menu
                                 anchorEl={this.state.menuAnchorElement}
@@ -359,6 +362,8 @@ OrgUnitSelector.propTypes = {
      * Checkbox color in org unit tree
      */
     checkboxColor: PropTypes.string,
+
+    useUserDataViewFallback: PropTypes.bool,
 };
 
 OrgUnitSelector.defaultProps = {
@@ -372,6 +377,7 @@ OrgUnitSelector.defaultProps = {
     checkboxColor: 'primary',
     deselectAllTooltipFontColor: 'white',
     deselectAllTooltipBackgroundColor: 'gray',
+    useUserDataViewFallback: false,
 };
 
 export default OrgUnitSelector;

--- a/packages/org-unit-dialog/src/OrgUnitSelector.js
+++ b/packages/org-unit-dialog/src/OrgUnitSelector.js
@@ -227,8 +227,8 @@ class OrgUnitSelector extends Component {
                                 }
                                 showFolderIcon
                                 disableSpacer
-                                useUserDataViewFallback={
-                                    this.props.useUserDataViewFallback
+                                isUserDataViewFallback={
+                                    this.props.isUserDataViewFallback
                                 }
                             />
                             <Menu
@@ -363,7 +363,10 @@ OrgUnitSelector.propTypes = {
      */
     checkboxColor: PropTypes.string,
 
-    useUserDataViewFallback: PropTypes.bool,
+    /**
+     * Extra query parameter to use when requesting org unit data from the API
+     */
+    isUserDataViewFallback: PropTypes.bool,
 };
 
 OrgUnitSelector.defaultProps = {
@@ -377,7 +380,7 @@ OrgUnitSelector.defaultProps = {
     checkboxColor: 'primary',
     deselectAllTooltipFontColor: 'white',
     deselectAllTooltipBackgroundColor: 'gray',
-    useUserDataViewFallback: false,
+    isUserDataViewFallback: false,
 };
 
 export default OrgUnitSelector;

--- a/packages/org-unit-dialog/src/OrgUnitSelector.js
+++ b/packages/org-unit-dialog/src/OrgUnitSelector.js
@@ -1,5 +1,5 @@
 import React, { Component, Fragment } from 'react';
-import { OrgUnitTree } from '@dhis2/d2-ui-org-unit-tree';
+import { OrgUnitTreeMultipleRoots } from '@dhis2/d2-ui-org-unit-tree';
 import i18n from '@dhis2/d2-i18n';
 import PropTypes from 'prop-types';
 
@@ -205,7 +205,8 @@ class OrgUnitSelector extends Component {
                                     style={styles.scrollableContainer.overlay}
                                 />
                             )}
-                            <OrgUnitTree
+                            <OrgUnitTreeMultipleRoots
+                                roots={this.props.roots}
                                 root={this.props.root}
                                 selected={this.props.selected.map(
                                     orgUnit => orgUnit.path
@@ -333,6 +334,11 @@ OrgUnitSelector.propTypes = {
      * Arguments supplied in callback: event, checked
      */
     handleUserOrgUnitClick: PropTypes.func.isRequired,
+
+    /**
+     * Root organisation units whenever multiple roots are available
+     */
+    roots: PropTypes.array,
 
     /**
      * Root organisation unit

--- a/packages/org-unit-dialog/src/OrgUnitSelector.js
+++ b/packages/org-unit-dialog/src/OrgUnitSelector.js
@@ -20,17 +20,23 @@ class OrgUnitSelector extends Component {
             menuAnchorElement: null,
             children: null,
             loadingChildren: false,
-            initiallyExpanded: this.props.selected.map(ou => removeLastPathSegment(ou.path)),
+            initiallyExpanded: this.props.selected.map(ou =>
+                removeLastPathSegment(ou.path)
+            ),
         };
     }
 
     componentDidUpdate(prevProps) {
         // if props.selected.length changed by more than 1, then another analytic object was selected
-        if (Math.abs(prevProps.selected.length - this.props.selected.length) > 1) {
+        if (
+            Math.abs(prevProps.selected.length - this.props.selected.length) > 1
+        ) {
             // In this case refresh expanded org units
             // eslint-disable-next-line
             this.setState({
-                initiallyExpanded: this.props.selected.map(ou => removeLastPathSegment(ou.path)),
+                initiallyExpanded: this.props.selected.map(ou =>
+                    removeLastPathSegment(ou.path)
+                ),
             });
         } else {
             // If props.selected.length changed by 1 or didnt change
@@ -38,9 +44,10 @@ class OrgUnitSelector extends Component {
             // if more than 1 ids are different, then and we should refresh expanded org units
             let counter = 0;
 
-            const orgUnits = prevProps.selected.length < this.props.selected.length
-                ? prevProps.selected
-                : this.props.selected;
+            const orgUnits =
+                prevProps.selected.length < this.props.selected.length
+                    ? prevProps.selected
+                    : this.props.selected;
 
             for (let i = 0; i < orgUnits.length; ++i) {
                 if (prevProps.selected[i].id !== this.props.selected[i].id) {
@@ -49,7 +56,9 @@ class OrgUnitSelector extends Component {
                     if (counter > 1) {
                         // eslint-disable-next-line
                         this.setState({
-                            initiallyExpanded: this.props.selected.map(ou => removeLastPathSegment(ou.path)),
+                            initiallyExpanded: this.props.selected.map(ou =>
+                                removeLastPathSegment(ou.path)
+                            ),
                         });
 
                         break;
@@ -59,19 +68,18 @@ class OrgUnitSelector extends Component {
         }
     }
 
-    onExpand = (orgUnit) => {
+    onExpand = orgUnit => {
         this.setState({
-            initiallyExpanded: [
-                ...this.state.initiallyExpanded,
-                orgUnit.path,
-            ],
+            initiallyExpanded: [...this.state.initiallyExpanded, orgUnit.path],
         });
     };
 
-    onCollapse = (orgUnit) => {
+    onCollapse = orgUnit => {
         this.setState({
             // Clear all org units which are children of collapsed org unit
-            initiallyExpanded: this.state.initiallyExpanded.filter(path => !path.includes(orgUnit.id)),
+            initiallyExpanded: this.state.initiallyExpanded.filter(
+                path => !path.includes(orgUnit.id)
+            ),
         });
     };
 
@@ -80,17 +88,22 @@ class OrgUnitSelector extends Component {
             return;
         }
 
-        this.setState({
-            menuAnchorElement: event.currentTarget,
-            loadingChildren: true,
-        }, () => {
-            loadChildren().then((children) => {
-                this.setState({
-                    children: Array.isArray(children) ? children : children.toArray(),
-                    loadingChildren: false,
+        this.setState(
+            {
+                menuAnchorElement: event.currentTarget,
+                loadingChildren: true,
+            },
+            () => {
+                loadChildren().then(children => {
+                    this.setState({
+                        children: Array.isArray(children)
+                            ? children
+                            : children.toArray(),
+                        loadingChildren: false,
+                    });
                 });
-            });
-        });
+            }
+        );
     };
 
     normalizeOptions = (result, item) => ({ ...result, [item.id]: item });
@@ -105,9 +118,12 @@ class OrgUnitSelector extends Component {
         this.setState({ menuAnchorElement: null });
     };
 
-    renderGroupOptions = (selected) => {
+    renderGroupOptions = selected => {
         if (this.props.groupOptions.length > 0) {
-            const options = this.props.groupOptions.reduce(this.normalizeOptions, {});
+            const options = this.props.groupOptions.reduce(
+                this.normalizeOptions,
+                {}
+            );
 
             return selected
                 .filter(id => options[id])
@@ -118,9 +134,12 @@ class OrgUnitSelector extends Component {
         return '';
     };
 
-    renderLevelOptions = (selected) => {
+    renderLevelOptions = selected => {
         if (this.props.levelOptions.length > 0) {
-            const options = this.props.levelOptions.reduce(this.normalizeOptions, {});
+            const options = this.props.levelOptions.reduce(
+                this.normalizeOptions,
+                {}
+            );
 
             return selected
                 .filter(id => options[id])
@@ -173,16 +192,24 @@ class OrgUnitSelector extends Component {
                             selected={this.props.selected}
                             styles={styles.userOrgUnits}
                             userOrgUnits={this.props.userOrgUnits}
-                            handleUserOrgUnitClick={this.props.handleUserOrgUnitClick}
+                            handleUserOrgUnitClick={
+                                this.props.handleUserOrgUnitClick
+                            }
                             checkboxColor={this.props.checkboxColor}
                         />
-                        <div style={styles.scrollableContainer.overlayContainer}>
+                        <div
+                            style={styles.scrollableContainer.overlayContainer}
+                        >
                             {this.props.userOrgUnits.length > 0 && (
-                                <div style={styles.scrollableContainer.overlay} />
+                                <div
+                                    style={styles.scrollableContainer.overlay}
+                                />
                             )}
                             <OrgUnitTree
                                 root={this.props.root}
-                                selected={this.props.selected.map(orgUnit => orgUnit.path)}
+                                selected={this.props.selected.map(
+                                    orgUnit => orgUnit.path
+                                )}
                                 initiallyExpanded={this.state.initiallyExpanded}
                                 onSelectClick={this.props.handleOrgUnitClick}
                                 onExpand={this.onExpand}
@@ -190,9 +217,13 @@ class OrgUnitSelector extends Component {
                                 onContextMenuClick={this.onContextMenuClick}
                                 treeStyle={styles.orgUnitTree.treeStyle}
                                 labelStyle={styles.orgUnitTree.labelStyle}
-                                selectedLabelStyle={styles.orgUnitTree.selectedLabelStyle}
+                                selectedLabelStyle={
+                                    styles.orgUnitTree.selectedLabelStyle
+                                }
                                 checkboxColor={this.props.checkboxColor}
-                                displayNameProperty={this.props.displayNameProperty}
+                                displayNameProperty={
+                                    this.props.displayNameProperty
+                                }
                                 showFolderIcon
                                 disableSpacer
                             />
@@ -214,10 +245,13 @@ class OrgUnitSelector extends Component {
                     <div style={styles.orgUnitsContainer.tooltipContainer}>
                         {this.props.selected.length > 0 && (
                             <div style={tooltipStyles}>
-                                {this.props.selected.length} {i18n.t('selected')} -
+                                {this.props.selected.length}{' '}
+                                {i18n.t('selected')} -
                                 <button
                                     onClick={this.props.onDeselectAllClick}
-                                    style={styles.orgUnitsContainer.tooltip.link}
+                                    style={
+                                        styles.orgUnitsContainer.tooltip.link
+                                    }
                                 >
                                     {i18n.t('Deselect all')}
                                 </button>

--- a/packages/org-unit-tree/src/OrgUnitTree.component.js
+++ b/packages/org-unit-tree/src/OrgUnitTree.component.js
@@ -14,15 +14,19 @@ class OrgUnitTree extends React.Component {
         super(props);
 
         this.state = {
-            children: (
+            children:
                 props.root.children === false ||
-                (Array.isArray(props.root.children) && props.root.children.length === 0)
-            )
-                ? []
-                : undefined,
+                (Array.isArray(props.root.children) &&
+                    props.root.children.length === 0)
+                    ? []
+                    : undefined,
             loading: false,
         };
-        if (props.root.children && typeof props.root.children.toArray === 'function' && !props.root.children.hasUnloadedData) {
+        if (
+            props.root.children &&
+            typeof props.root.children.toArray === 'function' &&
+            !props.root.children.hasUnloadedData
+        ) {
             this.state.children = props.root.children
                 .toArray()
                 // Sort here since the API returns nested children in random order
@@ -31,27 +35,33 @@ class OrgUnitTree extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.initiallyExpanded.some(ou => ou.includes(`/${this.props.root.id}`))) {
+        if (
+            this.props.initiallyExpanded.some(ou =>
+                ou.includes(`/${this.props.root.id}`)
+            )
+        ) {
             this.loadChildren();
         }
     }
 
     componentWillReceiveProps(newProps) {
         if (
-            newProps.initiallyExpanded.some(ou => ou.includes(`/${newProps.root.id}`)) ||
+            newProps.initiallyExpanded.some(ou =>
+                ou.includes(`/${newProps.root.id}`)
+            ) ||
             newProps.idsThatShouldBeReloaded.includes(newProps.root.id)
         ) {
             this.loadChildren();
         }
     }
 
-    onCollapse = (orgUnit) => {
+    onCollapse = orgUnit => {
         if (typeof this.props.onCollapse === 'function') {
             this.props.onCollapse(orgUnit);
         }
     };
 
-    onExpand = (orgUnit) => {
+    onExpand = orgUnit => {
         this.loadChildren();
 
         if (typeof this.props.onExpand === 'function') {
@@ -59,16 +69,21 @@ class OrgUnitTree extends React.Component {
         }
     };
 
-    onContextMenuClick = (e) => {
+    onContextMenuClick = e => {
         e.preventDefault();
         e.stopPropagation();
 
         if (this.props.onContextMenuClick !== undefined) {
-            this.props.onContextMenuClick(e, this.props.root, this.hasChildren(), this.loadChildren);
+            this.props.onContextMenuClick(
+                e,
+                this.props.root,
+                this.hasChildren(),
+                this.loadChildren
+            );
         }
     };
 
-    setChildState = (children) => {
+    setChildState = children => {
         let data = children;
 
         if (this.props.onChildrenLoaded) {
@@ -80,7 +95,9 @@ class OrgUnitTree extends React.Component {
         }
 
         this.setState({
-            children: data.sort((a, b) => a.displayName.localeCompare(b.displayName)),
+            children: data.sort((a, b) =>
+                a.displayName.localeCompare(b.displayName)
+            ),
             loading: false,
         });
     };
@@ -112,24 +129,30 @@ class OrgUnitTree extends React.Component {
         }
     };
 
-    handleSelectClick = (e) => {
+    handleSelectClick = e => {
         if (this.props.onSelectClick) {
             this.props.onSelectClick(e, this.props.root);
         }
         e.stopPropagation();
     };
 
-    hasChildren = () => this.state.children === undefined ||
+    hasChildren = () =>
+        this.state.children === undefined ||
         (Array.isArray(this.state.children) && this.state.children.length > 0);
 
-    shouldIncludeOrgUnit = (orgUnit) => {
-        if (!this.props.orgUnitsPathsToInclude || this.props.orgUnitsPathsToInclude.length === 0) {
+    shouldIncludeOrgUnit = orgUnit => {
+        if (
+            !this.props.orgUnitsPathsToInclude ||
+            this.props.orgUnitsPathsToInclude.length === 0
+        ) {
             return true;
         }
-        return !!(this.props.orgUnitsPathsToInclude.some(ou => ou.includes(`/${orgUnit.id}`)));
+        return !!this.props.orgUnitsPathsToInclude.some(ou =>
+            ou.includes(`/${orgUnit.id}`)
+        );
     };
 
-    setCurrentRoot = (e) => {
+    setCurrentRoot = e => {
         e.stopPropagation();
 
         this.props.onChangeCurrentRoot(this.props.root);
@@ -140,7 +163,9 @@ class OrgUnitTree extends React.Component {
             return null;
         }
 
-        const highlighted = this.props.searchResults.includes(orgUnit.path) && this.props.highlightSearchResults;
+        const highlighted =
+            this.props.searchResults.includes(orgUnit.path) &&
+            this.props.highlightSearchResults;
 
         return (
             <OrgUnitTree
@@ -156,7 +181,9 @@ class OrgUnitTree extends React.Component {
                 onChangeCurrentRoot={this.props.onChangeCurrentRoot}
                 labelStyle={{
                     ...this.props.labelStyle,
-                    fontWeight: highlighted ? 500 : this.props.labelStyle.fontWeight,
+                    fontWeight: highlighted
+                        ? 500
+                        : this.props.labelStyle.fontWeight,
                     color: highlighted ? 'orange' : 'inherit',
                 }}
                 selectedLabelStyle={this.props.selectedLabelStyle}
@@ -182,15 +209,28 @@ class OrgUnitTree extends React.Component {
         // If initiallyExpanded is an array, remove the current root id and pass the rest on
         // If it's a string, pass it on unless it's the current root id
         const expandedProp = Array.isArray(this.props.initiallyExpanded)
-            ? this.props.initiallyExpanded.filter(id => id !== this.props.root.id)
-            : (this.props.initiallyExpanded !== this.props.root.id && this.props.initiallyExpanded) || [];
+            ? this.props.initiallyExpanded.filter(
+                  id => id !== this.props.root.id
+              )
+            : (this.props.initiallyExpanded !== this.props.root.id &&
+                  this.props.initiallyExpanded) ||
+              [];
 
-        if (Array.isArray(this.state.children) && this.state.children.length > 0) {
-            return this.state.children.map(orgUnit => this.renderChild(orgUnit, expandedProp));
+        if (
+            Array.isArray(this.state.children) &&
+            this.state.children.length > 0
+        ) {
+            return this.state.children.map(orgUnit =>
+                this.renderChild(orgUnit, expandedProp)
+            );
         }
 
         if (this.state.loading) {
-            return <div style={styles.progress}><LinearProgress style={styles.progressBar} /></div>;
+            return (
+                <div style={styles.progress}>
+                    <LinearProgress style={styles.progressBar} />
+                </div>
+            );
         }
 
         return null;
@@ -210,42 +250,61 @@ class OrgUnitTree extends React.Component {
             fontWeight: isSelected ? 500 : 300,
             color: isSelected ? 'orange' : 'inherit',
             cursor: canBecomeCurrentRoot ? 'pointer' : 'default',
-            ...(isSelected ? this.props.selectedLabelStyle : this.props.labelStyle),
+            ...(isSelected
+                ? this.props.selectedLabelStyle
+                : this.props.labelStyle),
         };
-
 
         return (
             <div
                 style={labelStyle}
-                onClick={canBecomeCurrentRoot ? this.setCurrentRoot : (isSelectable ? this.handleSelectClick : undefined)}
+                onClick={
+                    canBecomeCurrentRoot
+                        ? this.setCurrentRoot
+                        : isSelectable
+                            ? this.handleSelectClick
+                            : undefined
+                }
                 onContextMenu={this.onContextMenuClick}
                 role="button"
                 tabIndex={0}
             >
-                {isSelectable && !this.props.hideCheckboxes && (
-                    <OUCheckboxComponent
-                        checked={isSelected}
-                        disabled={!isSelectable}
-                        onClick={this.handleSelectClick}
-                        color={this.props.checkboxColor}
-                    />
-                )}
-                {this.props.showFolderIcon && hasChildren && (
-                    <OUFolderIconComponent
-                        isExpanded={isInitiallyExpanded}
-                        styles={this.props.labelStyle.folderIcon}
-                    />
-                )}
-                {this.props.showFolderIcon && !hasChildren && (
-                    <StopIcon style={{ ...styles.stopIcon, ...this.props.labelStyle.stopIcon }} />
-                )}
-                <span style={this.props.labelStyle.text}>{currentOu.displayName}</span>
-                {hasChildren && !this.props.hideMemberCount && !!memberCount && (
-                    <span style={styles.memberCount}>({memberCount})</span>
-                )}
+                {isSelectable &&
+                    !this.props.hideCheckboxes && (
+                        <OUCheckboxComponent
+                            checked={isSelected}
+                            disabled={!isSelectable}
+                            onClick={this.handleSelectClick}
+                            color={this.props.checkboxColor}
+                        />
+                    )}
+                {this.props.showFolderIcon &&
+                    hasChildren && (
+                        <OUFolderIconComponent
+                            isExpanded={isInitiallyExpanded}
+                            styles={this.props.labelStyle.folderIcon}
+                        />
+                    )}
+                {this.props.showFolderIcon &&
+                    !hasChildren && (
+                        <StopIcon
+                            style={{
+                                ...styles.stopIcon,
+                                ...this.props.labelStyle.stopIcon,
+                            }}
+                        />
+                    )}
+                <span style={this.props.labelStyle.text}>
+                    {currentOu.displayName}
+                </span>
+                {hasChildren &&
+                    !this.props.hideMemberCount &&
+                    !!memberCount && (
+                        <span style={styles.memberCount}>({memberCount})</span>
+                    )}
             </div>
         );
-    };
+    }
 
     render() {
         const currentOu = this.props.root;
@@ -253,18 +312,26 @@ class OrgUnitTree extends React.Component {
         const isSelectable = !!this.props.onSelectClick;
         const pathRegEx = new RegExp(`/${currentOu.id}$`);
         const memberRegEx = new RegExp(`/${currentOu.id}`);
-        const isSelected = this.props.selected && this.props.selected.some(ou => pathRegEx.test(ou));
-        const isCurrentRoot = this.props.currentRoot && this.props.currentRoot.id === currentOu.id;
-        const isInitiallyExpanded = this.props.initiallyExpanded.some(ou => ou.includes(`/${currentOu.id}`));
-        const canBecomeCurrentRoot = this.props.onChangeCurrentRoot && !isCurrentRoot && hasChildren;
+        const isSelected =
+            this.props.selected &&
+            this.props.selected.some(ou => pathRegEx.test(ou));
+        const isCurrentRoot =
+            this.props.currentRoot &&
+            this.props.currentRoot.id === currentOu.id;
+        const isInitiallyExpanded = this.props.initiallyExpanded.some(ou =>
+            ou.includes(`/${currentOu.id}`)
+        );
+        const canBecomeCurrentRoot =
+            this.props.onChangeCurrentRoot && !isCurrentRoot && hasChildren;
 
-        const memberCount = this.props.selected !== undefined
-            ? this.props.selected.filter(ou => memberRegEx.test(ou)).length
-            : currentOu.memberCount;
+        const memberCount =
+            this.props.selected !== undefined
+                ? this.props.selected.filter(ou => memberRegEx.test(ou)).length
+                : currentOu.memberCount;
 
         const ouContainerStyle = {
             ...styles.ouContainer,
-            ...isCurrentRoot ? styles.currentOuContainer : {},
+            ...(isCurrentRoot ? styles.currentOuContainer : {}),
             ...this.props.treeStyle,
         };
 
@@ -311,9 +378,19 @@ class OrgUnitTree extends React.Component {
     }
 }
 
-function orgUnitPathPropValidator(propValue, key, compName, location, propFullName) {
+function orgUnitPathPropValidator(
+    propValue,
+    key,
+    compName,
+    location,
+    propFullName
+) {
     if (!/(\/[a-zA-Z][a-zA-Z0-9]{10})+/.test(propValue[key])) {
-        return new Error(`Invalid org unit path \`${propValue[key]}\` supplied to \`${compName}.${propFullName}\``);
+        return new Error(
+            `Invalid org unit path \`${
+                propValue[key]
+            }\` supplied to \`${compName}.${propFullName}\``
+        );
     }
     return undefined;
 }

--- a/packages/org-unit-tree/src/OrgUnitTree.component.js
+++ b/packages/org-unit-tree/src/OrgUnitTree.component.js
@@ -202,6 +202,7 @@ class OrgUnitTree extends React.Component {
                 disableSpacer={this.props.disableSpacer}
                 checkboxColor={this.props.checkboxColor}
                 displayNameProperty={this.props.displayNameProperty}
+                isUserDataViewFallback={this.props.isUserDataViewFallback}
             />
         );
     }

--- a/packages/org-unit-tree/src/OrgUnitTree.component.js
+++ b/packages/org-unit-tree/src/OrgUnitTree.component.js
@@ -121,7 +121,7 @@ class OrgUnitTree extends React.Component {
                 this.props.root,
                 this.props.displayNameProperty,
                 this.props.forceReloadChildren,
-                this.props.useUserDataViewFallback
+                this.props.isUserDataViewFallback
             );
 
             this.setChildState(children);
@@ -546,7 +546,7 @@ OrgUnitTree.propTypes = {
     /**
      * Indicates the userDataViewFallback parameter must be used in the requests made when expanding the tree
      */
-    useUserDataViewFallback: PropTypes.bool,
+    isUserDataViewFallback: PropTypes.bool,
 };
 
 OrgUnitTree.defaultProps = {
@@ -574,7 +574,7 @@ OrgUnitTree.defaultProps = {
     showFolderIcon: false,
     disableSpacer: false,
     checkboxColor: 'primary',
-    useUserDataViewFallback: false,
+    isUserDataViewFallback: false,
 };
 
 export default OrgUnitTree;

--- a/packages/org-unit-tree/src/OrgUnitTree.component.js
+++ b/packages/org-unit-tree/src/OrgUnitTree.component.js
@@ -120,7 +120,8 @@ class OrgUnitTree extends React.Component {
             const children = await loadChildren(
                 this.props.root,
                 this.props.displayNameProperty,
-                this.props.forceReloadChildren
+                this.props.forceReloadChildren,
+                this.props.useUserDataViewFallback
             );
 
             this.setChildState(children);
@@ -541,6 +542,11 @@ OrgUnitTree.propTypes = {
      * Prop function invoked when user opens context menu against org unit
      */
     onContextMenuClick: PropTypes.func,
+
+    /**
+     * Indicates the userDataViewFallback parameter must be used in the requests made when expanding the tree
+     */
+    useUserDataViewFallback: PropTypes.bool,
 };
 
 OrgUnitTree.defaultProps = {
@@ -568,6 +574,7 @@ OrgUnitTree.defaultProps = {
     showFolderIcon: false,
     disableSpacer: false,
     checkboxColor: 'primary',
+    useUserDataViewFallback: false,
 };
 
 export default OrgUnitTree;

--- a/packages/org-unit-tree/src/utils.js
+++ b/packages/org-unit-tree/src/utils.js
@@ -86,7 +86,7 @@ export const loadChildren = (
     root,
     displayNameProperty,
     forceReloadChildren,
-    useUserDataViewFallback
+    isUserDataViewFallback
 ) => {
     const fields = [
         'id',
@@ -101,7 +101,7 @@ export const loadChildren = (
         fields: fields.join(','),
     };
 
-    if (useUserDataViewFallback) {
+    if (isUserDataViewFallback) {
         options.userDataViewFallback = true;
     }
 

--- a/packages/org-unit-tree/src/utils.js
+++ b/packages/org-unit-tree/src/utils.js
@@ -85,7 +85,8 @@ export const mergeChildren = (root, children) => {
 export const loadChildren = (
     root,
     displayNameProperty,
-    forceReloadChildren
+    forceReloadChildren,
+    useUserDataViewFallback
 ) => {
     const fields = [
         'id',
@@ -96,10 +97,15 @@ export const loadChildren = (
         'parent',
     ];
 
+    const options = {
+        fields: fields.join(','),
+    };
+
+    if (useUserDataViewFallback) {
+        options.userDataViewFallback = true;
+    }
+
     // d2.ModelCollectionProperty.load takes a second parameter `forceReload` and will just return
     // the current valueMap unless either `this.hasUnloadedData` or `forceReload` are true
-    return root.children.load(
-        { fields: fields.join(',') },
-        forceReloadChildren
-    );
+    return root.children.load(options, forceReloadChildren);
 };

--- a/packages/org-unit-tree/src/utils.js
+++ b/packages/org-unit-tree/src/utils.js
@@ -6,7 +6,10 @@
  */
 export const forEachOnPath = (root, path, op) => {
     op(root);
-    if (path.length > 0 && (Array.isArray(root.children) || root.children.size > 0)) {
+    if (
+        path.length > 0 &&
+        (Array.isArray(root.children) || root.children.size > 0)
+    ) {
         if (root.children.has(path[0])) {
             forEachOnPath(root.children.get(path[0]), path.slice(1), op);
         } else {
@@ -22,7 +25,14 @@ export const forEachOnPath = (root, path, op) => {
  * @param orgUnit
  */
 export const decrementMemberCount = (root, orgUnit) => {
-    forEachOnPath(root, orgUnit.path.substr(1).split('/').slice(1), ou => ou.memberCount--);
+    forEachOnPath(
+        root,
+        orgUnit.path
+            .substr(1)
+            .split('/')
+            .slice(1),
+        ou => ou.memberCount--
+    );
 };
 
 /**
@@ -32,7 +42,14 @@ export const decrementMemberCount = (root, orgUnit) => {
  * @param orgUnit
  */
 export const incrementMemberCount = (root, orgUnit) => {
-    forEachOnPath(root, orgUnit.path.substr(1).split('/').slice(1), ou => ou.memberCount++);
+    forEachOnPath(
+        root,
+        orgUnit.path
+            .substr(1)
+            .split('/')
+            .slice(1),
+        ou => ou.memberCount++
+    );
 };
 
 /**
@@ -50,7 +67,10 @@ export const mergeChildren = (root, children) => {
         return root;
     }
 
-    const childPath = children.toArray()[0].path.substr(1).split('/');
+    const childPath = children
+        .toArray()[0]
+        .path.substr(1)
+        .split('/');
     childPath.splice(-1, 1);
     return assignChildren(root, childPath.slice(1), children);
 };
@@ -62,7 +82,11 @@ export const mergeChildren = (root, children) => {
  * @param forceReloadChildren
  * @returns {*}
  */
-export const loadChildren = (root, displayNameProperty, forceReloadChildren) => {
+export const loadChildren = (
+    root,
+    displayNameProperty,
+    forceReloadChildren
+) => {
     const fields = [
         'id',
         `${displayNameProperty}~rename(displayName)`,
@@ -74,6 +98,8 @@ export const loadChildren = (root, displayNameProperty, forceReloadChildren) => 
 
     // d2.ModelCollectionProperty.load takes a second parameter `forceReload` and will just return
     // the current valueMap unless either `this.hasUnloadedData` or `forceReload` are true
-    return root.children.load({ fields: fields.join(',') }, forceReloadChildren);
+    return root.children.load(
+        { fields: fields.join(',') },
+        forceReloadChildren
+    );
 };
-


### PR DESCRIPTION
Fixes DHIS2-7679.

Changes proposed in this pull request:

- allow propagation of multiple ou roots from apps to `OrgUnitTreeMultipleRoots` used internally by `OrgUnitSelector`

