### PR TITLE
fix: lock the Dialog width so it doesn't jump when paginating

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhis2/d2-ui",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {

--- a/packages/favorites-dialog/src/Favorites.js
+++ b/packages/favorites-dialog/src/Favorites.js
@@ -33,7 +33,7 @@ class Favorites extends Component {
         const showTypeColumn = /visualization|chart/.test(type);
 
         return (
-            <Dialog open={open} onClose={onRequestClose} disableEnforceFocus maxWidth="lg">
+            <Dialog open={open} onClose={onRequestClose} disableEnforceFocus maxWidth="md" fullWidth>
                 <DialogContent>
                     <EnhancedToolbar showTypeFilter={showTypeColumn} />
                     <EnhancedTable showTypeColumn={showTypeColumn} onFavoriteSelect={handleOnFavoriteSelect} />


### PR DESCRIPTION
I'm not exactly sure what happened between 2.34 and 2.35.
My theory is that in 2.35 we removed MUI dep in DV and now the MUI version used in DV is the one defined as dep of d2-ui, which happen to be a more recent version of what we have in DV in 2.34.
The behaviour of `maxWidth` has probably changed in MUI (different CSS).

The problem is the Dialog width jumping when paginating.
By passing `fullWidth` together with `maxWidth`, the width is always stretched to `maxWidth`.

Changed `maxWidth` to `md` as `lg` looks way too large on wide screens.
If the `md` size does not fit in the screen, the whole Dialog is resized.

![ezgif com-optimize (1)](https://user-images.githubusercontent.com/150978/92487419-83dc0880-f1ed-11ea-804b-4ba9e0b8cb66.gif)
