### PR TITLE
fix: bump version to v7.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhis2/d2-ui",
-  "version": "7.0.9",
+  "version": "7.0.10",
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {


### PR DESCRIPTION
I didn't realise 7.0.9 was already released when merging #657 