### PR TITLE
fix: reset pagination when using filters (DHIS2-8451)

### DIFF
--- a/packages/favorites-dialog/src/actions/index.js
+++ b/packages/favorites-dialog/src/actions/index.js
@@ -73,6 +73,7 @@ export const filterData = (filter, value) => {
         }
 
         dispatch(fetchData());
+        dispatch(setPage(0));
     };
 };
 export const sortData = (event, column) => {


### PR DESCRIPTION
When a (new) filter is applied, always show the first page of the list,
regardless of which page was shown before the filter was applied.

Fixes https://jira.dhis2.org/browse/DHIS2-8451.

Changes proposed in this pull request:

- reset the pagination to the first page when a filter is added/removed
