### PR TITLE
fix: add scrollbar for sharing dialog search results and limit result size from api request [DHIS2 6801]

### DIFF
--- a/packages/sharing-dialog/src/AutoComplete.component.js
+++ b/packages/sharing-dialog/src/AutoComplete.component.js
@@ -66,7 +66,7 @@ const styles = theme => ({
     suggestionPaper: {
         maxHeight: 100,
         overflow: 'auto',
-    },    
+    },
 });
 
 let popperNode;
@@ -108,8 +108,8 @@ class AutoComplete extends Component {
                                 {isOpen && (
                                     <Popper className={classes.popper} open anchorEl={popperNode}>
                                         <Paper 
-                                            className={classes.suggestionPaper} 
-                                            square 
+                                            className={classes.suggestionPaper}
+                                            square
                                             style={{ width: popperNode ? popperNode.clientWidth : null }}
                                         >
                                             {suggestions.map((suggestion, index) => {

--- a/packages/sharing-dialog/src/AutoComplete.component.js
+++ b/packages/sharing-dialog/src/AutoComplete.component.js
@@ -63,6 +63,10 @@ const styles = theme => ({
     inputRoot: {
         flexWrap: 'wrap',
     },
+    suggestionPaper: {
+        maxHeight: 100,
+        overflow: 'auto',
+    },    
 });
 
 let popperNode;
@@ -103,7 +107,11 @@ class AutoComplete extends Component {
                             <div {...getMenuProps()}>
                                 {isOpen && (
                                     <Popper className={classes.popper} open anchorEl={popperNode}>
-                                        <Paper square style={{ width: popperNode ? popperNode.clientWidth : null }}>
+                                        <Paper 
+                                            className={classes.suggestionPaper} 
+                                            square 
+                                            style={{ width: popperNode ? popperNode.clientWidth : null }}
+                                        >
                                             {suggestions.map((suggestion, index) => {
                                                 return (
                                                     <Suggestion

--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -77,9 +77,9 @@ class SharingDialog extends React.Component {
         }
     }
 
-    onSearchRequest = key =>
+    onSearchRequest = (key, pageSize) =>
         this.props.d2.Api.getApi()
-            .get('sharing/search', { key })
+            .get('sharing/search', { key, pageSize })
             .then(searchResult => searchResult);
 
     onSharingChanged = (updatedAttributes, onSuccess) => {

--- a/packages/sharing-dialog/src/UserSearch.component.js
+++ b/packages/sharing-dialog/src/UserSearch.component.js
@@ -30,7 +30,8 @@ const styles = {
     },
 };
 
-const searchDelay = 300;
+const searchDelay = 500;
+const searchResultsCount = 10;
 
 class UserSearch extends Component {
     constructor(props, context) {
@@ -94,7 +95,7 @@ class UserSearch extends Component {
         if (searchText === '') {
             this.handleSearchResult([]);
         } else {
-            this.props.onSearch(searchText).then(({ users, userGroups }) => {
+            this.props.onSearch(searchText, searchResultsCount).then(({ users, userGroups }) => {
                 const addType = type => result => ({ ...result, type });
                 const searchResult = users
                     .map(addType('userAccess'))


### PR DESCRIPTION
Fixes DHIS2-6801.

Changes proposed in this pull request:

- adds scroll bar to sharing dialogue suggestions
- limits sharing dialogue suggestions to 10 results
- increases debounce time on search to .5 seconds

(this implements PEPFAR's requested changes as laid out in the JIRA issue's comments)

