### PR TITLE
fix: upgrade dhis2/analytics in period-selector-dialog

### DIFF
--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -1,47 +1,47 @@
 {
-  "name": "@dhis2/d2-ui-period-selector-dialog",
-  "description": "Period selector dialog component for DHIS2",
-  "main": "./build/index.js",
-  "module": "./build/index.js",
-  "license": "BSD-3-Clause",
-  "author": "Ilya Nee <ilya@dhis2.org>",
-  "contributors": [
-    "Viktor Varland <viktor@dhis2.org>"
-  ],
-  "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
-  },
-  "scripts": {
-    "prebuild": "npm run lint && rimraf ./build/* && mkdirp ./build",
-    "build": "npm run build:css && babel src --out-dir build --ignore spec.js",
-    "build:css": "cp -R ./css/* ./build/",
-    "lint": "eslint src/",
-    "watch": "npm run build -- --watch",
-    "test-ci": "jest --config=../../jest.config.js packages/period-selector-dialog",
-    "test:watch": "npm test -- --watch"
-  },
-  "dependencies": {
-    "@dhis2/analytics": "^2.1.0",
-    "@dhis2/d2-i18n": "^1.0.4",
-    "@material-ui/core": "^3.3.1",
-    "@material-ui/icons": "^3.0.1",
-    "babel-runtime": "^6.26.0",
-    "prop-types": "^15.6.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run extract-pot && git add ./i18n"
-    }
-  },
-  "devDependencies": {
-    "babel-jest": "^23.0.1",
-    "enzyme": "^3.7.0",
-    "jest": "^23.1.0",
-    "mkdirp": "^0.5.1"
-  },
-  "version": "0.0.0-PLACEHOLDER"
+    "name": "@dhis2/d2-ui-period-selector-dialog",
+    "description": "Period selector dialog component for DHIS2",
+    "main": "./build/index.js",
+    "module": "./build/index.js",
+    "license": "BSD-3-Clause",
+    "author": "Ilya Nee <ilya@dhis2.org>",
+    "contributors": [
+        "Viktor Varland <viktor@dhis2.org>"
+    ],
+    "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0"
+    },
+    "scripts": {
+        "prebuild": "npm run lint && rimraf ./build/* && mkdirp ./build",
+        "build": "npm run build:css && babel src --out-dir build --ignore spec.js",
+        "build:css": "cp -R ./css/* ./build/",
+        "lint": "eslint src/",
+        "watch": "npm run build -- --watch",
+        "test-ci": "jest --config=../../jest.config.js packages/period-selector-dialog",
+        "test:watch": "npm test -- --watch"
+    },
+    "dependencies": {
+        "@dhis2/analytics": "^3.3.3",
+        "@dhis2/d2-i18n": "^1.0.4",
+        "@material-ui/core": "^3.3.1",
+        "@material-ui/icons": "^3.0.1",
+        "babel-runtime": "^6.26.0",
+        "prop-types": "^15.6.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "npm run extract-pot && git add ./i18n"
+        }
+    },
+    "devDependencies": {
+        "babel-jest": "^23.0.1",
+        "enzyme": "^3.7.0",
+        "jest": "^23.1.0",
+        "mkdirp": "^0.5.1"
+    },
+    "version": "0.0.0-PLACEHOLDER"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,6 +157,26 @@
     react-beautiful-dnd "^10.1.1"
     styled-jsx "^3.2.1"
 
+"@dhis2/analytics@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-3.3.3.tgz#17d77317ebe046710f3099abb90863423955d974"
+  integrity sha512-RDgu8bik1JTQdIwAv3jEkvx0ZhRcYRBW+4OHOtGwS/+8Mf3oTdwAA+myYLLKA2Al4PDyBoKxSXXGmRN+uRD+lw==
+  dependencies:
+    "@dhis2/d2-i18n" "^1.0.4"
+    "@dhis2/d2-ui-org-unit-dialog" "^6.3.2"
+    "@dhis2/d2-ui-period-selector-dialog" "^6.3.2"
+    "@dhis2/ui-core" "^4.7.1"
+    "@material-ui/core" "^3.9.3"
+    "@material-ui/icons" "^3.0.2"
+    classnames "^2.2.6"
+    d2-utilizr "^0.2.16"
+    d3-color "^1.2.3"
+    highcharts "^7.2.1"
+    lodash "^4.17.13"
+    react-beautiful-dnd "^10.1.1"
+    resize-observer-polyfill "^1.5.1"
+    styled-jsx "^3.2.1"
+
 "@dhis2/d2-i18n-extract@^1.0.6", "@dhis2/d2-i18n-extract@^1.0.7":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n-extract/-/d2-i18n-extract-1.0.7.tgz#805c92c75f5d3678a047374a551bda5f7571d7f3"
@@ -272,6 +292,16 @@
     lodash "^4.17.10"
     material-ui "^0.20.0"
 
+"@dhis2/d2-ui-core@6.5.5":
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-6.5.5.tgz#d75455a8388ef2c63a79824652a62f920441dfc6"
+  integrity sha512-5LQSB9Doy8X38qiDh9c4xmYtqhjKKi9NImi1JSqdHdL+rlaBXYxlnSX7Od/DtX4PMOBJt47dqOTF3s+UXitRVg==
+  dependencies:
+    babel-runtime "^6.26.0"
+    d2 "~31.7"
+    lodash "^4.17.10"
+    material-ui "^0.20.0"
+
 "@dhis2/d2-ui-org-unit-dialog@5.3.1":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-5.3.1.tgz#291fc5e1160b9820a8c1ee4bebc99c6b944b26b5"
@@ -301,6 +331,17 @@
   dependencies:
     "@dhis2/d2-i18n" "^1.0.3"
     "@dhis2/d2-ui-org-unit-tree" "6.1.1"
+    "@material-ui/core" "^3.3.1"
+    "@material-ui/icons" "^3.0.1"
+    prop-types "^15.5.10"
+
+"@dhis2/d2-ui-org-unit-dialog@^6.3.2":
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-6.5.5.tgz#3f793111bd1c2c61649c45430c2cb191074992b9"
+  integrity sha512-w1xg+YGib2SvezIF3V1PO4jBZVuIJgy1FxIzz/EKMkb/X9Nbt6NYlVbRCZh7v0idThKa1PgrhcxB5KWOWWoEnQ==
+  dependencies:
+    "@dhis2/d2-i18n" "^1.0.3"
+    "@dhis2/d2-ui-org-unit-tree" "6.5.5"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.5.10"
@@ -335,6 +376,16 @@
   integrity sha512-ys8br3vjbUaiOR0XjPfx6eZiMjU2DVFA5TnPsIX2rq9561MRU4nOyHNe21BdPvawUZO0L7nkrNy4xA8N8dwV2Q==
   dependencies:
     "@dhis2/d2-ui-core" "6.1.1"
+    "@material-ui/core" "^3.3.1"
+    babel-runtime "^6.26.0"
+    prop-types "^15.5.10"
+
+"@dhis2/d2-ui-org-unit-tree@6.5.5":
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-6.5.5.tgz#eabd3c2ad9a21e67f74aaa3b9b33c563bec710fc"
+  integrity sha512-PmHUGhPmsg5pgSdCVNDq9HdGF4L6uMqqzM5KpmSYY64z7FyupB9Azt0HuetRbXEnusDrQ72R0YCWv4av5FLi8Q==
+  dependencies:
+    "@dhis2/d2-ui-core" "6.5.5"
     "@material-ui/core" "^3.3.1"
     babel-runtime "^6.26.0"
     prop-types "^15.5.10"
@@ -379,6 +430,18 @@
     babel-runtime "^6.26.0"
     prop-types "^15.6.0"
 
+"@dhis2/d2-ui-period-selector-dialog@^6.3.2":
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-6.5.5.tgz#df3c704b79524fcbad207a3f4fbbb76f1e55addf"
+  integrity sha512-o2kDYjiUiWzi0TmPndFo7/jl1s9qEnQj7QEIcVR6UIRBoNzgP+NB0L6bus9mf4XEtBz3zHyD16PgYdDZPbSYhQ==
+  dependencies:
+    "@dhis2/analytics" "^2.1.0"
+    "@dhis2/d2-i18n" "^1.0.4"
+    "@material-ui/core" "^3.3.1"
+    "@material-ui/icons" "^3.0.1"
+    babel-runtime "^6.26.0"
+    prop-types "^15.6.0"
+
 "@dhis2/packages@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@dhis2/packages/-/packages-1.1.2.tgz#0bbdaa564b7a7f3dfe9bbcc9e4f0b02678af203b"
@@ -389,6 +452,22 @@
     fs-extra "^7.0.0"
     semver "^5.5.1"
     tape "^4.9.1"
+
+"@dhis2/prop-types@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-1.5.0.tgz#7e69919f66698be373dd21940a8a770234ded6a1"
+  integrity sha512-dueFkkAMOIMbXiU7Mhr3Y+DBRyOd/rHA+5/IDiYWN1xttlUTSuGZLQ5AnJ7osBicEhx+qElaGbTdRYQj3SMBtA==
+  dependencies:
+    prop-types "^15"
+
+"@dhis2/ui-core@^4.7.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.9.1.tgz#13ebaa43deceb5c3fa2955668c183131241847fa"
+  integrity sha512-ejKHYNiY49QIqgu6auLk6fL9It9+eZL1mmBk4Tqpst1u6YrSlnCyxfi/zV+UYqJLATAQX2aEAuB2ibRG5InZJA==
+  dependencies:
+    "@dhis2/prop-types" "^1.5.0"
+    "@popperjs/core" "^2.0.6"
+    classnames "^2.2.6"
 
 "@emotion/babel-utils@^0.6.4":
   version "0.6.10"
@@ -536,6 +615,11 @@
     "@babel/runtime" "^7.2.0"
     prop-types "^15.6.0"
     react-is "^16.6.3"
+
+"@popperjs/core@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.0.6.tgz#5a39ac118811ca844155b0ad5190b8c24f35e533"
+  integrity sha512-zj7Gw8QC4jmR92eKUvtrZUEpl2ypRbq+qlE4pwf9n2hnUO9BOAcWUs4/Ht+gNIbFt98xtqhLvccdCfD469MzpQ==
 
 "@sinonjs/commons@^1.0.2":
   version "1.3.0"
@@ -3807,13 +3891,6 @@ d2-utilizr@^0.2.15, d2-utilizr@^0.2.16:
     lodash.isset "^4.3.0"
     lodash.isstring "^4.0.1"
 
-d2@^31.1.1:
-  version "31.8.1"
-  resolved "https://registry.yarnpkg.com/d2/-/d2-31.8.1.tgz#017372001f9c8d3379a74c71c0382c98e9d2fc26"
-  integrity sha512-UpS2gv3DS4Bg7MrQTMNkYv5cXJ0k9jsujgw/p4Ex+el3gzslTf7fTH2n4gIZt42+l1tKmrs/R7yiJPov5Cax3w==
-  dependencies:
-    isomorphic-fetch "^2.2.1"
-
 d2@^31.7, d2@~31.7:
   version "31.7.0"
   resolved "https://registry.yarnpkg.com/d2/-/d2-31.7.0.tgz#3a843240fecaafdf213da78b55aed9b8611ee22e"
@@ -6076,6 +6153,11 @@ highcharts@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-7.1.2.tgz#f337e75cf0614f58f87fb28fbab48e1096265b5d"
   integrity sha512-diSTVxWKefQzShi22gaV63pdrIFlQAsTGe3f328Ur7cqBoYFvHMtiMP+q+VOFdM2mdGVtlUR0QQSxj62LLsPpg==
+
+highcharts@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-7.2.1.tgz#313c434bbfd4525a72b76c6bfbd9c39dfe2d1993"
+  integrity sha512-/fSUZiONmM+x49IQJNf8XwZGiNGOPRmxEOcd0xdJP9Xc3OlG46ZiUWgSLfhYQ9Oyhmzc3V3SKYCLud8+rKLi+w==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -8442,6 +8524,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.13:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 loglevel@^1.4.1, loglevel@^1.5.0, loglevel@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
@@ -10282,6 +10369,15 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
+prop-types@^15:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
@@ -10472,7 +10568,7 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-beautiful-dnd@^10.1.0, react-beautiful-dnd@^10.1.1:
+react-beautiful-dnd@^10.1.1:
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-10.1.1.tgz#d753088d77d7632e77cf8a8935fafcffa38f574b"
   integrity sha512-TdE06Shfp56wm28EzjgC56EEMgGI5PDHejJ2bxuAZvZr8CVsbksklsJC06Hxf0MSL7FHbflL/RpkJck9isuxHg==
@@ -10571,6 +10667,11 @@ react-is@^16.7.0:
   version "16.8.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.0.tgz#518db476214f3fb0716af9f82dfd420225ae970f"
   integrity sha512-LOy+3La39aduxaPfuj+lCXC5RQ8ukjVPAAsFJ3yQ+DIOLf4eR9OMKeWKF0IzjRyE95xMj5QELwiXGgfQsIJguA==
+
+react-is@^16.8.1:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
+  integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -11176,6 +11277,11 @@ requizzle@~0.2.1:
   integrity sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=
   dependencies:
     underscore "~1.6.0"
+
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Upgrade to the latest @dhis/analytics library. No new features or bug fixes. This is an attempt to resolve an issue in dashboards where a seemingly wrong version of ui-core is causing a showstopping error. It seems really unlikely that the version of ui-core in period-selector (via @dhis2/analytics) would be the cause, but keeping dependencies current is usually a good idea anyway, right? :)
