### PR TITLE
refactor: add support for visualization AO type

### DIFF
--- a/packages/interpretations/i18n/en.pot
+++ b/packages/interpretations/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-02-27T09:42:27.795Z\n"
-"PO-Revision-Date: 2019-02-27T09:42:27.795Z\n"
+"POT-Creation-Date: 2020-01-08T11:20:59.368Z\n"
+"PO-Revision-Date: 2020-01-08T11:20:59.368Z\n"
 
 msgid "Pivot Tables"
 msgstr ""
@@ -30,6 +30,9 @@ msgid "Event Reports"
 msgstr ""
 
 msgid "Event Visualizer"
+msgstr ""
+
+msgid "Visualization details"
 msgstr ""
 
 msgid "View"

--- a/packages/interpretations/src/api/redirect.js
+++ b/packages/interpretations/src/api/redirect.js
@@ -6,6 +6,7 @@ export const MAP = 'MAP';
 export const REPORT_TABLE = 'REPORT_TABLE';
 export const EVENT_REPORT = 'EVENT_REPORT';
 export const EVENT_CHART = 'EVENT_CHART';
+export const VISUALIZATION = 'VISUALIZATION';
 
 export const extractFavorite = item => {
     if (!isObject(item)) {
@@ -23,6 +24,8 @@ export const extractFavorite = item => {
             return item.eventReport;
         case EVENT_CHART:
             return item.eventChart;
+        case VISUALIZATION:
+            return item.chart || item.reportTable;
         default:
             return (
                 item.reportTable ||
@@ -85,5 +88,12 @@ export const itemTypeMap = {
         propName:  'eventChart',
         appName: i18n.t('Event Visualizer'),
         detailsTitle: i18n.t('Chart details'),
+    },
+    [VISUALIZATION]: {
+        id: VISUALIZATION,
+        appUrl: (modelId, interpretationId) => `dhis-web-data-visualizer/#/${modelId}/interpretation/${interpretationId}`,
+        propName: 'visualization',
+        appName: i18n.t('Visualizer'),
+        detailsTitle: i18n.t('Visualization details'),
     },
 };


### PR DESCRIPTION
Fixes DHIS2-8118.

Changes proposed in this pull request:

- visualization type needs to be supported in the interpretations component in order to show the AO's details and load the interpretations

