### PR TITLE
fix: correctly detect italic/bold marker after non-word char  (DHIS2-9382)

### DIFF
--- a/packages/rich-text/src/parser/MdParser.js
+++ b/packages/rich-text/src/parser/MdParser.js
@@ -25,7 +25,7 @@ const codes = {
         domEl: "em",
         encodedChar: 0x5f,
         // see https://regex101.com/r/p6LpjK/6 for explanation of regexp
-        regexString: "\\b_((?!\\s)[^_]+(\\B|[^_\\s]))_\\b",
+        regexString: "\\b_((?!\\s)[^_]+(?:\\B|[^_\\s]))_\\b",
         contentFn: val => val,
     },
     emoji: {

--- a/packages/rich-text/src/parser/MdParser.js
+++ b/packages/rich-text/src/parser/MdParser.js
@@ -15,8 +15,8 @@ const codes = {
         char: "*",
         domEl: "strong",
         encodedChar: 0x2a,
-        // see https://regex101.com/r/evswdV/7 for explanation of regexp
-        regexString: "\\B\\*((?!\\s)[^*]+)(?:\\b|[^*\\s])\\*\\B",
+        // see https://regex101.com/r/evswdV/8 for explanation of regexp
+        regexString: "\\B\\*((?!\\s)[^*]+(?:\\b|[^*\\s]))\\*\\B",
         contentFn: val => val,
     },
     italic: {

--- a/packages/rich-text/src/parser/MdParser.js
+++ b/packages/rich-text/src/parser/MdParser.js
@@ -24,8 +24,8 @@ const codes = {
         char: "_",
         domEl: "em",
         encodedChar: 0x5f,
-        // see https://regex101.com/r/p6LpjK/5 for explanation of regexp
-        regexString: "\\b_((?!\\s)[^_]+)\\B_\\b",
+        // see https://regex101.com/r/p6LpjK/6 for explanation of regexp
+        regexString: "\\b_((?!\\s)[^_]+(\\B|[^_\\s]))_\\b",
         contentFn: val => val,
     },
     emoji: {

--- a/packages/rich-text/src/parser/MdParser.js
+++ b/packages/rich-text/src/parser/MdParser.js
@@ -15,8 +15,8 @@ const codes = {
         char: "*",
         domEl: "strong",
         encodedChar: 0x2a,
-        // see https://regex101.com/r/evswdV/6 for explanation of regexp
-        regexString: "\\B\\*((?!\\s)[^*]+)\\b\\*\\B",
+        // see https://regex101.com/r/evswdV/7 for explanation of regexp
+        regexString: "\\B\\*((?!\\s)[^*]+)(?:\\b|[^*\\s])\\*\\B",
         contentFn: val => val,
     },
     italic: {

--- a/packages/rich-text/src/parser/__tests__/MdParser.spec.js
+++ b/packages/rich-text/src/parser/__tests__/MdParser.spec.js
@@ -62,6 +62,9 @@ describe('MdParser class', () => {
             ['_italic_ and *bold* with a example.com/link_with_underscore', '<em>italic</em> and <strong>bold</strong> with a <a href="http://example.com/link_with_underscore">example.com/link_with_underscore</a>'],
             ['example.com/path with *bold* after :)', '<a href="http://example.com/path">example.com/path</a> with <strong>bold</strong> after <span>\u{1F642}</span>'],
             ['_before_ example.com/path_with_underscore *after* :)', '<em>before</em> <a href="http://example.com/path_with_underscore">example.com/path_with_underscore</a> <strong>after</strong> <span>\u{1F642}</span>'],
+
+            // italic markers right after non-word characters
+            ['_If % of ART retention rate after 12 months >90(%)_: Sustain the efforts.', '<em>If % of ART retention rate after 12 months &gt;90(%)</em>: Sustain the efforts.'],
         ];
 
         tests.forEach((test) => {

--- a/packages/rich-text/src/parser/__tests__/MdParser.spec.js
+++ b/packages/rich-text/src/parser/__tests__/MdParser.spec.js
@@ -63,8 +63,9 @@ describe('MdParser class', () => {
             ['example.com/path with *bold* after :)', '<a href="http://example.com/path">example.com/path</a> with <strong>bold</strong> after <span>\u{1F642}</span>'],
             ['_before_ example.com/path_with_underscore *after* :)', '<em>before</em> <a href="http://example.com/path_with_underscore">example.com/path_with_underscore</a> <strong>after</strong> <span>\u{1F642}</span>'],
 
-            // italic markers right after non-word characters
+            // italic/bold markers right after non-word characters
             ['_If % of ART retention rate after 12 months >90(%)_: Sustain the efforts.', '<em>If % of ART retention rate after 12 months &gt;90(%)</em>: Sustain the efforts.'],
+            ['*If % of ART retention rate after 12 months >90(%)*: Sustain the efforts.', '<strong>If % of ART retention rate after 12 months &gt;90(%)</strong>: Sustain the efforts.'],
         ];
 
         tests.forEach((test) => {


### PR DESCRIPTION
Fixes [DHIS2-9382](https://jira.dhis2.org/browse/DHIS2-9382).

Changes proposed in this pull request:

- fix regexp for correctly detecting the closing italic/bold marker when is preceded by a non-word character.

Fixes the specific case reported in the ticket and any other string where a non-word character is the last character before the closing italic/bold marker.

