### PR TITLE
fix: replace unsafe componentWillReceiveProps method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhis2/d2-ui",
-  "version": "7.0.8",
+  "version": "7.0.9",
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {

--- a/packages/favorites-dialog/src/Favorites.js
+++ b/packages/favorites-dialog/src/Favorites.js
@@ -14,9 +14,24 @@ import EnhancedTable from './EnhancedTable';
 import { fetchData } from './actions';
 
 class Favorites extends Component {
-    componentWillReceiveProps(nextProps) {
+    componentDidMount() {
         // fetch data only the first time the dialog is open
-        if (nextProps.open && (!nextProps.dataIsLoaded || nextProps.refreshData)) {
+        if (
+            this.props.open &&
+            (!this.props.dataIsLoaded || this.props.refreshData)
+        ) {
+            this.props.fetchData();
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (
+            this.props.open !== prevProps.open &&
+            this.props.open &&
+            (!this.props.dataIsLoaded ||
+                this.props.refreshData ||
+                this.props.type !== prevProps.type)
+        ) {
             this.props.fetchData();
         }
     }
@@ -33,13 +48,24 @@ class Favorites extends Component {
         const showTypeColumn = /visualization|chart/.test(type);
 
         return (
-            <Dialog open={open} onClose={onRequestClose} disableEnforceFocus maxWidth="md" fullWidth>
+            <Dialog
+                open={open}
+                onClose={onRequestClose}
+                disableEnforceFocus
+                maxWidth="md"
+                fullWidth
+            >
                 <DialogContent>
                     <EnhancedToolbar showTypeFilter={showTypeColumn} />
-                    <EnhancedTable showTypeColumn={showTypeColumn} onFavoriteSelect={handleOnFavoriteSelect} />
+                    <EnhancedTable
+                        showTypeColumn={showTypeColumn}
+                        onFavoriteSelect={handleOnFavoriteSelect}
+                    />
                 </DialogContent>
                 <DialogActions>
-                    <Button color="primary" onClick={onRequestClose}>{i18n.t('Close')}</Button>
+                    <Button color="primary" onClick={onRequestClose}>
+                        {i18n.t('Close')}
+                    </Button>
                 </DialogActions>
             </Dialog>
         );
@@ -56,7 +82,7 @@ Favorites.propTypes = {
     fetchData: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
     dataIsLoaded: state.data.totalRecords > 0,
 });
 
@@ -64,7 +90,4 @@ const mapDispatchToProps = {
     fetchData,
 };
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(Favorites);
+export default connect(mapStateToProps, mapDispatchToProps)(Favorites);

--- a/packages/favorites-dialog/src/Favorites.js
+++ b/packages/favorites-dialog/src/Favorites.js
@@ -15,7 +15,6 @@ import { fetchData } from './actions';
 
 class Favorites extends Component {
     componentDidMount() {
-        // fetch data only the first time the dialog is open
         if (
             this.props.open &&
             (!this.props.dataIsLoaded || this.props.refreshData)


### PR DESCRIPTION
Required by https://github.com/dhis2/analytics/pull/655.

The new FileMenu uses `@dhis2/ui` components.
Conditional rendering is used to open a Popover component, since it doesn't have a `open` prop that can be toggled.
The problem was that the FavoritesDialog need to be added to the DOM with the `open` and `refreshData` props already set to `true`.
The old `componentWillReceiveProps`, never triggered, because those
props don't change in that case, they are just set when the `FavoritesDialog`
component renders.
`componentDidMount` is executed after the component is rendered, so the
condition for `open` and `refreshData` is checked also when using the
component without toggling the `open` prop.
`componentDidUpdate` is executed when a prop changes, this is triggered
when using the old approach of toggling the open prop.