### PR TITLE
fix: translations for pagination labels in FavoritesDialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhis2/d2-ui",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {

--- a/packages/favorites-dialog/i18n/en.pot
+++ b/packages/favorites-dialog/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-05-13T14:40:54.600Z\n"
-"PO-Revision-Date: 2020-05-13T14:40:54.600Z\n"
+"POT-Creation-Date: 2020-05-14T08:14:36.232Z\n"
+"PO-Revision-Date: 2020-05-14T08:14:36.232Z\n"
 
 msgid "Name"
 msgstr ""
@@ -18,12 +18,6 @@ msgid "Last updated"
 msgstr ""
 
 msgid "Type"
-msgstr ""
-
-msgid "{{from}}-{{to}} of {{total}}"
-msgstr ""
-
-msgid "{{from}}-{{to}} of more than {{to}}"
 msgstr ""
 
 msgid "Search by name"

--- a/packages/favorites-dialog/i18n/en.pot
+++ b/packages/favorites-dialog/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-04-30T20:43:22.797Z\n"
-"PO-Revision-Date: 2020-04-30T20:43:22.797Z\n"
+"POT-Creation-Date: 2020-05-13T14:40:54.600Z\n"
+"PO-Revision-Date: 2020-05-13T14:40:54.600Z\n"
 
 msgid "Name"
 msgstr ""
@@ -18,6 +18,12 @@ msgid "Last updated"
 msgstr ""
 
 msgid "Type"
+msgstr ""
+
+msgid "{{from}}-{{to}} of {{total}}"
+msgstr ""
+
+msgid "{{from}}-{{to}} of more than {{to}}"
 msgstr ""
 
 msgid "Search by name"

--- a/packages/favorites-dialog/src/EnhancedTable.js
+++ b/packages/favorites-dialog/src/EnhancedTable.js
@@ -138,18 +138,8 @@ const EnhancedTable = props => {
                             onChangePage={changePage}
                             labelDisplayedRows={({ from, to, count }) => {
                                 return count !== -1
-                                    ? i18n.t('{{from}}-{{to}} of {{total}}', {
-                                          from,
-                                          to,
-                                          total: count,
-                                      })
-                                    : i18n.t(
-                                          '{{from}}-{{to}} of more than {{to}}',
-                                          {
-                                              from,
-                                              to,
-                                          }
-                                      );
+                                    ? `${from}-${to} / ${count}`
+                                    : `${from}-${to} / ${to}`;
                             }}
                             //onChangeRowsPerPage={setRowsPerPage}
                             //rowsPerPageOptions={[5, 10, 15, 20]}

--- a/packages/favorites-dialog/src/EnhancedTable.js
+++ b/packages/favorites-dialog/src/EnhancedTable.js
@@ -13,9 +13,14 @@ import Tooltip from '@material-ui/core/Tooltip';
 
 import i18n from '@dhis2/d2-i18n';
 
-import {getVisTypeLabel, visTypeIcons} from './visTypes';
+import { getVisTypeLabel, visTypeIcons } from './visTypes';
 
-import { changePage, setRowsPerPage, sortData, selectFavorite } from './actions';
+import {
+    changePage,
+    setRowsPerPage,
+    sortData,
+    selectFavorite,
+} from './actions';
 
 const Time = ({ date }) => {
     const d = new Date(date);
@@ -84,7 +89,12 @@ const EnhancedTable = props => {
     return (
         <div>
             <Table>
-                <EnhancedTableHead order={order} column={column} sortData={sortData} showTypeColumn={showTypeColumn} />
+                <EnhancedTableHead
+                    order={order}
+                    column={column}
+                    sortData={sortData}
+                    showTypeColumn={showTypeColumn}
+                />
                 <TableBody>
                     {data.map(favorite => {
                         const visTypeIcon = visTypeIcons[favorite.type];
@@ -98,16 +108,17 @@ const EnhancedTable = props => {
                                 >
                                     {favorite.displayName}
                                 </TableCell>
-                                {showTypeColumn &&
-                                    <TableCell
-                                        padding="dense">
+                                {showTypeColumn && (
+                                    <TableCell padding="dense">
                                         <Tooltip
-                                            title={getVisTypeLabel(favorite.type)}
+                                            title={getVisTypeLabel(
+                                                favorite.type
+                                            )}
                                         >
                                             {visTypeIcon}
                                         </Tooltip>
                                     </TableCell>
-                                }
+                                )}
                                 <TableCell padding="dense">
                                     <Time date={favorite.created} />
                                 </TableCell>
@@ -167,4 +178,7 @@ const mapDispatchToProps = {
     selectFavorite,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(EnhancedTable);
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(EnhancedTable);

--- a/packages/favorites-dialog/src/EnhancedTable.js
+++ b/packages/favorites-dialog/src/EnhancedTable.js
@@ -125,6 +125,21 @@ const EnhancedTable = props => {
                             rowsPerPage={rowsPerPage}
                             page={page}
                             onChangePage={changePage}
+                            labelDisplayedRows={({ from, to, count }) => {
+                                return count !== -1
+                                    ? i18n.t('{{from}}-{{to}} of {{total}}', {
+                                          from,
+                                          to,
+                                          total: count,
+                                      })
+                                    : i18n.t(
+                                          '{{from}}-{{to}} of more than {{to}}',
+                                          {
+                                              from,
+                                              to,
+                                          }
+                                      );
+                            }}
                             //onChangeRowsPerPage={setRowsPerPage}
                             //rowsPerPageOptions={[5, 10, 15, 20]}
                             rowsPerPageOptions={[]}


### PR DESCRIPTION
Fixes DHIS2-8638.
https://jira.dhis2.org/browse/DHIS2-8638

Changes proposed in this pull request:

- mark the pagination labels without words to prevent translation

Before:
<img width="394" alt="Screenshot 2020-05-14 at 09 26 37" src="https://user-images.githubusercontent.com/150978/81905511-187a8500-95c5-11ea-984f-ae5e40430535.png">

After:
![image](https://user-images.githubusercontent.com/12590483/81910476-4e6f3780-95cc-11ea-99a6-305e12ecce96.png)
