### PR TITLE
fix: label for selecting sub units in tree DHIS2-6562

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhis2/d2-ui",
-  "version": "6.5.8",
+  "version": "6.5.9",
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {

--- a/packages/org-unit-dialog/src/OrgUnitSelector.js
+++ b/packages/org-unit-dialog/src/OrgUnitSelector.js
@@ -241,7 +241,7 @@ class OrgUnitSelector extends Component {
                                     disabled={this.state.loadingChildren}
                                     dense
                                 >
-                                    {i18n.t('Select children')}
+                                    {i18n.t('Select all org units below')}
                                 </MenuItem>
                             </Menu>
                         </div>


### PR DESCRIPTION
Fixes DHIS2-6562.

Changes proposed in this pull request:

- rename label for selecting sub units

