### PR TITLE
chore: bump version to v6.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhis2/d2-ui",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Fixes DHIS2-7609.

Changes proposed in this pull request:

- bump version for updating dep in DV

(This cannot be pushed directly in master, it has to go through a PR)