### PR TITLE
fix: org-unit-dialog z-index issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhis2/d2-ui",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {

--- a/packages/org-unit-dialog/src/GridControl.js
+++ b/packages/org-unit-dialog/src/GridControl.js
@@ -27,6 +27,9 @@ const GridControl = ({ label, placeholder, options, ...selectProps }) => {
                     renderValue={renderValue}
                     displayEmpty
                     fullWidth
+                    MenuProps={{
+                        style: { zIndex: 3100 }
+                    }}
                 >
                     {options.map(option => (
                         <MenuItem

--- a/packages/org-unit-dialog/src/OrgUnitSelector.js
+++ b/packages/org-unit-dialog/src/OrgUnitSelector.js
@@ -235,6 +235,7 @@ class OrgUnitSelector extends Component {
                                 anchorEl={this.state.menuAnchorElement}
                                 open={Boolean(this.state.menuAnchorElement)}
                                 onClose={this.closeContextMenu}
+                                style={{ zIndex: 3100 }}
                             >
                                 <MenuItem
                                     onClick={this.selectChildren}


### PR DESCRIPTION
Bumps the z-index of the right-click menu and the two select elements in the org-unit-dialog to be compatible with @dhis2/ui z-index ranges. When used within a @dhis2/ui `Modal` (z-index 3000) the z-index needs to be higher than the modal's, which is why 3100 is used.

-----------

![image](https://user-images.githubusercontent.com/12590483/93063980-4953ef00-f677-11ea-8f61-8f20b0ae2999.png)
![image](https://user-images.githubusercontent.com/12590483/93064040-5f61af80-f677-11ea-8feb-96b97f832904.png)
![image](https://user-images.githubusercontent.com/12590483/93063999-4eb13980-f677-11ea-8e39-d6085555a4d9.png)
