### PR TITLE
fix: fix "Open in app" URL for visualization objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhis2/d2-ui",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {

--- a/packages/file-menu/src/GetLinkDialog.js
+++ b/packages/file-menu/src/GetLinkDialog.js
@@ -19,6 +19,7 @@ const getAppUrl = (fileType, fileId, context) => {
 
     switch (fileType) {
         case 'chart':
+        case 'visualization':
             appName = 'dhis-web-data-visualizer';
             appUrl = `dhis-web-data-visualizer/#/${fileId}`;
             break;


### PR DESCRIPTION
Fixes DHIS2-8208.

Changes proposed in this pull request:

- fix the "Open in app" URL for visualization type objects

