### PR TITLE
chore: move ItemSelector component from analytics to PeriodSelector

### DIFF
--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -74,6 +74,9 @@ class App extends Component {
                     <HeaderBarExample d2={this.state.d2} />
                     <p>Look at the top of the screen...</p>
 
+                    <h2>Period selector</h2>
+                    <PeriodSelector d2={this.state.d2} />
+
                     <h2>Rich Text</h2>
                     <RichTextExample />
 
@@ -143,8 +146,7 @@ class App extends Component {
                     <h2>FormEditor</h2>
                     <FormEditor />
 
-                    <h2>Period selector</h2>
-                    <PeriodSelector d2={this.state.d2} />
+                    
 
                     <h2>OrgUnitSelect</h2>
                     <OrgUnitSelect d2={this.state.d2} />

--- a/examples/create-react-app/src/App.js
+++ b/examples/create-react-app/src/App.js
@@ -74,9 +74,6 @@ class App extends Component {
                     <HeaderBarExample d2={this.state.d2} />
                     <p>Look at the top of the screen...</p>
 
-                    <h2>Period selector</h2>
-                    <PeriodSelector d2={this.state.d2} />
-
                     <h2>Rich Text</h2>
                     <RichTextExample />
 
@@ -146,7 +143,8 @@ class App extends Component {
                     <h2>FormEditor</h2>
                     <FormEditor />
 
-                    
+                    <h2>Period selector</h2>
+                    <PeriodSelector d2={this.state.d2} />
 
                     <h2>OrgUnitSelect</h2>
                     <OrgUnitSelect d2={this.state.d2} />

--- a/packages/period-selector-dialog/css/PeriodSelector.css
+++ b/packages/period-selector-dialog/css/PeriodSelector.css
@@ -188,12 +188,16 @@ button.nav-button:last-child {
     width: 130px;
 }
 
-.unselected-period-item:hover {
-    background-color: #e0e0e0;
+.unselected-period-item:not(.highlighted):hover {
+    background-color: #e0e0e0 !important;
 }
 
-.selected-period-item:hover {
-    background-color: '#86c4bf';
+.selected-period-item:not(.highlighted):hover {
+    background-color: #86c4bf !important;
+}
+
+.item-selector-arrow-button {
+    background-color: transparent;
 }
 
 .item-selector-arrow-button:focus {

--- a/packages/period-selector-dialog/css/PeriodSelector.css
+++ b/packages/period-selector-dialog/css/PeriodSelector.css
@@ -187,3 +187,33 @@ button.nav-button:last-child {
 #year-select-menu {
     width: 130px;
 }
+
+.unselected-period-item:hover {
+    background-color: #e0e0e0;
+}
+
+.selected-period-item:hover {
+    background-color: '#86c4bf';
+}
+
+.item-selector-arrow-button:focus {
+    outline: 'none';
+}
+
+.item-selector-arrow-button:active:focus {
+    background-color: rgba(158, 158, 158, 0.18);
+}
+
+.item-selector-arrow-button:hover {
+    cursor: pointer;
+    background-color: rgba(158, 158, 158, 0.07);
+}
+
+.selected-list-item {
+    display: flex;
+    margin: 2px;
+}
+
+.selected-list-item:focus {
+    outline: none;
+}

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -26,6 +26,7 @@
         "@material-ui/core": "^3.3.1",
         "@material-ui/icons": "^3.0.1",
         "babel-runtime": "^6.26.0",
+        "classnames": "^2.2.6",
         "prop-types": "^15.6.0",
         "react-beautiful-dnd": "^10.1.1"
     },

--- a/packages/period-selector-dialog/package.json
+++ b/packages/period-selector-dialog/package.json
@@ -23,11 +23,11 @@
         "test:watch": "npm test -- --watch"
     },
     "dependencies": {
-        "@dhis2/analytics": "^4.0.1",
         "@material-ui/core": "^3.3.1",
         "@material-ui/icons": "^3.0.1",
         "babel-runtime": "^6.26.0",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.0",
+        "react-beautiful-dnd": "^10.1.1"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/period-selector-dialog/src/ItemSelector/ItemSelector.js
+++ b/packages/period-selector-dialog/src/ItemSelector/ItemSelector.js
@@ -1,0 +1,91 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+import UnselectedItems from './UnselectedItems'
+import SelectedItems from './SelectedItems'
+
+const styles = {
+    itemSelectorContainer: {
+        boxSizing: 'border-box',
+        display: 'flex',
+        flex: '1 1 auto',
+        fontFamily: 'Roboto, sans-serif',
+    },
+    section: {
+        border: '1px solid #e8edf2',
+        display: 'flex',
+        flexDirection: 'column',
+        height: '480px',
+        position: 'relative',
+    },
+    unselected: {
+        marginRight: '55px',
+        width: '418px',
+    },
+    selected: {
+        width: '276px',
+    }
+}
+
+class ItemSelector extends Component {
+    render() {
+        const {
+            unselected,
+            selected,
+            children: filterZone,
+            dataTest,
+        } = this.props
+
+        const unselectedStyle = Object.assign({}, styles.section, styles.unselected)
+        const selectedStyle = Object.assign({}, styles.section, styles.selected)
+
+        return (
+            <div style={styles.itemSelectorContainer} data-test={dataTest}>
+                <div style={unselectedStyle}>
+                    {filterZone}
+                    <UnselectedItems
+                        {...unselected}
+                        dataTest={`${dataTest}-unselected-items`}
+                    />
+                </div>
+                <div style={selectedStyle}>
+                    <SelectedItems
+                        {...selected}
+                        dataTest={`${dataTest}-selected-items`}
+                    />
+                </div>
+            </div>
+        )
+    }
+}
+
+ItemSelector.propTypes = {
+    children: PropTypes.object,
+    dataTest: PropTypes.string,
+    selected: PropTypes.shape({
+        items: PropTypes.arrayOf(
+            PropTypes.shape({
+                id: PropTypes.string.isRequired,
+                name: PropTypes.string.isRequired,
+                isActive: PropTypes.bool,
+            })
+        ).isRequired,
+        onDeselect: PropTypes.func.isRequired,
+        onReorder: PropTypes.func.isRequired,
+        dialogId: PropTypes.string,
+        infoBoxMessage: PropTypes.string,
+    }),
+    unselected: PropTypes.shape({
+        items: PropTypes.arrayOf(
+            PropTypes.shape({
+                id: PropTypes.string.isRequired,
+                name: PropTypes.string.isRequired,
+            })
+        ).isRequired,
+        onSelect: PropTypes.func.isRequired,
+        filterText: PropTypes.string,
+        requestMoreItems: PropTypes.func,
+    }),
+}
+
+export default ItemSelector

--- a/packages/period-selector-dialog/src/ItemSelector/ItemSelector.js
+++ b/packages/period-selector-dialog/src/ItemSelector/ItemSelector.js
@@ -33,26 +33,19 @@ class ItemSelector extends Component {
             unselected,
             selected,
             children: filterZone,
-            dataTest,
         } = this.props
 
         const unselectedStyle = Object.assign({}, styles.section, styles.unselected)
         const selectedStyle = Object.assign({}, styles.section, styles.selected)
 
         return (
-            <div style={styles.itemSelectorContainer} data-test={dataTest}>
+            <div style={styles.itemSelectorContainer}>
                 <div style={unselectedStyle}>
                     {filterZone}
-                    <UnselectedItems
-                        {...unselected}
-                        dataTest={`${dataTest}-unselected-items`}
-                    />
+                    <UnselectedItems {...unselected} />
                 </div>
                 <div style={selectedStyle}>
-                    <SelectedItems
-                        {...selected}
-                        dataTest={`${dataTest}-selected-items`}
-                    />
+                    <SelectedItems {...selected} />
                 </div>
             </div>
         )
@@ -61,7 +54,6 @@ class ItemSelector extends Component {
 
 ItemSelector.propTypes = {
     children: PropTypes.object,
-    dataTest: PropTypes.string,
     selected: PropTypes.shape({
         items: PropTypes.arrayOf(
             PropTypes.shape({

--- a/packages/period-selector-dialog/src/ItemSelector/SelectedItems.js
+++ b/packages/period-selector-dialog/src/ItemSelector/SelectedItems.js
@@ -11,9 +11,6 @@ import { toggler } from './modules/toggler'
 import { reorderList } from './modules/reorderList'
 import styles from './styles/SelectedItems.style'
 
-console.log('styles.selectedListItem', styles.selectedListItem)
-const mystyle = styles.selectedListItem
-
 const Subtitle = () => (
     <div style={styles.subtitleContainer}>
         <span style={styles.subtitleText}>{i18n.t('Selected Data')}</span>

--- a/packages/period-selector-dialog/src/ItemSelector/SelectedItems.js
+++ b/packages/period-selector-dialog/src/ItemSelector/SelectedItems.js
@@ -1,0 +1,285 @@
+import React, { Component, Fragment } from 'react'
+import PropTypes from 'prop-types'
+import i18n from '@dhis2/d2-i18n'
+import InfoIcon from '@material-ui/icons/InfoOutlined'
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd'
+import Button from '@material-ui/core/Button';
+
+import Item from './widgets/SelectedItem'
+import { ArrowButton as UnAssignButton } from './widgets/ArrowButton'
+import { toggler } from './modules/toggler'
+import { reorderList } from './modules/reorderList'
+import styles from './styles/SelectedItems.style'
+
+console.log('styles.selectedListItem', styles.selectedListItem)
+const mystyle = styles.selectedListItem
+
+const Subtitle = () => (
+    <div style={styles.subtitleContainer}>
+        <span style={styles.subtitleText}>{i18n.t('Selected Data')}</span>
+    </div>
+)
+
+const InfoBox = ({ message, dataTest }) => (
+    <div style={styles.infoTontainer} data-test={dataTest}>
+        <InfoIcon style={{ fontSize: 16, color: '#6e7a8a' }} />
+        <span style={styles.infoText}>{message}</span>
+    </div>
+)
+
+const ItemsList = ({ innerRef, children, dataTest }) => (
+    <ul style={styles.selectedList} ref={innerRef} data-test={dataTest}>
+        {children}
+    </ul>
+)
+
+const CLONE_INDEX = 9999 // a high number to not influence the actual item list
+
+export class SelectedItems extends Component {
+    state = { highlighted: [], lastClickedIndex: 0, draggingId: null }
+
+    onDeselectHighlighted = () => {
+        this.props.onDeselect(this.state.highlighted)
+        this.setState({ highlighted: [] })
+    }
+
+    onDeselectOne = id => {
+        const highlighted = this.state.highlighted.filter(
+            highlightedId => highlightedId !== id
+        )
+
+        this.props.onDeselect([id])
+        this.setState({ highlighted })
+    }
+
+    onDeselectAll = () => {
+        this.props.onDeselect(this.props.items.map(item => item.id))
+        this.setState({ highlighted: [] })
+    }
+
+    toggleHighlight = ({ isCtrlPressed, isShiftPressed, index, id }) => {
+        const newState = toggler({
+            id,
+            isCtrlPressed,
+            isShiftPressed,
+            index,
+            lastClickedIndex: this.state.lastClickedIndex,
+            highlightedIds: this.state.highlighted,
+            items: this.props.items.map(item => item.id),
+        })
+
+        this.setState({
+            highlighted: newState.ids,
+            lastClickedIndex: newState.lastClickedIndex,
+        })
+    }
+
+    isMultiDrag = draggableId => {
+        return (
+            this.state.highlighted.includes(draggableId) &&
+            this.state.highlighted.length > 1
+        )
+    }
+
+    onDragStart = start => {
+        const id = start.draggableId
+        const selected = this.state.highlighted.find(itemId => itemId === id)
+
+        // if dragging an item that is not highlighted, unhighlight all items
+        if (!selected) {
+            this.setState({ highlighted: [] })
+        }
+
+        this.setState({ draggingId: start.draggableId })
+    }
+
+    onDragEnd = ({ destination, source, draggableId }) => {
+        this.setState({ draggingId: null })
+
+        if (destination === null) {
+            return
+        }
+
+        if (
+            destination.draggableId === source.draggableId &&
+            destination.index === source.index
+        ) {
+            return
+        }
+
+        const newList = reorderList({
+            destinationIndex: destination.index,
+            sourceIndex: source.index,
+            draggableId,
+            isMultiDrag: this.isMultiDrag(draggableId),
+            items: this.props.items,
+            highlightedItemIds: this.state.highlighted,
+        })
+
+        this.props.onReorder(newList)
+    }
+
+    renderListItem = ({ id, name, isActive }, index) => (
+        <Draggable draggableId={id} index={index} key={id}>
+            {(provided, snapshot) => {
+                const isDraggedItem =
+                    snapshot.isDragging &&
+                    this.state.highlighted.length > 1 &&
+                    this.state.highlighted.includes(this.state.draggingId)
+
+                const ghost =
+                    this.state.highlighted.includes(id) &&
+                    Boolean(this.state.draggingId) &&
+                    this.state.draggingId !== id
+
+                const itemText = isDraggedItem
+                    ? `${this.state.highlighted.length} items`
+                    : name
+
+                return (
+                    <li
+                        className="selected-list-item"
+                        id={id}
+                        onDoubleClick={() => this.onDeselectOne(id)}
+                        {...provided.draggableProps}
+                        {...provided.dragHandleProps}
+                        ref={provided.innerRef}
+                        data-test={`${this.props.dataTest}-list-item`}
+                    >
+                        <Item
+                            id={id}
+                            index={index}
+                            name={itemText}
+                            highlighted={!!this.state.highlighted.includes(id)}
+                            active={isActive}
+                            onRemoveItem={this.onDeselectOne}
+                            onClick={this.toggleHighlight}
+                            ghost={ghost}
+                        />
+                    </li>
+                )
+            }}
+        </Draggable>
+    )
+
+    renderCloneItem = ({ id, name }, index) => {
+        const cloneId = `${id}-clone`
+        return (
+            <Draggable draggableId={cloneId} index={index} key={cloneId}>
+                {provided => (
+                    <li
+                        className="selected-list-item"
+                        id={cloneId}
+                        {...provided.draggableProps}
+                        {...provided.dragHandleProps}
+                        ref={provided.innerRef}
+                    >
+                        <Item
+                            id={cloneId}
+                            index={CLONE_INDEX}
+                            name={name}
+                            highlighted={!!this.state.highlighted.includes(id)}
+                            selected
+                            ghost
+                        />
+                    </li>
+                )}
+            </Draggable>
+        )
+    }
+
+    getItemListWithClone = () => {
+        const list = []
+
+        this.props.items.forEach(item => {
+            list.push(item)
+
+            const isDraggedItem =
+                this.isMultiDrag(this.state.draggingId) &&
+                this.state.draggingId === item.id
+
+            if (isDraggedItem) {
+                list.push({
+                    id: item.id,
+                    name: item.name,
+                    isActive: item.isActive,
+                    clone: true,
+                })
+            }
+        })
+
+        return list
+    }
+
+    render = () => {
+        const itemList = this.getItemListWithClone().map((item, i) =>
+            item.clone
+                ? this.renderCloneItem(item, i)
+                : this.renderListItem(item, i)
+        )
+
+        return (
+            <Fragment>
+                <Subtitle />
+                {this.props.infoBoxMessage ? (
+                    <InfoBox
+                        message={this.props.infoBoxMessage}
+                        dataTest={`${this.props.dataTest}-info-box`}
+                    />
+                ) : null}
+                <DragDropContext
+                    onDragStart={this.onDragStart}
+                    onDragEnd={this.onDragEnd}
+                >
+                    <Droppable droppableId="selected-items-droppable">
+                        {provided => (
+                            <ItemsList
+                                innerRef={provided.innerRef}
+                                dataTest={`${this.props.dataTest}-list`}
+                                {...provided.droppableProps}
+                            >
+                                {itemList}
+                                {provided.placeholder}
+                            </ItemsList>
+                        )}
+                    </Droppable>
+                </DragDropContext>
+                <div style={styles.deselectAllButton}>
+                    <Button
+                        onClick={this.onDeselectAll}
+                        dataTest={`${this.props.dataTest}-deselect-all-button`}
+                    >
+                        {i18n.t('Deselect All')}
+                    </Button>
+                </div>
+                <div style={styles.deselectHighlightedButton}>
+                    <UnAssignButton
+                        onClick={this.onDeselectHighlighted}
+                        iconType={'arrowBack'}
+                    />
+                </div>
+            </Fragment>
+        )
+    }
+}
+
+InfoBox.propTypes = {
+    dataTest: PropTypes.string,
+    message: PropTypes.string,
+}
+
+ItemsList.propTypes = {
+    children: PropTypes.array,
+    dataTest: PropTypes.string,
+    innerRef: PropTypes.func,
+}
+
+SelectedItems.propTypes = {
+    items: PropTypes.array.isRequired,
+    onDeselect: PropTypes.func.isRequired,
+    onReorder: PropTypes.func.isRequired,
+    dataTest: PropTypes.string,
+    infoBoxMessage: PropTypes.string,
+}
+
+export default SelectedItems

--- a/packages/period-selector-dialog/src/ItemSelector/SelectedItems.js
+++ b/packages/period-selector-dialog/src/ItemSelector/SelectedItems.js
@@ -17,15 +17,15 @@ const Subtitle = () => (
     </div>
 )
 
-const InfoBox = ({ message, dataTest }) => (
-    <div style={styles.infoTontainer} data-test={dataTest}>
+const InfoBox = ({ message }) => (
+    <div style={styles.infoTontainer}>
         <InfoIcon style={{ fontSize: 16, color: '#6e7a8a' }} />
         <span style={styles.infoText}>{message}</span>
     </div>
 )
 
-const ItemsList = ({ innerRef, children, dataTest }) => (
-    <ul style={styles.selectedList} ref={innerRef} data-test={dataTest}>
+const ItemsList = ({ innerRef, children }) => (
+    <ul style={styles.selectedList} ref={innerRef}>
         {children}
     </ul>
 )
@@ -141,7 +141,6 @@ export class SelectedItems extends Component {
                         {...provided.draggableProps}
                         {...provided.dragHandleProps}
                         ref={provided.innerRef}
-                        data-test={`${this.props.dataTest}-list-item`}
                     >
                         <Item
                             id={id}
@@ -219,10 +218,7 @@ export class SelectedItems extends Component {
             <Fragment>
                 <Subtitle />
                 {this.props.infoBoxMessage ? (
-                    <InfoBox
-                        message={this.props.infoBoxMessage}
-                        dataTest={`${this.props.dataTest}-info-box`}
-                    />
+                    <InfoBox message={this.props.infoBoxMessage} />
                 ) : null}
                 <DragDropContext
                     onDragStart={this.onDragStart}
@@ -232,7 +228,6 @@ export class SelectedItems extends Component {
                         {provided => (
                             <ItemsList
                                 innerRef={provided.innerRef}
-                                dataTest={`${this.props.dataTest}-list`}
                                 {...provided.droppableProps}
                             >
                                 {itemList}
@@ -242,10 +237,7 @@ export class SelectedItems extends Component {
                     </Droppable>
                 </DragDropContext>
                 <div style={styles.deselectAllButton}>
-                    <Button
-                        onClick={this.onDeselectAll}
-                        dataTest={`${this.props.dataTest}-deselect-all-button`}
-                    >
+                    <Button onClick={this.onDeselectAll}>
                         {i18n.t('Deselect All')}
                     </Button>
                 </div>
@@ -261,13 +253,11 @@ export class SelectedItems extends Component {
 }
 
 InfoBox.propTypes = {
-    dataTest: PropTypes.string,
     message: PropTypes.string,
 }
 
 ItemsList.propTypes = {
     children: PropTypes.array,
-    dataTest: PropTypes.string,
     innerRef: PropTypes.func,
 }
 
@@ -275,7 +265,6 @@ SelectedItems.propTypes = {
     items: PropTypes.array.isRequired,
     onDeselect: PropTypes.func.isRequired,
     onReorder: PropTypes.func.isRequired,
-    dataTest: PropTypes.string,
     infoBoxMessage: PropTypes.string,
 }
 

--- a/packages/period-selector-dialog/src/ItemSelector/UnselectedItems.js
+++ b/packages/period-selector-dialog/src/ItemSelector/UnselectedItems.js
@@ -66,7 +66,6 @@ export class UnselectedItems extends Component {
             style={styles.unselectedListItem}
             key={dataDim.id}
             onDoubleClick={() => this.onDoubleClickItem(dataDim.id)}
-            data-test={`${this.props.dataTest}-list-item`}
         >
             <Item
                 id={dataDim.id}
@@ -104,17 +103,13 @@ export class UnselectedItems extends Component {
                     onScroll={this.requestMoreItems}
                     style={styles.unselectedListContainer}
                 >
-                    <ul
-                        style={styles.unselectedList}
-                        data-test={`${this.props.dataTest}-list`}
-                    >
+                    <ul style={styles.unselectedList}>
                         {listItems}
                     </ul>
                 </div>
                 <div className="select-all-button" style={styles.selectAllButton}>
                     <Button
                         onClick={this.onSelectAllClick}
-                        dataTest={`${this.props.dataTest}-select-all-button`}
                     >
                         {i18n.t('Select all')}
                     </Button>
@@ -138,7 +133,6 @@ UnselectedItems.propTypes = {
         })
     ).isRequired,
     onSelect: PropTypes.func.isRequired,
-    dataTest: PropTypes.string,
     filterText: PropTypes.string,
     requestMoreItems: PropTypes.func,
 }

--- a/packages/period-selector-dialog/src/ItemSelector/UnselectedItems.js
+++ b/packages/period-selector-dialog/src/ItemSelector/UnselectedItems.js
@@ -111,7 +111,7 @@ export class UnselectedItems extends Component {
                         {listItems}
                     </ul>
                 </div>
-                <div style={styles.selectAllButton}>
+                <div className="select-all-button" style={styles.selectAllButton}>
                     <Button
                         onClick={this.onSelectAllClick}
                         dataTest={`${this.props.dataTest}-select-all-button`}

--- a/packages/period-selector-dialog/src/ItemSelector/UnselectedItems.js
+++ b/packages/period-selector-dialog/src/ItemSelector/UnselectedItems.js
@@ -1,0 +1,151 @@
+import React, { Component, Fragment } from 'react'
+import PropTypes from 'prop-types'
+import i18n from '@dhis2/d2-i18n'
+import Button from '@material-ui/core/Button';
+import throttle from 'lodash/throttle'
+
+import Item from './widgets/UnselectedItem'
+import { ArrowButton as AssignButton } from './widgets/ArrowButton'
+import { toggler } from './modules/toggler'
+import styles from './styles/UnselectedItems.style'
+
+export class UnselectedItems extends Component {
+    constructor(props) {
+        super(props)
+        this.scrolElRef = React.createRef()
+    }
+
+    state = { highlighted: [], lastClickedIndex: 0 }
+
+    onSelectClick = () => {
+        this.props.onSelect(this.state.highlighted)
+        this.setState({ highlighted: [] })
+    }
+
+    onSelectAllClick = () => {
+        this.props.onSelect(this.props.items.map(i => i.id))
+        this.setState({ highlighted: [] })
+    }
+
+    onDoubleClickItem = id => {
+        const highlighted = this.state.highlighted.filter(
+            dataDimId => dataDimId !== id
+        )
+
+        this.setState({ highlighted })
+        this.props.onSelect([id])
+    }
+
+    filterTextContains = displayName =>
+        displayName.toLowerCase().includes(this.props.filterText.toLowerCase())
+
+    filterItems = (item, index) =>
+        this.filterTextContains(item.name)
+            ? this.renderListItem(item, index)
+            : null
+
+    toggleHighlight = ({ isCtrlPressed, isShiftPressed, index, id }) => {
+        const newState = toggler({
+            id,
+            isCtrlPressed,
+            isShiftPressed,
+            index,
+            lastClickedIndex: this.state.lastClickedIndex,
+            highlightedIds: this.state.highlighted,
+            items: this.props.items.map(item => item.id),
+        })
+
+        this.setState({
+            highlighted: newState.ids,
+            lastClickedIndex: newState.lastClickedIndex,
+        })
+    }
+
+    renderListItem = (dataDim, index) => (
+        <li
+            style={styles.unselectedListItem}
+            key={dataDim.id}
+            onDoubleClick={() => this.onDoubleClickItem(dataDim.id)}
+            data-test={`${this.props.dataTest}-list-item`}
+        >
+            <Item
+                id={dataDim.id}
+                index={index}
+                name={dataDim.name}
+                highlighted={!!this.state.highlighted.includes(dataDim.id)}
+                onClick={this.toggleHighlight}
+            />
+        </li>
+    )
+
+    requestMoreItems = throttle(() => {
+        const node = this.scrolElRef.current
+
+        if (node) {
+            const bottom =
+                node.scrollHeight - node.scrollTop === node.clientHeight
+            if (bottom) {
+                this.props.requestMoreItems()
+            }
+        }
+    }, 1000)
+
+    render = () => {
+        const listItems = this.props.items.map((item, index) =>
+            this.props.filterText.length
+                ? this.filterItems(item, index)
+                : this.renderListItem(item, index)
+        )
+
+        return (
+            <Fragment>
+                <div
+                    ref={this.scrolElRef}
+                    onScroll={this.requestMoreItems}
+                    style={styles.unselectedListContainer}
+                >
+                    <ul
+                        style={styles.unselectedList}
+                        data-test={`${this.props.dataTest}-list`}
+                    >
+                        {listItems}
+                    </ul>
+                </div>
+                <div style={styles.selectAllButton}>
+                    <Button
+                        onClick={this.onSelectAllClick}
+                        dataTest={`${this.props.dataTest}-select-all-button`}
+                    >
+                        {i18n.t('Select all')}
+                    </Button>
+                </div>
+                <div style={styles.selectHighlightedButton}>
+                    <AssignButton
+                        onClick={this.onSelectClick}
+                        iconType={'arrowForward'}
+                    />
+                </div>
+            </Fragment>
+        )
+    }
+}
+
+UnselectedItems.propTypes = {
+    items: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            name: PropTypes.string.isRequired,
+        })
+    ).isRequired,
+    onSelect: PropTypes.func.isRequired,
+    dataTest: PropTypes.string,
+    filterText: PropTypes.string,
+    requestMoreItems: PropTypes.func,
+}
+
+UnselectedItems.defaultProps = {
+    requestMoreItems: () => null,
+    filterText: '',
+}
+
+export default UnselectedItems

--- a/packages/period-selector-dialog/src/ItemSelector/__tests__/SelectedItems.spec.js
+++ b/packages/period-selector-dialog/src/ItemSelector/__tests__/SelectedItems.spec.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { SelectedItems } from '../SelectedItems'
+
+describe('The SelectedItems component', () => {
+    let props
+    let selectedItemsWrapper
+
+    const selectedItems = () => {
+        if (!selectedItemsWrapper) {
+            selectedItemsWrapper = mount(<SelectedItems {...props} />)
+        }
+        return selectedItemsWrapper
+    }
+
+    beforeEach(() => {
+        props = {
+            items: [],
+            onDeselect: jest.fn(),
+            onReorder: jest.fn(),
+        }
+        selectedItemsWrapper = undefined
+    })
+
+    it('matches the snapshot when list is empty', () => {
+        expect(selectedItems()).toMatchSnapshot()
+    })
+
+    describe('list with items', () => {
+        beforeEach(() => {
+            props.items = [
+                {
+                    id: 'rb',
+                    name: 'rainbow',
+                },
+                { id: 'rr', name: 'rarity' },
+            ]
+        })
+        it('matches the snapshot with list has items', () => {
+            expect(selectedItems()).toMatchSnapshot()
+        })
+
+        it('triggers onDeselect when item double-clicked', () => {
+            selectedItems().find('li').first().simulate('doubleClick')
+
+            expect(props.onDeselect).toHaveBeenCalled()
+            expect(props.onDeselect).toHaveBeenCalledWith(['rb'])
+        })
+
+        it('triggers onDeselect when Deselect All button clicked', () => {
+            selectedItems().find('Button').first().simulate('click')
+
+            expect(props.onDeselect).toHaveBeenCalled()
+            expect(props.onDeselect).toHaveBeenCalledWith(['rb', 'rr'])
+        })
+
+        it('triggers onDeselect when "Deselect highlighted" button clicked', () => {
+            const list = selectedItems()
+
+            list.find('Item').first().simulate('click', false, false, 0, 'rb')
+
+            const onClickFn = list.find('ArrowButton').prop('onClick')
+
+            onClickFn() // enzyme simulate was not working
+
+            expect(props.onDeselect).toHaveBeenCalled()
+            expect(props.onDeselect).toHaveBeenCalledWith(['rb'])
+        })
+    })
+})

--- a/packages/period-selector-dialog/src/ItemSelector/__tests__/UnselectedItems.spec.js
+++ b/packages/period-selector-dialog/src/ItemSelector/__tests__/UnselectedItems.spec.js
@@ -1,0 +1,86 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { UnselectedItems } from '../UnselectedItems'
+
+describe('UnselectedItems component', () => {
+    let props
+    let shallowItems
+    const unselectedItems = () => {
+        if (!shallowItems) {
+            shallowItems = shallow(<UnselectedItems {...props} />)
+        }
+        return shallowItems
+    }
+
+    beforeEach(() => {
+        props = {
+            items: [],
+            filterText: '',
+            onSelect: jest.fn(),
+            requestMoreItems: jest.fn(),
+        }
+        shallowItems = undefined
+    })
+
+    it('matches the snapshot when list is empty', () => {
+        expect(unselectedItems()).toMatchSnapshot()
+    })
+
+    describe('list with items', () => {
+        beforeEach(() => {
+            props.items = [
+                {
+                    id: 'rb',
+                    name: 'rainbow',
+                },
+                { id: 'rr', name: 'rarity' },
+            ]
+        })
+
+        it('matches the snapshot when list has items', () => {
+            expect(unselectedItems()).toMatchSnapshot()
+        })
+
+        it('triggers onSelect all when "select all" button clicked', () => {
+            unselectedItems()
+                .find('.select-all-button')
+                .childAt(0)
+                .simulate('click')
+
+            expect(props.onSelect).toHaveBeenCalled()
+            expect(props.onSelect).toHaveBeenCalledWith(['rb', 'rr'])
+        })
+
+        it('triggers onSelect when item double-clicked', () => {
+            unselectedItems().find('li').first().simulate('doubleClick')
+
+            expect(props.onSelect).toHaveBeenCalled()
+            expect(props.onSelect).toHaveBeenCalledWith(['rb'])
+        })
+
+        it('triggers onSelect when "assign" button clicked', () => {
+            const list = unselectedItems()
+            list.find('Item').first().simulate('click', {
+                isCtrlPressed: false,
+                isShiftPressed: false,
+                index: 0,
+                id: 'rb',
+            })
+
+            list.find('ArrowButton').first().simulate('click')
+
+            expect(props.onSelect).toHaveBeenCalled()
+            expect(props.onSelect).toHaveBeenCalledWith(['rb'])
+        })
+
+        it('renders only items matching the filter', () => {
+            props.filterText = 'b'
+            const items = unselectedItems().find('Item')
+
+            expect(items.length).toEqual(1)
+            expect(items.dive().text()).toEqual(
+                expect.stringContaining('rainbow')
+            )
+        })
+    })
+})

--- a/packages/period-selector-dialog/src/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
+++ b/packages/period-selector-dialog/src/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
@@ -19,14 +19,29 @@ exports[`The SelectedItems component list with items matches the snapshot with l
 >
   <Subtitle>
     <div
-      className="subtitle-container"
+      style={
+        Object {
+          "borderBottom": "1px solid #e8edf2",
+          "height": "42px",
+        }
+      }
     >
       <span
-        className="subtitle-text"
+        style={
+          Object {
+            "color": "#212934",
+            "fontFamily": "Roboto",
+            "fontSize": "15px",
+            "fontWeight": "500",
+            "height": "20px",
+            "left": "8px",
+            "position": "relative",
+            "top": "12px",
+          }
+        }
       >
         Selected Data
       </span>
-      <style />
     </div>
   </Subtitle>
   <DragDropContext
@@ -78,8 +93,17 @@ exports[`The SelectedItems component list with items matches the snapshot with l
               innerRef={[Function]}
             >
               <ul
-                className="selected-list"
                 data-test="undefined-list"
+                style={
+                  Object {
+                    "flex": "1",
+                    "listStyle": "none",
+                    "margin": "0 6px",
+                    "overflowY": "auto",
+                    "paddingLeft": "0px",
+                    "userSelect": "none",
+                  }
+                }
               >
                 <Connect(Draggable)
                   disableInteractiveElementBlocking={false}
@@ -190,28 +214,41 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                             onRemoveItem={[Function]}
                           >
                             <div
-                              className="item selected-item"
+                              className="selected-period-item"
                               data-test="dimension-item-rb"
                               onClick={[Function]}
+                              style={
+                                Object {
+                                  "alignItems": "center",
+                                  "backgroundColor": "#b2dfdb",
+                                  "borderRadius": "4px",
+                                  "cursor": "pointer",
+                                  "display": "flex",
+                                  "padding": "3px",
+                                }
+                              }
                             >
                               <ItemIcon
                                 backgroundColor="#00796b"
                               >
-                                <div>
-                                  <style>
-                                    
-                div {
-                    background-color: #00796b;
-                    min-height: 6px;
-                    min-width: 6px;
-                    margin: 0px 5px;
-                }
-            
-                                  </style>
-                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "backgroundColor": "#00796b",
+                                      "margin": "0 5px",
+                                      "minHeight": "6px",
+                                      "minWidth": "6px",
+                                    }
+                                  }
+                                />
                               </ItemIcon>
                               <span
-                                className="item-label"
+                                style={
+                                  Object {
+                                    "fontSize": "14px",
+                                    "padding": "2px",
+                                  }
+                                }
                               >
                                 rainbow
                               </span>
@@ -220,8 +257,17 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                                 onClick={[Function]}
                               >
                                 <button
-                                  className="deselect-icon-button"
                                   onClick={[Function]}
+                                  style={
+                                    Object {
+                                      "background": "none",
+                                      "border": "none",
+                                      "height": "18px",
+                                      "outline": "none",
+                                      "padding": "0px",
+                                      "width": "18px",
+                                    }
+                                  }
                                 >
                                   <span>
                                     <pure(CloseIcon)
@@ -254,15 +300,15 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                                           <SvgIcon
                                             classes={
                                               Object {
-                                                "colorAction": "MuiSvgIcon-colorAction-4",
-                                                "colorDisabled": "MuiSvgIcon-colorDisabled-6",
-                                                "colorError": "MuiSvgIcon-colorError-5",
-                                                "colorPrimary": "MuiSvgIcon-colorPrimary-2",
-                                                "colorSecondary": "MuiSvgIcon-colorSecondary-3",
-                                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-7",
-                                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-9",
-                                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-8",
-                                                "root": "MuiSvgIcon-root-1",
+                                                "colorAction": "MuiSvgIcon-colorAction-33",
+                                                "colorDisabled": "MuiSvgIcon-colorDisabled-35",
+                                                "colorError": "MuiSvgIcon-colorError-34",
+                                                "colorPrimary": "MuiSvgIcon-colorPrimary-31",
+                                                "colorSecondary": "MuiSvgIcon-colorSecondary-32",
+                                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-36",
+                                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-38",
+                                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-37",
+                                                "root": "MuiSvgIcon-root-30",
                                               }
                                             }
                                             color="inherit"
@@ -279,7 +325,7 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                                           >
                                             <svg
                                               aria-hidden="true"
-                                              className="MuiSvgIcon-root-1"
+                                              className="MuiSvgIcon-root-30"
                                               focusable="false"
                                               role="presentation"
                                               style={
@@ -304,13 +350,10 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                                       </CloseIcon>
                                     </pure(CloseIcon)>
                                   </span>
-                                  <style />
                                 </button>
                               </DeselectIconButton>
-                              <style />
                             </div>
                           </Item>
-                          <style />
                         </li>
                       </DragHandle>
                     </DraggableDimensionPublisher>
@@ -425,28 +468,41 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                             onRemoveItem={[Function]}
                           >
                             <div
-                              className="item selected-item"
+                              className="selected-period-item"
                               data-test="dimension-item-rr"
                               onClick={[Function]}
+                              style={
+                                Object {
+                                  "alignItems": "center",
+                                  "backgroundColor": "#b2dfdb",
+                                  "borderRadius": "4px",
+                                  "cursor": "pointer",
+                                  "display": "flex",
+                                  "padding": "3px",
+                                }
+                              }
                             >
                               <ItemIcon
                                 backgroundColor="#00796b"
                               >
-                                <div>
-                                  <style>
-                                    
-                div {
-                    background-color: #00796b;
-                    min-height: 6px;
-                    min-width: 6px;
-                    margin: 0px 5px;
-                }
-            
-                                  </style>
-                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "backgroundColor": "#00796b",
+                                      "margin": "0 5px",
+                                      "minHeight": "6px",
+                                      "minWidth": "6px",
+                                    }
+                                  }
+                                />
                               </ItemIcon>
                               <span
-                                className="item-label"
+                                style={
+                                  Object {
+                                    "fontSize": "14px",
+                                    "padding": "2px",
+                                  }
+                                }
                               >
                                 rarity
                               </span>
@@ -455,8 +511,17 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                                 onClick={[Function]}
                               >
                                 <button
-                                  className="deselect-icon-button"
                                   onClick={[Function]}
+                                  style={
+                                    Object {
+                                      "background": "none",
+                                      "border": "none",
+                                      "height": "18px",
+                                      "outline": "none",
+                                      "padding": "0px",
+                                      "width": "18px",
+                                    }
+                                  }
                                 >
                                   <span>
                                     <pure(CloseIcon)
@@ -489,15 +554,15 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                                           <SvgIcon
                                             classes={
                                               Object {
-                                                "colorAction": "MuiSvgIcon-colorAction-4",
-                                                "colorDisabled": "MuiSvgIcon-colorDisabled-6",
-                                                "colorError": "MuiSvgIcon-colorError-5",
-                                                "colorPrimary": "MuiSvgIcon-colorPrimary-2",
-                                                "colorSecondary": "MuiSvgIcon-colorSecondary-3",
-                                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-7",
-                                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-9",
-                                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-8",
-                                                "root": "MuiSvgIcon-root-1",
+                                                "colorAction": "MuiSvgIcon-colorAction-33",
+                                                "colorDisabled": "MuiSvgIcon-colorDisabled-35",
+                                                "colorError": "MuiSvgIcon-colorError-34",
+                                                "colorPrimary": "MuiSvgIcon-colorPrimary-31",
+                                                "colorSecondary": "MuiSvgIcon-colorSecondary-32",
+                                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-36",
+                                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-38",
+                                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-37",
+                                                "root": "MuiSvgIcon-root-30",
                                               }
                                             }
                                             color="inherit"
@@ -514,7 +579,7 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                                           >
                                             <svg
                                               aria-hidden="true"
-                                              className="MuiSvgIcon-root-1"
+                                              className="MuiSvgIcon-root-30"
                                               focusable="false"
                                               role="presentation"
                                               style={
@@ -539,13 +604,10 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                                       </CloseIcon>
                                     </pure(CloseIcon)>
                                   </span>
-                                  <style />
                                 </button>
                               </DeselectIconButton>
-                              <style />
                             </div>
                           </Item>
-                          <style />
                         </li>
                       </DragHandle>
                     </DraggableDimensionPublisher>
@@ -555,7 +617,6 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                   on={null}
                   shouldAnimate={true}
                 />
-                <style />
               </ul>
             </ItemsList>
           </DroppableDimensionPublisher>
@@ -564,41 +625,193 @@ exports[`The SelectedItems component list with items matches the snapshot with l
     </ErrorBoundary>
   </DragDropContext>
   <div
-    className="deselect-all-button"
+    style={
+      Object {
+        "display": "block",
+        "margin": "0 auto",
+        "padding": "5px",
+      }
+    }
   >
-    <Button
+    <WithStyles(Button)
       dataTest="undefined-deselect-all-button"
       onClick={[Function]}
-      type="button"
     >
-      <button
-        className="jsx-2371629422 "
-        data-test="undefined-deselect-all-button"
-        onBlur={[Function]}
+      <Button
+        classes={
+          Object {
+            "colorInherit": "MuiButton-colorInherit-22",
+            "contained": "MuiButton-contained-12",
+            "containedPrimary": "MuiButton-containedPrimary-13",
+            "containedSecondary": "MuiButton-containedSecondary-14",
+            "disabled": "MuiButton-disabled-21",
+            "extendedFab": "MuiButton-extendedFab-19",
+            "fab": "MuiButton-fab-18",
+            "flat": "MuiButton-flat-6",
+            "flatPrimary": "MuiButton-flatPrimary-7",
+            "flatSecondary": "MuiButton-flatSecondary-8",
+            "focusVisible": "MuiButton-focusVisible-20",
+            "fullWidth": "MuiButton-fullWidth-26",
+            "label": "MuiButton-label-2",
+            "mini": "MuiButton-mini-23",
+            "outlined": "MuiButton-outlined-9",
+            "outlinedPrimary": "MuiButton-outlinedPrimary-10",
+            "outlinedSecondary": "MuiButton-outlinedSecondary-11",
+            "raised": "MuiButton-raised-15",
+            "raisedPrimary": "MuiButton-raisedPrimary-16",
+            "raisedSecondary": "MuiButton-raisedSecondary-17",
+            "root": "MuiButton-root-1",
+            "sizeLarge": "MuiButton-sizeLarge-25",
+            "sizeSmall": "MuiButton-sizeSmall-24",
+            "text": "MuiButton-text-3",
+            "textPrimary": "MuiButton-textPrimary-4",
+            "textSecondary": "MuiButton-textSecondary-5",
+          }
+        }
+        color="default"
+        component="button"
+        dataTest="undefined-deselect-all-button"
+        disableFocusRipple={false}
+        disabled={false}
+        fullWidth={false}
+        mini={false}
         onClick={[Function]}
-        onFocus={[Function]}
+        size="medium"
         type="button"
+        variant="text"
       >
-        Deselect All
-        <JSXStyle
-          id="2371629422"
-        />
-      </button>
-    </Button>
+        <WithStyles(ButtonBase)
+          className="MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6"
+          component="button"
+          dataTest="undefined-deselect-all-button"
+          disabled={false}
+          focusRipple={true}
+          focusVisibleClassName="MuiButton-focusVisible-20"
+          onClick={[Function]}
+          type="button"
+        >
+          <ButtonBase
+            centerRipple={false}
+            className="MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6"
+            classes={
+              Object {
+                "disabled": "MuiButtonBase-disabled-28",
+                "focusVisible": "MuiButtonBase-focusVisible-29",
+                "root": "MuiButtonBase-root-27",
+              }
+            }
+            component="button"
+            dataTest="undefined-deselect-all-button"
+            disableRipple={false}
+            disableTouchRipple={false}
+            disabled={false}
+            focusRipple={true}
+            focusVisibleClassName="MuiButton-focusVisible-20"
+            onClick={[Function]}
+            tabIndex="0"
+            type="button"
+          >
+            <button
+              className="MuiButtonBase-root-27 MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6"
+              dataTest="undefined-deselect-all-button"
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex="0"
+              type="button"
+            >
+              <span
+                className="MuiButton-label-2"
+              >
+                Deselect All
+              </span>
+              <NoSsr
+                defer={false}
+                fallback={null}
+              >
+                <WithStyles(TouchRipple)
+                  center={false}
+                  innerRef={[Function]}
+                >
+                  <TouchRipple
+                    center={false}
+                    classes={
+                      Object {
+                        "child": "MuiTouchRipple-child-43",
+                        "childLeaving": "MuiTouchRipple-childLeaving-44",
+                        "childPulsate": "MuiTouchRipple-childPulsate-45",
+                        "ripple": "MuiTouchRipple-ripple-40",
+                        "ripplePulsate": "MuiTouchRipple-ripplePulsate-42",
+                        "rippleVisible": "MuiTouchRipple-rippleVisible-41",
+                        "root": "MuiTouchRipple-root-39",
+                      }
+                    }
+                  >
+                    <TransitionGroup
+                      childFactory={[Function]}
+                      className="MuiTouchRipple-root-39"
+                      component="span"
+                      enter={true}
+                      exit={true}
+                    >
+                      <span
+                        className="MuiTouchRipple-root-39"
+                      />
+                    </TransitionGroup>
+                  </TouchRipple>
+                </WithStyles(TouchRipple)>
+              </NoSsr>
+            </button>
+          </ButtonBase>
+        </WithStyles(ButtonBase)>
+      </Button>
+    </WithStyles(Button)>
   </div>
   <div
-    className="deselect-highlighted-button"
+    style={
+      Object {
+        "left": "-48px",
+        "position": "absolute",
+        "top": "291px",
+      }
+    }
   >
     <ArrowButton
       iconType="arrowBack"
       onClick={[Function]}
     >
       <button
-        className="arrow-button"
+        className="item-selector-arrow-button"
         onClick={[Function]}
+        style={
+          Object {
+            "border": "1px solid #d5dde5",
+            "borderRadius": "4px",
+            "height": "36px",
+            "minHeight": "36px",
+            "minWidth": "40px",
+            "padding": "0",
+            "width": "40px",
+          }
+        }
       >
         <span
-          className="arrow-icon"
+          style={
+            Object {
+              "fill": "#4a5768",
+              "height": "20px",
+              "width": "24px",
+            }
+          }
         >
           <pure(ArrowBackIcon)>
             <ArrowBackIcon>
@@ -606,15 +819,15 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                 <SvgIcon
                   classes={
                     Object {
-                      "colorAction": "MuiSvgIcon-colorAction-4",
-                      "colorDisabled": "MuiSvgIcon-colorDisabled-6",
-                      "colorError": "MuiSvgIcon-colorError-5",
-                      "colorPrimary": "MuiSvgIcon-colorPrimary-2",
-                      "colorSecondary": "MuiSvgIcon-colorSecondary-3",
-                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-7",
-                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-9",
-                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-8",
-                      "root": "MuiSvgIcon-root-1",
+                      "colorAction": "MuiSvgIcon-colorAction-33",
+                      "colorDisabled": "MuiSvgIcon-colorDisabled-35",
+                      "colorError": "MuiSvgIcon-colorError-34",
+                      "colorPrimary": "MuiSvgIcon-colorPrimary-31",
+                      "colorSecondary": "MuiSvgIcon-colorSecondary-32",
+                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-36",
+                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-38",
+                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-37",
+                      "root": "MuiSvgIcon-root-30",
                     }
                   }
                   color="inherit"
@@ -624,7 +837,7 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                 >
                   <svg
                     aria-hidden="true"
-                    className="MuiSvgIcon-root-1"
+                    className="MuiSvgIcon-root-30"
                     focusable="false"
                     role="presentation"
                     viewBox="0 0 24 24"
@@ -642,11 +855,9 @@ exports[`The SelectedItems component list with items matches the snapshot with l
             </ArrowBackIcon>
           </pure(ArrowBackIcon)>
         </span>
-        <style />
       </button>
     </ArrowButton>
   </div>
-  <style />
 </SelectedItems>
 `;
 
@@ -658,14 +869,29 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
 >
   <Subtitle>
     <div
-      className="subtitle-container"
+      style={
+        Object {
+          "borderBottom": "1px solid #e8edf2",
+          "height": "42px",
+        }
+      }
     >
       <span
-        className="subtitle-text"
+        style={
+          Object {
+            "color": "#212934",
+            "fontFamily": "Roboto",
+            "fontSize": "15px",
+            "fontWeight": "500",
+            "height": "20px",
+            "left": "8px",
+            "position": "relative",
+            "top": "12px",
+          }
+        }
       >
         Selected Data
       </span>
-      <style />
     </div>
   </Subtitle>
   <DragDropContext
@@ -717,14 +943,22 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
               innerRef={[Function]}
             >
               <ul
-                className="selected-list"
                 data-test="undefined-list"
+                style={
+                  Object {
+                    "flex": "1",
+                    "listStyle": "none",
+                    "margin": "0 6px",
+                    "overflowY": "auto",
+                    "paddingLeft": "0px",
+                    "userSelect": "none",
+                  }
+                }
               >
                 <AnimateInOut
                   on={null}
                   shouldAnimate={true}
                 />
-                <style />
               </ul>
             </ItemsList>
           </DroppableDimensionPublisher>
@@ -733,41 +967,193 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
     </ErrorBoundary>
   </DragDropContext>
   <div
-    className="deselect-all-button"
+    style={
+      Object {
+        "display": "block",
+        "margin": "0 auto",
+        "padding": "5px",
+      }
+    }
   >
-    <Button
+    <WithStyles(Button)
       dataTest="undefined-deselect-all-button"
       onClick={[Function]}
-      type="button"
     >
-      <button
-        className="jsx-2371629422 "
-        data-test="undefined-deselect-all-button"
-        onBlur={[Function]}
+      <Button
+        classes={
+          Object {
+            "colorInherit": "MuiButton-colorInherit-22",
+            "contained": "MuiButton-contained-12",
+            "containedPrimary": "MuiButton-containedPrimary-13",
+            "containedSecondary": "MuiButton-containedSecondary-14",
+            "disabled": "MuiButton-disabled-21",
+            "extendedFab": "MuiButton-extendedFab-19",
+            "fab": "MuiButton-fab-18",
+            "flat": "MuiButton-flat-6",
+            "flatPrimary": "MuiButton-flatPrimary-7",
+            "flatSecondary": "MuiButton-flatSecondary-8",
+            "focusVisible": "MuiButton-focusVisible-20",
+            "fullWidth": "MuiButton-fullWidth-26",
+            "label": "MuiButton-label-2",
+            "mini": "MuiButton-mini-23",
+            "outlined": "MuiButton-outlined-9",
+            "outlinedPrimary": "MuiButton-outlinedPrimary-10",
+            "outlinedSecondary": "MuiButton-outlinedSecondary-11",
+            "raised": "MuiButton-raised-15",
+            "raisedPrimary": "MuiButton-raisedPrimary-16",
+            "raisedSecondary": "MuiButton-raisedSecondary-17",
+            "root": "MuiButton-root-1",
+            "sizeLarge": "MuiButton-sizeLarge-25",
+            "sizeSmall": "MuiButton-sizeSmall-24",
+            "text": "MuiButton-text-3",
+            "textPrimary": "MuiButton-textPrimary-4",
+            "textSecondary": "MuiButton-textSecondary-5",
+          }
+        }
+        color="default"
+        component="button"
+        dataTest="undefined-deselect-all-button"
+        disableFocusRipple={false}
+        disabled={false}
+        fullWidth={false}
+        mini={false}
         onClick={[Function]}
-        onFocus={[Function]}
+        size="medium"
         type="button"
+        variant="text"
       >
-        Deselect All
-        <JSXStyle
-          id="2371629422"
-        />
-      </button>
-    </Button>
+        <WithStyles(ButtonBase)
+          className="MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6"
+          component="button"
+          dataTest="undefined-deselect-all-button"
+          disabled={false}
+          focusRipple={true}
+          focusVisibleClassName="MuiButton-focusVisible-20"
+          onClick={[Function]}
+          type="button"
+        >
+          <ButtonBase
+            centerRipple={false}
+            className="MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6"
+            classes={
+              Object {
+                "disabled": "MuiButtonBase-disabled-28",
+                "focusVisible": "MuiButtonBase-focusVisible-29",
+                "root": "MuiButtonBase-root-27",
+              }
+            }
+            component="button"
+            dataTest="undefined-deselect-all-button"
+            disableRipple={false}
+            disableTouchRipple={false}
+            disabled={false}
+            focusRipple={true}
+            focusVisibleClassName="MuiButton-focusVisible-20"
+            onClick={[Function]}
+            tabIndex="0"
+            type="button"
+          >
+            <button
+              className="MuiButtonBase-root-27 MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6"
+              dataTest="undefined-deselect-all-button"
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex="0"
+              type="button"
+            >
+              <span
+                className="MuiButton-label-2"
+              >
+                Deselect All
+              </span>
+              <NoSsr
+                defer={false}
+                fallback={null}
+              >
+                <WithStyles(TouchRipple)
+                  center={false}
+                  innerRef={[Function]}
+                >
+                  <TouchRipple
+                    center={false}
+                    classes={
+                      Object {
+                        "child": "MuiTouchRipple-child-43",
+                        "childLeaving": "MuiTouchRipple-childLeaving-44",
+                        "childPulsate": "MuiTouchRipple-childPulsate-45",
+                        "ripple": "MuiTouchRipple-ripple-40",
+                        "ripplePulsate": "MuiTouchRipple-ripplePulsate-42",
+                        "rippleVisible": "MuiTouchRipple-rippleVisible-41",
+                        "root": "MuiTouchRipple-root-39",
+                      }
+                    }
+                  >
+                    <TransitionGroup
+                      childFactory={[Function]}
+                      className="MuiTouchRipple-root-39"
+                      component="span"
+                      enter={true}
+                      exit={true}
+                    >
+                      <span
+                        className="MuiTouchRipple-root-39"
+                      />
+                    </TransitionGroup>
+                  </TouchRipple>
+                </WithStyles(TouchRipple)>
+              </NoSsr>
+            </button>
+          </ButtonBase>
+        </WithStyles(ButtonBase)>
+      </Button>
+    </WithStyles(Button)>
   </div>
   <div
-    className="deselect-highlighted-button"
+    style={
+      Object {
+        "left": "-48px",
+        "position": "absolute",
+        "top": "291px",
+      }
+    }
   >
     <ArrowButton
       iconType="arrowBack"
       onClick={[Function]}
     >
       <button
-        className="arrow-button"
+        className="item-selector-arrow-button"
         onClick={[Function]}
+        style={
+          Object {
+            "border": "1px solid #d5dde5",
+            "borderRadius": "4px",
+            "height": "36px",
+            "minHeight": "36px",
+            "minWidth": "40px",
+            "padding": "0",
+            "width": "40px",
+          }
+        }
       >
         <span
-          className="arrow-icon"
+          style={
+            Object {
+              "fill": "#4a5768",
+              "height": "20px",
+              "width": "24px",
+            }
+          }
         >
           <pure(ArrowBackIcon)>
             <ArrowBackIcon>
@@ -775,15 +1161,15 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
                 <SvgIcon
                   classes={
                     Object {
-                      "colorAction": "MuiSvgIcon-colorAction-4",
-                      "colorDisabled": "MuiSvgIcon-colorDisabled-6",
-                      "colorError": "MuiSvgIcon-colorError-5",
-                      "colorPrimary": "MuiSvgIcon-colorPrimary-2",
-                      "colorSecondary": "MuiSvgIcon-colorSecondary-3",
-                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-7",
-                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-9",
-                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-8",
-                      "root": "MuiSvgIcon-root-1",
+                      "colorAction": "MuiSvgIcon-colorAction-33",
+                      "colorDisabled": "MuiSvgIcon-colorDisabled-35",
+                      "colorError": "MuiSvgIcon-colorError-34",
+                      "colorPrimary": "MuiSvgIcon-colorPrimary-31",
+                      "colorSecondary": "MuiSvgIcon-colorSecondary-32",
+                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-36",
+                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-38",
+                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-37",
+                      "root": "MuiSvgIcon-root-30",
                     }
                   }
                   color="inherit"
@@ -793,7 +1179,7 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
                 >
                   <svg
                     aria-hidden="true"
-                    className="MuiSvgIcon-root-1"
+                    className="MuiSvgIcon-root-30"
                     focusable="false"
                     role="presentation"
                     viewBox="0 0 24 24"
@@ -811,10 +1197,8 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
             </ArrowBackIcon>
           </pure(ArrowBackIcon)>
         </span>
-        <style />
       </button>
     </ArrowButton>
   </div>
-  <style />
 </SelectedItems>
 `;

--- a/packages/period-selector-dialog/src/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
+++ b/packages/period-selector-dialog/src/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
@@ -1,0 +1,820 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The SelectedItems component list with items matches the snapshot with list has items 1`] = `
+<SelectedItems
+  items={
+    Array [
+      Object {
+        "id": "rb",
+        "name": "rainbow",
+      },
+      Object {
+        "id": "rr",
+        "name": "rarity",
+      },
+    ]
+  }
+  onDeselect={[MockFunction]}
+  onReorder={[MockFunction]}
+>
+  <Subtitle>
+    <div
+      className="subtitle-container"
+    >
+      <span
+        className="subtitle-text"
+      >
+        Selected Data
+      </span>
+      <style />
+    </div>
+  </Subtitle>
+  <DragDropContext
+    onDragEnd={[Function]}
+    onDragStart={[Function]}
+  >
+    <ErrorBoundary
+      onError={[Function]}
+    >
+      <Connect(Droppable)
+        direction="vertical"
+        droppableId="selected-items-droppable"
+        ignoreContainerClipping={false}
+        isCombineEnabled={false}
+        isDropDisabled={false}
+        type="DEFAULT"
+      >
+        <Droppable
+          direction="vertical"
+          droppableId="selected-items-droppable"
+          ignoreContainerClipping={false}
+          isCombineEnabled={false}
+          isDropDisabled={false}
+          placeholder={null}
+          shouldAnimatePlaceholder={true}
+          snapshot={
+            Object {
+              "draggingFromThisWith": null,
+              "draggingOverWith": null,
+              "isDraggingOver": false,
+            }
+          }
+          type="DEFAULT"
+          updateViewportMaxScroll={[Function]}
+        >
+          <DroppableDimensionPublisher
+            direction="vertical"
+            droppableId="selected-items-droppable"
+            getDroppableRef={[Function]}
+            getPlaceholderRef={[Function]}
+            ignoreContainerClipping={false}
+            isCombineEnabled={false}
+            isDropDisabled={false}
+            type="DEFAULT"
+          >
+            <ItemsList
+              data-react-beautiful-dnd-droppable="1"
+              dataTest="undefined-list"
+              innerRef={[Function]}
+            >
+              <ul
+                className="selected-list"
+                data-test="undefined-list"
+              >
+                <Connect(Draggable)
+                  disableInteractiveElementBlocking={false}
+                  draggableId="rb"
+                  index={0}
+                  isDragDisabled={false}
+                  key="rb"
+                  shouldRespectForceTouch={true}
+                >
+                  <Draggable
+                    disableInteractiveElementBlocking={false}
+                    draggableId="rb"
+                    drop={[Function]}
+                    dropAnimationFinished={[Function]}
+                    index={0}
+                    isDragDisabled={false}
+                    lift={[Function]}
+                    mapped={
+                      Object {
+                        "combineTargetFor": null,
+                        "offset": Object {
+                          "x": 0,
+                          "y": 0,
+                        },
+                        "shouldAnimateDisplacement": true,
+                        "snapshot": Object {
+                          "combineTargetFor": null,
+                          "combineWith": null,
+                          "draggingOver": null,
+                          "dropAnimation": null,
+                          "isDragging": false,
+                          "isDropAnimating": false,
+                          "mode": null,
+                        },
+                        "type": "SECONDARY",
+                      }
+                    }
+                    move={[Function]}
+                    moveByWindowScroll={[Function]}
+                    moveDown={[Function]}
+                    moveLeft={[Function]}
+                    moveRight={[Function]}
+                    moveUp={[Function]}
+                    shouldRespectForceTouch={true}
+                  >
+                    <DraggableDimensionPublisher
+                      draggableId="rb"
+                      droppableId="selected-items-droppable"
+                      getDraggableRef={[Function]}
+                      index={0}
+                      key="rb"
+                      type="DEFAULT"
+                    >
+                      <DragHandle
+                        callbacks={
+                          Object {
+                            "onCancel": [Function],
+                            "onDrop": [Function],
+                            "onLift": [Function],
+                            "onMove": [Function],
+                            "onMoveDown": [Function],
+                            "onMoveLeft": [Function],
+                            "onMoveRight": [Function],
+                            "onMoveUp": [Function],
+                            "onWindowScroll": [Function],
+                          }
+                        }
+                        canDragInteractiveElements={false}
+                        draggableId="rb"
+                        getDraggableRef={[Function]}
+                        getShouldRespectForceTouch={[Function]}
+                        isDragging={false}
+                        isDropAnimating={false}
+                        isEnabled={true}
+                      >
+                        <li
+                          aria-roledescription="Draggable item. Press space bar to lift"
+                          className="selected-list-item"
+                          data-react-beautiful-dnd-drag-handle="1"
+                          data-react-beautiful-dnd-draggable="1"
+                          data-test="undefined-list-item"
+                          draggable={false}
+                          id="rb"
+                          onBlur={[Function]}
+                          onDoubleClick={[Function]}
+                          onDragStart={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchStart={[Function]}
+                          onTransitionEnd={null}
+                          style={
+                            Object {
+                              "transform": null,
+                              "transition": null,
+                            }
+                          }
+                          tabIndex={0}
+                        >
+                          <Item
+                            active={true}
+                            ghost={false}
+                            highlighted={false}
+                            id="rb"
+                            index={0}
+                            name="rainbow"
+                            onClick={[Function]}
+                            onRemoveItem={[Function]}
+                          >
+                            <div
+                              className="item selected-item"
+                              data-test="dimension-item-rb"
+                              onClick={[Function]}
+                            >
+                              <ItemIcon
+                                backgroundColor="#00796b"
+                              >
+                                <div>
+                                  <style>
+                                    
+                div {
+                    background-color: #00796b;
+                    min-height: 6px;
+                    min-width: 6px;
+                    margin: 0px 5px;
+                }
+            
+                                  </style>
+                                </div>
+                              </ItemIcon>
+                              <span
+                                className="item-label"
+                              >
+                                rainbow
+                              </span>
+                              <DeselectIconButton
+                                fill="#00796b"
+                                onClick={[Function]}
+                              >
+                                <button
+                                  className="deselect-icon-button"
+                                  onClick={[Function]}
+                                >
+                                  <span>
+                                    <pure(CloseIcon)
+                                      style={
+                                        Object {
+                                          "fill": "#00796b",
+                                          "height": "13px",
+                                          "width": "10px",
+                                        }
+                                      }
+                                    >
+                                      <CloseIcon
+                                        style={
+                                          Object {
+                                            "fill": "#00796b",
+                                            "height": "13px",
+                                            "width": "10px",
+                                          }
+                                        }
+                                      >
+                                        <WithStyles(SvgIcon)
+                                          style={
+                                            Object {
+                                              "fill": "#00796b",
+                                              "height": "13px",
+                                              "width": "10px",
+                                            }
+                                          }
+                                        >
+                                          <SvgIcon
+                                            classes={
+                                              Object {
+                                                "colorAction": "MuiSvgIcon-colorAction-4",
+                                                "colorDisabled": "MuiSvgIcon-colorDisabled-6",
+                                                "colorError": "MuiSvgIcon-colorError-5",
+                                                "colorPrimary": "MuiSvgIcon-colorPrimary-2",
+                                                "colorSecondary": "MuiSvgIcon-colorSecondary-3",
+                                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-7",
+                                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-9",
+                                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-8",
+                                                "root": "MuiSvgIcon-root-1",
+                                              }
+                                            }
+                                            color="inherit"
+                                            component="svg"
+                                            fontSize="default"
+                                            style={
+                                              Object {
+                                                "fill": "#00796b",
+                                                "height": "13px",
+                                                "width": "10px",
+                                              }
+                                            }
+                                            viewBox="0 0 24 24"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              className="MuiSvgIcon-root-1"
+                                              focusable="false"
+                                              role="presentation"
+                                              style={
+                                                Object {
+                                                  "fill": "#00796b",
+                                                  "height": "13px",
+                                                  "width": "10px",
+                                                }
+                                              }
+                                              viewBox="0 0 24 24"
+                                            >
+                                              <path
+                                                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                              />
+                                              <path
+                                                d="M0 0h24v24H0z"
+                                                fill="none"
+                                              />
+                                            </svg>
+                                          </SvgIcon>
+                                        </WithStyles(SvgIcon)>
+                                      </CloseIcon>
+                                    </pure(CloseIcon)>
+                                  </span>
+                                  <style />
+                                </button>
+                              </DeselectIconButton>
+                              <style />
+                            </div>
+                          </Item>
+                          <style />
+                        </li>
+                      </DragHandle>
+                    </DraggableDimensionPublisher>
+                  </Draggable>
+                </Connect(Draggable)>
+                <Connect(Draggable)
+                  disableInteractiveElementBlocking={false}
+                  draggableId="rr"
+                  index={1}
+                  isDragDisabled={false}
+                  key="rr"
+                  shouldRespectForceTouch={true}
+                >
+                  <Draggable
+                    disableInteractiveElementBlocking={false}
+                    draggableId="rr"
+                    drop={[Function]}
+                    dropAnimationFinished={[Function]}
+                    index={1}
+                    isDragDisabled={false}
+                    lift={[Function]}
+                    mapped={
+                      Object {
+                        "combineTargetFor": null,
+                        "offset": Object {
+                          "x": 0,
+                          "y": 0,
+                        },
+                        "shouldAnimateDisplacement": true,
+                        "snapshot": Object {
+                          "combineTargetFor": null,
+                          "combineWith": null,
+                          "draggingOver": null,
+                          "dropAnimation": null,
+                          "isDragging": false,
+                          "isDropAnimating": false,
+                          "mode": null,
+                        },
+                        "type": "SECONDARY",
+                      }
+                    }
+                    move={[Function]}
+                    moveByWindowScroll={[Function]}
+                    moveDown={[Function]}
+                    moveLeft={[Function]}
+                    moveRight={[Function]}
+                    moveUp={[Function]}
+                    shouldRespectForceTouch={true}
+                  >
+                    <DraggableDimensionPublisher
+                      draggableId="rr"
+                      droppableId="selected-items-droppable"
+                      getDraggableRef={[Function]}
+                      index={1}
+                      key="rr"
+                      type="DEFAULT"
+                    >
+                      <DragHandle
+                        callbacks={
+                          Object {
+                            "onCancel": [Function],
+                            "onDrop": [Function],
+                            "onLift": [Function],
+                            "onMove": [Function],
+                            "onMoveDown": [Function],
+                            "onMoveLeft": [Function],
+                            "onMoveRight": [Function],
+                            "onMoveUp": [Function],
+                            "onWindowScroll": [Function],
+                          }
+                        }
+                        canDragInteractiveElements={false}
+                        draggableId="rr"
+                        getDraggableRef={[Function]}
+                        getShouldRespectForceTouch={[Function]}
+                        isDragging={false}
+                        isDropAnimating={false}
+                        isEnabled={true}
+                      >
+                        <li
+                          aria-roledescription="Draggable item. Press space bar to lift"
+                          className="selected-list-item"
+                          data-react-beautiful-dnd-drag-handle="1"
+                          data-react-beautiful-dnd-draggable="1"
+                          data-test="undefined-list-item"
+                          draggable={false}
+                          id="rr"
+                          onBlur={[Function]}
+                          onDoubleClick={[Function]}
+                          onDragStart={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchStart={[Function]}
+                          onTransitionEnd={null}
+                          style={
+                            Object {
+                              "transform": null,
+                              "transition": null,
+                            }
+                          }
+                          tabIndex={0}
+                        >
+                          <Item
+                            active={true}
+                            ghost={false}
+                            highlighted={false}
+                            id="rr"
+                            index={1}
+                            name="rarity"
+                            onClick={[Function]}
+                            onRemoveItem={[Function]}
+                          >
+                            <div
+                              className="item selected-item"
+                              data-test="dimension-item-rr"
+                              onClick={[Function]}
+                            >
+                              <ItemIcon
+                                backgroundColor="#00796b"
+                              >
+                                <div>
+                                  <style>
+                                    
+                div {
+                    background-color: #00796b;
+                    min-height: 6px;
+                    min-width: 6px;
+                    margin: 0px 5px;
+                }
+            
+                                  </style>
+                                </div>
+                              </ItemIcon>
+                              <span
+                                className="item-label"
+                              >
+                                rarity
+                              </span>
+                              <DeselectIconButton
+                                fill="#00796b"
+                                onClick={[Function]}
+                              >
+                                <button
+                                  className="deselect-icon-button"
+                                  onClick={[Function]}
+                                >
+                                  <span>
+                                    <pure(CloseIcon)
+                                      style={
+                                        Object {
+                                          "fill": "#00796b",
+                                          "height": "13px",
+                                          "width": "10px",
+                                        }
+                                      }
+                                    >
+                                      <CloseIcon
+                                        style={
+                                          Object {
+                                            "fill": "#00796b",
+                                            "height": "13px",
+                                            "width": "10px",
+                                          }
+                                        }
+                                      >
+                                        <WithStyles(SvgIcon)
+                                          style={
+                                            Object {
+                                              "fill": "#00796b",
+                                              "height": "13px",
+                                              "width": "10px",
+                                            }
+                                          }
+                                        >
+                                          <SvgIcon
+                                            classes={
+                                              Object {
+                                                "colorAction": "MuiSvgIcon-colorAction-4",
+                                                "colorDisabled": "MuiSvgIcon-colorDisabled-6",
+                                                "colorError": "MuiSvgIcon-colorError-5",
+                                                "colorPrimary": "MuiSvgIcon-colorPrimary-2",
+                                                "colorSecondary": "MuiSvgIcon-colorSecondary-3",
+                                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-7",
+                                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-9",
+                                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-8",
+                                                "root": "MuiSvgIcon-root-1",
+                                              }
+                                            }
+                                            color="inherit"
+                                            component="svg"
+                                            fontSize="default"
+                                            style={
+                                              Object {
+                                                "fill": "#00796b",
+                                                "height": "13px",
+                                                "width": "10px",
+                                              }
+                                            }
+                                            viewBox="0 0 24 24"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              className="MuiSvgIcon-root-1"
+                                              focusable="false"
+                                              role="presentation"
+                                              style={
+                                                Object {
+                                                  "fill": "#00796b",
+                                                  "height": "13px",
+                                                  "width": "10px",
+                                                }
+                                              }
+                                              viewBox="0 0 24 24"
+                                            >
+                                              <path
+                                                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                              />
+                                              <path
+                                                d="M0 0h24v24H0z"
+                                                fill="none"
+                                              />
+                                            </svg>
+                                          </SvgIcon>
+                                        </WithStyles(SvgIcon)>
+                                      </CloseIcon>
+                                    </pure(CloseIcon)>
+                                  </span>
+                                  <style />
+                                </button>
+                              </DeselectIconButton>
+                              <style />
+                            </div>
+                          </Item>
+                          <style />
+                        </li>
+                      </DragHandle>
+                    </DraggableDimensionPublisher>
+                  </Draggable>
+                </Connect(Draggable)>
+                <AnimateInOut
+                  on={null}
+                  shouldAnimate={true}
+                />
+                <style />
+              </ul>
+            </ItemsList>
+          </DroppableDimensionPublisher>
+        </Droppable>
+      </Connect(Droppable)>
+    </ErrorBoundary>
+  </DragDropContext>
+  <div
+    className="deselect-all-button"
+  >
+    <Button
+      dataTest="undefined-deselect-all-button"
+      onClick={[Function]}
+      type="button"
+    >
+      <button
+        className="jsx-2371629422 "
+        data-test="undefined-deselect-all-button"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        type="button"
+      >
+        Deselect All
+        <JSXStyle
+          id="2371629422"
+        />
+      </button>
+    </Button>
+  </div>
+  <div
+    className="deselect-highlighted-button"
+  >
+    <ArrowButton
+      iconType="arrowBack"
+      onClick={[Function]}
+    >
+      <button
+        className="arrow-button"
+        onClick={[Function]}
+      >
+        <span
+          className="arrow-icon"
+        >
+          <pure(ArrowBackIcon)>
+            <ArrowBackIcon>
+              <WithStyles(SvgIcon)>
+                <SvgIcon
+                  classes={
+                    Object {
+                      "colorAction": "MuiSvgIcon-colorAction-4",
+                      "colorDisabled": "MuiSvgIcon-colorDisabled-6",
+                      "colorError": "MuiSvgIcon-colorError-5",
+                      "colorPrimary": "MuiSvgIcon-colorPrimary-2",
+                      "colorSecondary": "MuiSvgIcon-colorSecondary-3",
+                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-7",
+                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-9",
+                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-8",
+                      "root": "MuiSvgIcon-root-1",
+                    }
+                  }
+                  color="inherit"
+                  component="svg"
+                  fontSize="default"
+                  viewBox="0 0 24 24"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="MuiSvgIcon-root-1"
+                    focusable="false"
+                    role="presentation"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+                    />
+                  </svg>
+                </SvgIcon>
+              </WithStyles(SvgIcon)>
+            </ArrowBackIcon>
+          </pure(ArrowBackIcon)>
+        </span>
+        <style />
+      </button>
+    </ArrowButton>
+  </div>
+  <style />
+</SelectedItems>
+`;
+
+exports[`The SelectedItems component matches the snapshot when list is empty 1`] = `
+<SelectedItems
+  items={Array []}
+  onDeselect={[MockFunction]}
+  onReorder={[MockFunction]}
+>
+  <Subtitle>
+    <div
+      className="subtitle-container"
+    >
+      <span
+        className="subtitle-text"
+      >
+        Selected Data
+      </span>
+      <style />
+    </div>
+  </Subtitle>
+  <DragDropContext
+    onDragEnd={[Function]}
+    onDragStart={[Function]}
+  >
+    <ErrorBoundary
+      onError={[Function]}
+    >
+      <Connect(Droppable)
+        direction="vertical"
+        droppableId="selected-items-droppable"
+        ignoreContainerClipping={false}
+        isCombineEnabled={false}
+        isDropDisabled={false}
+        type="DEFAULT"
+      >
+        <Droppable
+          direction="vertical"
+          droppableId="selected-items-droppable"
+          ignoreContainerClipping={false}
+          isCombineEnabled={false}
+          isDropDisabled={false}
+          placeholder={null}
+          shouldAnimatePlaceholder={true}
+          snapshot={
+            Object {
+              "draggingFromThisWith": null,
+              "draggingOverWith": null,
+              "isDraggingOver": false,
+            }
+          }
+          type="DEFAULT"
+          updateViewportMaxScroll={[Function]}
+        >
+          <DroppableDimensionPublisher
+            direction="vertical"
+            droppableId="selected-items-droppable"
+            getDroppableRef={[Function]}
+            getPlaceholderRef={[Function]}
+            ignoreContainerClipping={false}
+            isCombineEnabled={false}
+            isDropDisabled={false}
+            type="DEFAULT"
+          >
+            <ItemsList
+              data-react-beautiful-dnd-droppable="0"
+              dataTest="undefined-list"
+              innerRef={[Function]}
+            >
+              <ul
+                className="selected-list"
+                data-test="undefined-list"
+              >
+                <AnimateInOut
+                  on={null}
+                  shouldAnimate={true}
+                />
+                <style />
+              </ul>
+            </ItemsList>
+          </DroppableDimensionPublisher>
+        </Droppable>
+      </Connect(Droppable)>
+    </ErrorBoundary>
+  </DragDropContext>
+  <div
+    className="deselect-all-button"
+  >
+    <Button
+      dataTest="undefined-deselect-all-button"
+      onClick={[Function]}
+      type="button"
+    >
+      <button
+        className="jsx-2371629422 "
+        data-test="undefined-deselect-all-button"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        type="button"
+      >
+        Deselect All
+        <JSXStyle
+          id="2371629422"
+        />
+      </button>
+    </Button>
+  </div>
+  <div
+    className="deselect-highlighted-button"
+  >
+    <ArrowButton
+      iconType="arrowBack"
+      onClick={[Function]}
+    >
+      <button
+        className="arrow-button"
+        onClick={[Function]}
+      >
+        <span
+          className="arrow-icon"
+        >
+          <pure(ArrowBackIcon)>
+            <ArrowBackIcon>
+              <WithStyles(SvgIcon)>
+                <SvgIcon
+                  classes={
+                    Object {
+                      "colorAction": "MuiSvgIcon-colorAction-4",
+                      "colorDisabled": "MuiSvgIcon-colorDisabled-6",
+                      "colorError": "MuiSvgIcon-colorError-5",
+                      "colorPrimary": "MuiSvgIcon-colorPrimary-2",
+                      "colorSecondary": "MuiSvgIcon-colorSecondary-3",
+                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-7",
+                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-9",
+                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-8",
+                      "root": "MuiSvgIcon-root-1",
+                    }
+                  }
+                  color="inherit"
+                  component="svg"
+                  fontSize="default"
+                  viewBox="0 0 24 24"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="MuiSvgIcon-root-1"
+                    focusable="false"
+                    role="presentation"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+                    />
+                  </svg>
+                </SvgIcon>
+              </WithStyles(SvgIcon)>
+            </ArrowBackIcon>
+          </pure(ArrowBackIcon)>
+        </span>
+        <style />
+      </button>
+    </ArrowButton>
+  </div>
+  <style />
+</SelectedItems>
+`;

--- a/packages/period-selector-dialog/src/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
+++ b/packages/period-selector-dialog/src/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
@@ -89,11 +89,9 @@ exports[`The SelectedItems component list with items matches the snapshot with l
           >
             <ItemsList
               data-react-beautiful-dnd-droppable="1"
-              dataTest="undefined-list"
               innerRef={[Function]}
             >
               <ul
-                data-test="undefined-list"
                 style={
                   Object {
                     "flex": "1",
@@ -184,7 +182,6 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                           className="selected-list-item"
                           data-react-beautiful-dnd-drag-handle="1"
                           data-react-beautiful-dnd-draggable="1"
-                          data-test="undefined-list-item"
                           draggable={false}
                           id="rb"
                           onBlur={[Function]}
@@ -438,7 +435,6 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                           className="selected-list-item"
                           data-react-beautiful-dnd-drag-handle="1"
                           data-react-beautiful-dnd-draggable="1"
-                          data-test="undefined-list-item"
                           draggable={false}
                           id="rr"
                           onBlur={[Function]}
@@ -634,7 +630,6 @@ exports[`The SelectedItems component list with items matches the snapshot with l
     }
   >
     <WithStyles(Button)
-      dataTest="undefined-deselect-all-button"
       onClick={[Function]}
     >
       <Button
@@ -670,7 +665,6 @@ exports[`The SelectedItems component list with items matches the snapshot with l
         }
         color="default"
         component="button"
-        dataTest="undefined-deselect-all-button"
         disableFocusRipple={false}
         disabled={false}
         fullWidth={false}
@@ -683,7 +677,6 @@ exports[`The SelectedItems component list with items matches the snapshot with l
         <WithStyles(ButtonBase)
           className="MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6"
           component="button"
-          dataTest="undefined-deselect-all-button"
           disabled={false}
           focusRipple={true}
           focusVisibleClassName="MuiButton-focusVisible-20"
@@ -701,7 +694,6 @@ exports[`The SelectedItems component list with items matches the snapshot with l
               }
             }
             component="button"
-            dataTest="undefined-deselect-all-button"
             disableRipple={false}
             disableTouchRipple={false}
             disabled={false}
@@ -713,7 +705,6 @@ exports[`The SelectedItems component list with items matches the snapshot with l
           >
             <button
               className="MuiButtonBase-root-27 MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6"
-              dataTest="undefined-deselect-all-button"
               disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
@@ -939,11 +930,9 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
           >
             <ItemsList
               data-react-beautiful-dnd-droppable="0"
-              dataTest="undefined-list"
               innerRef={[Function]}
             >
               <ul
-                data-test="undefined-list"
                 style={
                   Object {
                     "flex": "1",
@@ -976,7 +965,6 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
     }
   >
     <WithStyles(Button)
-      dataTest="undefined-deselect-all-button"
       onClick={[Function]}
     >
       <Button
@@ -1012,7 +1000,6 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
         }
         color="default"
         component="button"
-        dataTest="undefined-deselect-all-button"
         disableFocusRipple={false}
         disabled={false}
         fullWidth={false}
@@ -1025,7 +1012,6 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
         <WithStyles(ButtonBase)
           className="MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6"
           component="button"
-          dataTest="undefined-deselect-all-button"
           disabled={false}
           focusRipple={true}
           focusVisibleClassName="MuiButton-focusVisible-20"
@@ -1043,7 +1029,6 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
               }
             }
             component="button"
-            dataTest="undefined-deselect-all-button"
             disableRipple={false}
             disableTouchRipple={false}
             disabled={false}
@@ -1055,7 +1040,6 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
           >
             <button
               className="MuiButtonBase-root-27 MuiButton-root-1 MuiButton-text-3 MuiButton-flat-6"
-              dataTest="undefined-deselect-all-button"
               disabled={false}
               onBlur={[Function]}
               onClick={[Function]}

--- a/packages/period-selector-dialog/src/ItemSelector/__tests__/__snapshots__/UnselectedItems.spec.js.snap
+++ b/packages/period-selector-dialog/src/ItemSelector/__tests__/__snapshots__/UnselectedItems.spec.js.snap
@@ -12,7 +12,6 @@ exports[`UnselectedItems component list with items matches the snapshot when lis
     }
   >
     <ul
-      data-test="undefined-list"
       style={
         Object {
           "borderBottom": "0px",
@@ -24,7 +23,6 @@ exports[`UnselectedItems component list with items matches the snapshot when lis
       }
     >
       <li
-        data-test="undefined-list-item"
         key="rb"
         onDoubleClick={[Function]}
         style={
@@ -43,7 +41,6 @@ exports[`UnselectedItems component list with items matches the snapshot when lis
         />
       </li>
       <li
-        data-test="undefined-list-item"
         key="rr"
         onDoubleClick={[Function]}
         style={
@@ -74,7 +71,6 @@ exports[`UnselectedItems component list with items matches the snapshot when lis
     }
   >
     <WithStyles(Button)
-      dataTest="undefined-select-all-button"
       onClick={[Function]}
     >
       Select all
@@ -109,7 +105,6 @@ exports[`UnselectedItems component matches the snapshot when list is empty 1`] =
     }
   >
     <ul
-      data-test="undefined-list"
       style={
         Object {
           "borderBottom": "0px",
@@ -132,7 +127,6 @@ exports[`UnselectedItems component matches the snapshot when list is empty 1`] =
     }
   >
     <WithStyles(Button)
-      dataTest="undefined-select-all-button"
       onClick={[Function]}
     >
       Select all

--- a/packages/period-selector-dialog/src/ItemSelector/__tests__/__snapshots__/UnselectedItems.spec.js.snap
+++ b/packages/period-selector-dialog/src/ItemSelector/__tests__/__snapshots__/UnselectedItems.spec.js.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UnselectedItems component list with items matches the snapshot when list has items 1`] = `
+<Fragment>
+  <div
+    className="unselected-list-container"
+    onScroll={[Function]}
+  >
+    <ul
+      className="unselected-list"
+      data-test="undefined-list"
+    >
+      <li
+        className="unselected-list-item"
+        data-test="undefined-list-item"
+        key="rb"
+        onDoubleClick={[Function]}
+      >
+        <Item
+          highlighted={false}
+          id="rb"
+          index={0}
+          name="rainbow"
+          onClick={[Function]}
+        />
+        <style />
+      </li>
+      <li
+        className="unselected-list-item"
+        data-test="undefined-list-item"
+        key="rr"
+        onDoubleClick={[Function]}
+      >
+        <Item
+          highlighted={false}
+          id="rr"
+          index={1}
+          name="rarity"
+          onClick={[Function]}
+        />
+        <style />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="select-all-button"
+  >
+    <Button
+      dataTest="undefined-select-all-button"
+      onClick={[Function]}
+      type="button"
+    >
+      Select all
+    </Button>
+  </div>
+  <div
+    className="select-highlighted-button"
+  >
+    <ArrowButton
+      iconType="arrowForward"
+      onClick={[Function]}
+    />
+  </div>
+  <style />
+</Fragment>
+`;
+
+exports[`UnselectedItems component matches the snapshot when list is empty 1`] = `
+<Fragment>
+  <div
+    className="unselected-list-container"
+    onScroll={[Function]}
+  >
+    <ul
+      className="unselected-list"
+      data-test="undefined-list"
+    />
+  </div>
+  <div
+    className="select-all-button"
+  >
+    <Button
+      dataTest="undefined-select-all-button"
+      onClick={[Function]}
+      type="button"
+    >
+      Select all
+    </Button>
+  </div>
+  <div
+    className="select-highlighted-button"
+  >
+    <ArrowButton
+      iconType="arrowForward"
+      onClick={[Function]}
+    />
+  </div>
+  <style />
+</Fragment>
+`;

--- a/packages/period-selector-dialog/src/ItemSelector/__tests__/__snapshots__/UnselectedItems.spec.js.snap
+++ b/packages/period-selector-dialog/src/ItemSelector/__tests__/__snapshots__/UnselectedItems.spec.js.snap
@@ -3,18 +3,36 @@
 exports[`UnselectedItems component list with items matches the snapshot when list has items 1`] = `
 <Fragment>
   <div
-    className="unselected-list-container"
     onScroll={[Function]}
+    style={
+      Object {
+        "flex": "1",
+        "overflowY": "auto",
+      }
+    }
   >
     <ul
-      className="unselected-list"
       data-test="undefined-list"
+      style={
+        Object {
+          "borderBottom": "0px",
+          "listStyle": "none",
+          "margin": "0px",
+          "paddingLeft": "0px",
+          "userSelect": "none",
+        }
+      }
     >
       <li
-        className="unselected-list-item"
         data-test="undefined-list-item"
         key="rb"
         onDoubleClick={[Function]}
+        style={
+          Object {
+            "display": "flex",
+            "margin": "2px",
+          }
+        }
       >
         <Item
           highlighted={false}
@@ -23,13 +41,17 @@ exports[`UnselectedItems component list with items matches the snapshot when lis
           name="rainbow"
           onClick={[Function]}
         />
-        <style />
       </li>
       <li
-        className="unselected-list-item"
         data-test="undefined-list-item"
         key="rr"
         onDoubleClick={[Function]}
+        style={
+          Object {
+            "display": "flex",
+            "margin": "2px",
+          }
+        }
       >
         <Item
           highlighted={false}
@@ -38,63 +60,97 @@ exports[`UnselectedItems component list with items matches the snapshot when lis
           name="rarity"
           onClick={[Function]}
         />
-        <style />
       </li>
     </ul>
   </div>
   <div
     className="select-all-button"
+    style={
+      Object {
+        "display": "block",
+        "margin": "0 auto",
+        "padding": "5px",
+      }
+    }
   >
-    <Button
+    <WithStyles(Button)
       dataTest="undefined-select-all-button"
       onClick={[Function]}
-      type="button"
     >
       Select all
-    </Button>
+    </WithStyles(Button)>
   </div>
   <div
-    className="select-highlighted-button"
+    style={
+      Object {
+        "left": "426px",
+        "position": "absolute",
+        "top": "230px",
+      }
+    }
   >
     <ArrowButton
       iconType="arrowForward"
       onClick={[Function]}
     />
   </div>
-  <style />
 </Fragment>
 `;
 
 exports[`UnselectedItems component matches the snapshot when list is empty 1`] = `
 <Fragment>
   <div
-    className="unselected-list-container"
     onScroll={[Function]}
+    style={
+      Object {
+        "flex": "1",
+        "overflowY": "auto",
+      }
+    }
   >
     <ul
-      className="unselected-list"
       data-test="undefined-list"
+      style={
+        Object {
+          "borderBottom": "0px",
+          "listStyle": "none",
+          "margin": "0px",
+          "paddingLeft": "0px",
+          "userSelect": "none",
+        }
+      }
     />
   </div>
   <div
     className="select-all-button"
+    style={
+      Object {
+        "display": "block",
+        "margin": "0 auto",
+        "padding": "5px",
+      }
+    }
   >
-    <Button
+    <WithStyles(Button)
       dataTest="undefined-select-all-button"
       onClick={[Function]}
-      type="button"
     >
       Select all
-    </Button>
+    </WithStyles(Button)>
   </div>
   <div
-    className="select-highlighted-button"
+    style={
+      Object {
+        "left": "426px",
+        "position": "absolute",
+        "top": "230px",
+      }
+    }
   >
     <ArrowButton
       iconType="arrowForward"
       onClick={[Function]}
     />
   </div>
-  <style />
 </Fragment>
 `;

--- a/packages/period-selector-dialog/src/ItemSelector/modules/__tests__/reorderList.spec.js
+++ b/packages/period-selector-dialog/src/ItemSelector/modules/__tests__/reorderList.spec.js
@@ -1,0 +1,163 @@
+import { reorderList } from '../reorderList'
+
+const items = [
+    {
+        id: '1',
+    },
+    {
+        id: '2',
+    },
+    {
+        id: '3',
+    },
+    {
+        id: '4',
+    },
+    {
+        id: '5',
+    },
+    {
+        id: '6',
+    },
+]
+
+describe('reorderList', () => {
+    const props = {
+        items,
+        highlightedItemIds: [],
+        destinationIndex: 0,
+        sourceIndex: 0,
+        draggableId: '',
+    }
+
+    beforeEach(() => {
+        props.highlightedItemIds = []
+    })
+
+    describe('single item drag', () => {
+        beforeEach(() => {
+            props.isMultiDrag = false
+        })
+
+        it('moves 1st item to 5th position', () => {
+            props.highlightedItemIds = [items[0].id]
+            props.draggableId = items[0].id
+            props.sourceIndex = 0
+            props.destinationIndex = 4
+
+            const result = reorderList(props)
+            const expected = ['2', '3', '4', '5', '1', '6']
+            expect(result).toEqual(expected)
+        })
+
+        it('moves last item to 3rd position', () => {
+            props.highlightedItemIds = [items[5].id]
+            props.draggableId = items[5].id
+            props.sourceIndex = 5
+            props.destinationIndex = 2
+
+            const result = reorderList(props)
+            const expected = ['1', '2', '6', '3', '4', '5']
+            expect(result).toEqual(expected)
+        })
+    })
+
+    describe('multi item drag', () => {
+        beforeEach(() => {
+            props.isMultiDrag = true
+        })
+
+        it('moves first two items to 3rd position', () => {
+            props.highlightedItemIds = [items[0].id, items[1].id]
+            props.draggableId = items[0].id
+            props.sourceIndex = 0
+            props.destinationIndex = 4
+
+            const result = reorderList(props)
+            const expected = ['3', '4', '1', '2', '5', '6']
+            expect(result).toEqual(expected)
+        })
+
+        it('moves first two items to 5th (2nd to last) position', () => {
+            props.highlightedItemIds = [items[0].id, items[1].id]
+            props.draggableId = items[0].id
+            props.sourceIndex = 0
+            props.destinationIndex = 5
+
+            const result = reorderList(props)
+            const expected = ['3', '4', '5', '1', '2', '6']
+            expect(result).toEqual(expected)
+        })
+
+        it('moves first two items to last position', () => {
+            props.highlightedItemIds = [items[0].id, items[1].id]
+            props.draggableId = items[0].id
+            props.sourceIndex = 0
+            props.destinationIndex = 6
+
+            const result = reorderList(props)
+            const expected = ['3', '4', '5', '6', '1', '2']
+            expect(result).toEqual(expected)
+        })
+
+        it('moves last two items to 3rd position', () => {
+            props.highlightedItemIds = [items[4].id, items[5].id]
+            props.draggableId = items[4].id
+            props.sourceIndex = 5
+            props.destinationIndex = 2
+
+            const result = reorderList(props)
+            const expected = ['1', '2', '5', '6', '3', '4']
+            expect(result).toEqual(expected)
+        })
+
+        it('moves second and sixth items to 4th position', () => {
+            props.highlightedItemIds = [items[1].id, items[5].id]
+            props.draggableId = items[1].id
+            props.sourceIndex = 1
+            props.destinationIndex = 4
+
+            const result = reorderList(props)
+            const expected = ['1', '3', '4', '2', '6', '5']
+            expect(result).toEqual(expected)
+        })
+
+        it('moves first three items to 2nd position', () => {
+            props.highlightedItemIds = [items[0].id, items[1].id, items[2].id]
+            props.draggableId = items[1].id
+            props.sourceIndex = 0
+            props.destinationIndex = 4
+
+            const result = reorderList(props)
+            const expected = ['4', '1', '2', '3', '5', '6']
+            expect(result).toEqual(expected)
+        })
+
+        it('moves first four items to 2nd position', () => {
+            props.highlightedItemIds = [
+                items[0].id,
+                items[1].id,
+                items[2].id,
+                items[3].id,
+            ]
+            props.draggableId = items[1].id
+            props.sourceIndex = 0
+            props.destinationIndex = 5
+
+            const result = reorderList(props)
+            const expected = ['5', '1', '2', '3', '4', '6']
+            expect(result).toEqual(expected)
+        })
+
+        it('moves last three items to 1st position', () => {
+            props.highlightedItemIds = [items[3].id, items[4].id, items[5].id]
+            props.draggableId = items[4].id
+            props.sourceIndex = 4
+            props.destinationIndex = 0
+
+            const result = reorderList(props)
+            const expected = ['4', '5', '6', '1', '2', '3']
+            expect(result).toEqual(expected)
+        })
+    })
+})

--- a/packages/period-selector-dialog/src/ItemSelector/modules/__tests__/toggler.spec.js
+++ b/packages/period-selector-dialog/src/ItemSelector/modules/__tests__/toggler.spec.js
@@ -1,0 +1,251 @@
+import { toggler } from '../toggler'
+
+describe('using the toggler ', () => {
+    let id
+    let isCtrlPressed
+    let isShiftPressed
+    let index
+    let lastClickedIndex
+    let highlightedIds
+    let items
+
+    describe('with only mouse click', () => {
+        beforeEach(() => {
+            id = 'id'
+            isCtrlPressed = false
+            isShiftPressed = false
+            index = 1
+            lastClickedIndex = 0
+            highlightedIds = ['stuff', 'here']
+            items = ['some', 'id', 'strings']
+        })
+
+        it('should not add duplicate items', () => {
+            id = 'some'
+
+            const expectedResult = {
+                ids: [id],
+                lastClickedIndex: index,
+            }
+
+            const actualResult = toggler({
+                id,
+                isCtrlPressed,
+                isShiftPressed,
+                index,
+                lastClickedIndex,
+                highlightedIds,
+                items,
+            })
+
+            expect(actualResult).toStrictEqual(expectedResult)
+        })
+
+        it('should update the lastClickedIndex', () => {
+            const expectedResult = {
+                ids: id,
+                lastClickedIndex: index,
+            }
+
+            const actualResult = toggler({
+                id,
+                isCtrlPressed,
+                isShiftPressed,
+                index,
+                lastClickedIndex,
+                highlightedIds,
+                items,
+            })
+
+            expect(actualResult.lastClickedIndex).toEqual(
+                expectedResult.lastClickedIndex
+            )
+        })
+
+        it('should remove all items and replace the contens with only the given value (id)', () => {
+            const expectedResult = {
+                ids: [id],
+                lastClickedIndex: index,
+            }
+
+            const actualResult = toggler({
+                id,
+                isCtrlPressed,
+                isShiftPressed,
+                index,
+                lastClickedIndex,
+                highlightedIds,
+                items,
+            })
+
+            expect(actualResult).toEqual(expectedResult)
+        })
+    })
+
+    describe('with shift key pressed', () => {
+        beforeEach(() => {
+            id = 'ones'
+            isCtrlPressed = false
+            isShiftPressed = true
+            index = 1
+            lastClickedIndex = 0
+            highlightedIds = ['ones', 'stuff', 'here']
+            items = [
+                'ones',
+                'some',
+                'id',
+                'strings',
+                'stuff',
+                'here',
+                'as',
+                'well',
+            ]
+        })
+
+        it('should return the highlighted ids in the same order as original item list', () => {
+            const actual = toggler({
+                id: 'id',
+                isCtrlPressed: false,
+                isShiftPressed: true,
+                index: 2,
+                lastClickedIndex: 0,
+                highlightedIds: ['ones'],
+                items,
+            })
+
+            expect(actual.ids).toEqual(['ones', 'some', 'id'])
+        })
+
+        it('should not update the lastClickedIndex', () => {
+            const expectedResult = {
+                ids: items,
+                lastClickedIndex: lastClickedIndex,
+            }
+
+            const actualResult = toggler({
+                id,
+                isCtrlPressed,
+                isShiftPressed,
+                index,
+                lastClickedIndex,
+                highlightedIds,
+                items,
+            })
+
+            expect(actualResult.lastClickedIndex).toStrictEqual(
+                expectedResult.lastClickedIndex
+            )
+        })
+
+        it('should keep the highlighted ids and not add duplicate items', () => {
+            const expectedResult = {
+                ids: ['ones', 'some', 'stuff', 'here'],
+                lastClickedIndex: lastClickedIndex,
+            }
+
+            const actualResult = toggler({
+                id,
+                isCtrlPressed,
+                isShiftPressed,
+                index,
+                lastClickedIndex,
+                highlightedIds,
+                items,
+            })
+
+            expect(actualResult).toEqual(expectedResult)
+        })
+
+        it('should add items from lastClickedIndex to current index into the array', () => {
+            const expectedResult = {
+                ids: ['ones', 'some', 'stuff', 'here'],
+                lastClickedIndex: lastClickedIndex,
+            }
+
+            const actualResult = toggler({
+                id,
+                isCtrlPressed,
+                isShiftPressed,
+                index,
+                lastClickedIndex,
+                highlightedIds,
+                items,
+            })
+
+            expect(actualResult).toEqual(expectedResult)
+        })
+    })
+
+    describe('with meta key pressed', () => {
+        beforeEach(() => {
+            id = 'ones'
+            isCtrlPressed = true
+            isShiftPressed = false
+            index = 0
+            lastClickedIndex = 2
+            highlightedIds = ['stuff', 'here']
+            items = ['ones', 'stuff', 'here']
+        })
+
+        it('should not add duplicate items', () => {
+            id = 'stuff'
+
+            const expectedResult = {
+                ids: ['here'],
+                lastClickedIndex: lastClickedIndex,
+            }
+
+            const actualResult = toggler({
+                id,
+                isCtrlPressed,
+                isShiftPressed,
+                index,
+                lastClickedIndex,
+                highlightedIds,
+                items,
+            })
+
+            expect(actualResult).toStrictEqual(expectedResult)
+        })
+
+        it('should be able to add one item and update the lastClickedIndex', () => {
+            const expectedResult = {
+                ids: ['ones', 'stuff', 'here'],
+                lastClickedIndex: index,
+            }
+
+            const actualResult = toggler({
+                id,
+                isCtrlPressed,
+                isShiftPressed,
+                index,
+                lastClickedIndex,
+                highlightedIds,
+                items,
+            })
+
+            expect(actualResult).toStrictEqual(expectedResult)
+        })
+
+        it('should be able to remove one item without updating lastClickedIndex', () => {
+            id = 'here'
+
+            const expectedResult = {
+                ids: ['stuff'],
+                lastClickedIndex: lastClickedIndex,
+            }
+
+            const actualResult = toggler({
+                id,
+                isCtrlPressed,
+                isShiftPressed,
+                index,
+                lastClickedIndex,
+                highlightedIds,
+                items,
+            })
+
+            expect(actualResult).toStrictEqual(expectedResult)
+        })
+    })
+})

--- a/packages/period-selector-dialog/src/ItemSelector/modules/reorderList.js
+++ b/packages/period-selector-dialog/src/ItemSelector/modules/reorderList.js
@@ -1,0 +1,43 @@
+import sortBy from 'lodash/sortBy'
+
+export const reorderList = ({
+    items,
+    highlightedItemIds,
+    destinationIndex,
+    sourceIndex,
+    draggableId,
+    isMultiDrag,
+}) => {
+    const list = Array.from(items.map(item => item.id))
+
+    if (isMultiDrag) {
+        const indexedItemsToMove = sortBy(
+            highlightedItemIds.map(highlightedItemId => ({
+                item: highlightedItemId,
+                idx: items.map(item => item.id).indexOf(highlightedItemId),
+            })),
+            'idx'
+        )
+
+        const highlightedAboveDestination = indexedItemsToMove.filter(
+            item => item.idx < destinationIndex
+        )
+
+        const newDestinationIndex =
+            destinationIndex - highlightedAboveDestination.length
+
+        indexedItemsToMove.forEach(indexed => {
+            const idx = list.indexOf(indexed.item)
+            list.splice(idx, 1)
+        })
+
+        indexedItemsToMove.forEach((indexed, i) => {
+            list.splice(newDestinationIndex + i, 0, indexed.item)
+        })
+    } else {
+        list.splice(sourceIndex, 1)
+        list.splice(destinationIndex, 0, draggableId)
+    }
+
+    return list
+}

--- a/packages/period-selector-dialog/src/ItemSelector/modules/toggler.js
+++ b/packages/period-selector-dialog/src/ItemSelector/modules/toggler.js
@@ -1,0 +1,75 @@
+export const toggler = ({
+    id,
+    isCtrlPressed,
+    isShiftPressed,
+    index,
+    lastClickedIndex,
+    highlightedIds,
+    items,
+}) => {
+    let ids
+    let newIndex = lastClickedIndex
+
+    if (!isCtrlPressed && !isShiftPressed) {
+        ids = [id]
+        newIndex = index
+    } else if (isShiftPressed) {
+        const minIndex = getMinIndex(lastClickedIndex, index)
+        const maxIndex = getMaxIndex(lastClickedIndex, index)
+
+        ids = mergeIds({ highlightedIds, items, minIndex, maxIndex })
+    } else {
+        const newArr = updateArray({
+            highlightedIds,
+            id,
+            lastClickedIndex,
+            index,
+        })
+        ids = newArr.ids
+        newIndex = newArr.newIndex
+    }
+
+    const orderedIds = items.filter(item => ids.includes(item))
+
+    return {
+        ids: orderedIds,
+        lastClickedIndex: newIndex,
+    }
+}
+
+const getMinIndex = (lastClickedIndex, index) =>
+    lastClickedIndex > index ? index : lastClickedIndex
+
+const getMaxIndex = (lastClickedIndex, index) =>
+    lastClickedIndex < index ? index : lastClickedIndex
+
+const mergeIds = ({ highlightedIds, items, minIndex, maxIndex }) =>
+    highlightedIds.length
+        ? items
+              .slice(minIndex, maxIndex + 1)
+              .filter(id => !highlightedIds.includes(id))
+              .concat(highlightedIds)
+        : items.slice(minIndex, maxIndex + 1)
+
+const updateArray = ({ highlightedIds, id, lastClickedIndex, index }) => {
+    let ids
+    let newIndex = lastClickedIndex
+
+    const idIndex = highlightedIds.findIndex(
+        highlightedId => highlightedId === id
+    )
+
+    if (idIndex >= 0) {
+        ids = highlightedIds
+            .slice(0, idIndex)
+            .concat(highlightedIds.slice(idIndex + 1))
+    } else {
+        ids = [...highlightedIds, id]
+        newIndex = index
+    }
+
+    return {
+        ids,
+        newIndex,
+    }
+}

--- a/packages/period-selector-dialog/src/ItemSelector/styles/SelectedItems.style.js
+++ b/packages/period-selector-dialog/src/ItemSelector/styles/SelectedItems.style.js
@@ -1,0 +1,55 @@
+export default {
+    selectedList: {
+        flex: '1',
+        listStyle: 'none',
+        margin: '0 6px',
+        overflowY: 'auto',
+        paddingLeft: '0px',
+        userSelect: 'none',
+    },
+    selectedListItem: {
+        display: 'flex',
+        margin: '2px',
+    },
+    subtitleContainer: {
+        borderBottom: '1px solid #e8edf2',
+        height: '42px',
+    },
+    subtitleText: {
+        color: '#212934',
+        height: '20px',
+        fontFamily: 'Roboto',
+        fontSize: '15px',
+        fontWeight: '500',
+        left: '8px',
+        position: 'relative',
+        top: '12px',
+    },
+    infoContainer: {
+        display: 'flex',
+        margin: '8px',
+        padding: '8px',
+        backgroundColor: '#e8edf2',
+        borderRadius: '4px',
+    },
+    infoText: {
+        paddingLeft: '6px',
+        color: '#4a5768',
+        fontSize: '12px',
+        lineHeight: '17px',
+    },
+    infoIcon: {
+        fontSize: '16px',
+        color: '#4a5768',
+    },
+    deselectAllButton: {
+        display: 'block',
+        margin: '0 auto',
+        padding: '5px',
+    },
+    deselectHighlightedButton: {
+        left: '-48px',
+        position: 'absolute',
+        top: '291px',
+    }
+}

--- a/packages/period-selector-dialog/src/ItemSelector/styles/UnselectedItems.style.js
+++ b/packages/period-selector-dialog/src/ItemSelector/styles/UnselectedItems.style.js
@@ -1,0 +1,27 @@
+export default {
+    unselectedListContainer: {
+        flex: '1',
+        overflowY: 'auto',
+    },
+    unselectedList: {
+        borderBottom: '0px',
+        listStyle: 'none',
+        margin: '0px',
+        paddingLeft: '0px',
+        userSelect: 'none',
+    },
+    unselectedListItem: {
+        display: 'flex',
+        margin: '2px',
+    },
+    selectAllButton: {
+        display: 'block',
+        margin: '0 auto',
+        padding: '5px',
+    },
+    selectHighlightedButton: {
+        left: '426px',
+        position: 'absolute',
+        top: '230px',
+    }
+}

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/ArrowButton.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/ArrowButton.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ArrowForward from '@material-ui/icons/ArrowForward'
+import ArrowBack from '@material-ui/icons/ArrowBack'
+
+import styles from './styles/ArrowButton.style'
+
+export const ArrowButton = ({ onClick, iconType }) => (
+    <button className="item-selector-arrow-button" style={styles.arrowButton} onClick={onClick}>
+        <span style={styles.arrowIcon}>
+            {iconType === 'arrowForward' ? <ArrowForward /> : <ArrowBack />}
+        </span>
+    </button>
+)
+
+ArrowButton.propTypes = {
+    iconType: PropTypes.string,
+    onClick: PropTypes.func,
+}
+
+export default ArrowButton

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/DeselectIconButton.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/DeselectIconButton.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import DeselectIcon from '@material-ui/icons/Close'
+import styles from './styles/DeselectIconButton.style'
+
+export const DeselectIconButton = ({ fill, onClick }) => {
+    const iconStyle = {
+        height: '13px',
+        width: '10px',
+        fill,
+    }
+
+    return (
+        <button
+            style={styles.deselectIconButton}
+            onClick={e => {
+                e.stopPropagation()
+                onClick()
+            }}
+        >
+            <span>
+                <DeselectIcon style={iconStyle} />
+            </span>
+        </button>
+    )
+}
+
+DeselectIconButton.propTypes = {
+    fill: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
+}
+
+export default DeselectIconButton

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/ItemIcon.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/ItemIcon.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const ItemIcon = ({ backgroundColor }) => {
+    const style = {
+        backgroundColor,
+        minHeight: '6px',
+        minWidth: '6px',
+        margin: '0 5px',
+    }
+    return (
+        <div style={style} />
+    )
+}
+
+ItemIcon.propTypes = {
+    backgroundColor: PropTypes.string,
+}
+
+export default ItemIcon

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/SelectedItem.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/SelectedItem.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import ItemIcon from './ItemIcon'
+import DeselectIconButton from './DeselectIconButton'
+import styles from './styles/SelectedItem.style'
+
+const colors = {
+    white: '#fff'
+}
+
+const theme = {
+    secondary600: '#00796b',
+}
+
+
+const onClickWrapper = ({ id, index, onClick }) => event =>
+    onClick({
+        isCtrlPressed: event.metaKey || event.ctrlKey,
+        isShiftPressed: event.shiftKey,
+        index,
+        id,
+    })
+
+export const Item = ({
+    name,
+    highlighted,
+    ghost,
+    active,
+    onRemoveItem,
+    ...rest
+}) => {
+    const itemStyle = Object.assign({}, styles.item, ghost && styles.ghost, highlighted && styles.highlightedItem, !highlighted && styles.selectedItem, !active && styles.inactiveItem)
+    const itemLabelStyle = Object.assign({}, styles.itemLabel, highlighted && styles.highlightedText)
+    return (
+        <div
+            className={!highlighted && 'selected-period-item'}
+            style={itemStyle}
+            onClick={onClickWrapper(rest)}
+            data-test={`dimension-item-${rest.id}`}
+        >
+            <ItemIcon
+                backgroundColor={
+                    highlighted ? colors.white : theme.secondary600
+                }
+            />
+            <span
+                style={itemLabelStyle}
+            >
+                {name}
+            </span>
+            <DeselectIconButton
+                fill={highlighted ? colors.white : theme.secondary600}
+                onClick={() => onRemoveItem(rest.id)}
+            />
+        </div>
+    )
+}
+
+Item.defaultProps = {
+    active: true,
+    onRemoveItem: () => null,
+    onClick: () => null,
+}
+
+Item.propTypes = {
+    highlighted: PropTypes.bool.isRequired,
+    id: PropTypes.string.isRequired,
+    index: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+    active: PropTypes.bool,
+    ghost: PropTypes.bool,
+    onClick: PropTypes.func,
+    onRemoveItem: PropTypes.func,
+}
+
+export default Item

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/SelectedItem.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/SelectedItem.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
 import ItemIcon from './ItemIcon'
 import DeselectIconButton from './DeselectIconButton'
@@ -34,7 +35,7 @@ export const Item = ({
     const itemLabelStyle = Object.assign({}, styles.itemLabel, highlighted && styles.highlightedText)
     return (
         <div
-            className={!highlighted && 'selected-period-item'}
+            className={cx('selected-period-item', highlighted && 'highlighted')}
             style={itemStyle}
             onClick={onClickWrapper(rest)}
             data-test={`dimension-item-${rest.id}`}

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/UnselectedItem.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/UnselectedItem.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
 import ItemIcon from './ItemIcon'
 import styles from './styles/UnselectedItem.style'
@@ -13,12 +14,11 @@ const onClickWrapper = ({ id, index, onClick }) => event =>
     })
 
 export const Item = ({ name, highlighted, ...rest }) => {
-
     const itemStyle= Object.assign({}, styles.item, highlighted && styles.highlightedItem)
     const itemLabelStyle = Object.assign({}, styles.itemLabel, highlighted && styles.highlightedText)
     return (
         <div
-            className={!highlighted && "unselected-period-item"}
+            className={cx("unselected-period-item", highlighted && 'highlighted')}
             style={itemStyle}
             onClick={onClickWrapper(rest)}
             data-test={`dimension-item-${rest.id}`}

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/UnselectedItem.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/UnselectedItem.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import ItemIcon from './ItemIcon'
+import styles from './styles/UnselectedItem.style'
+
+const onClickWrapper = ({ id, index, onClick }) => event =>
+    onClick({
+        isCtrlPressed: event.metaKey || event.ctrlKey,
+        isShiftPressed: event.shiftKey,
+        index,
+        id,
+    })
+
+export const Item = ({ name, highlighted, ...rest }) => {
+
+    const itemStyle= Object.assign({}, styles.item, highlighted && styles.highlightedItem)
+    const itemLabelStyle = Object.assign({}, styles.itemLabel, highlighted && styles.highlightedText)
+    return (
+        <div
+            className={!highlighted && "unselected-period-item"}
+            style={itemStyle}
+            onClick={onClickWrapper(rest)}
+            data-test={`dimension-item-${rest.id}`}
+        >
+            <ItemIcon backgroundColor="#a0adba" />
+            <span
+                style={itemLabelStyle}
+            >
+                {name}
+            </span>
+        </div>
+    )
+}
+
+Item.defualtProps = {
+    onClick: () => null,
+}
+
+Item.propTypes = {
+    highlighted: PropTypes.bool.isRequired,
+    id: PropTypes.string.isRequired,
+    index: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+    onClick: PropTypes.func,
+}
+
+export default Item

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/__tests__/SelectedItem.spec.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/__tests__/SelectedItem.spec.js
@@ -1,0 +1,115 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Item from '../SelectedItem'
+
+describe('Selected item component', () => {
+    let props
+    let shallowItem
+
+    const item = () => {
+        if (!shallowItem) {
+            shallowItem = shallow(<Item {...props} />)
+        }
+        return shallowItem
+    }
+
+    beforeEach(() => {
+        props = {
+            id: 'selected-item-test-id',
+            name: 'I am a selected item',
+            index: 0,
+            highlighted: false,
+            ghost: false,
+            onClick: jest.fn(),
+            onRemove: jest.fn(),
+        }
+        shallowItem = undefined
+    })
+
+    it('renders an unhighlighted item', () => {
+        const wrapper = item()
+
+        expect(wrapper).toMatchSnapshot()
+    })
+
+    it('renders a highlighted item', () => {
+        props.highlighted = true
+        const wrapper = item()
+
+        expect(wrapper).toMatchSnapshot()
+    })
+
+    it('renders a ghost item', () => {
+        props.ghost = true
+        const wrapper = item()
+
+        expect(wrapper).toMatchSnapshot()
+    })
+
+    describe('onClick', () => {
+        it('fires onClick property', () => {
+            item()
+                .props()
+                .onClick({ preventDefault: () => undefined })
+
+            expect(props.onClick).toBeCalledTimes(1)
+        })
+
+        it('fires onClick with correct arguments when metaKey pressed', () => {
+            item()
+                .props()
+                .onClick({
+                    preventDefault: () => undefined,
+                    metaKey: true,
+                    ctrlKey: false,
+                    shiftKey: false,
+                })
+
+            expect(props.onClick).toBeCalledTimes(1)
+            expect(props.onClick).toBeCalledWith({
+                isCtrlPressed: true,
+                isShiftPressed: false,
+                index: 0,
+                id: props.id,
+            })
+        })
+
+        it('fires onClick with correct arguments when ctrlKey pressed', () => {
+            item()
+                .props()
+                .onClick({
+                    preventDefault: () => undefined,
+                    metaKey: false,
+                    ctrlKey: true,
+                    shiftKey: false,
+                })
+
+            expect(props.onClick).toBeCalledTimes(1)
+            expect(props.onClick).toBeCalledWith({
+                isCtrlPressed: true,
+                isShiftPressed: false,
+                index: 0,
+                id: props.id,
+            })
+        })
+
+        it('fires onClick with correct arguments when shiftKey pressed', () => {
+            item()
+                .props()
+                .onClick({
+                    preventDefault: () => undefined,
+                    metaKey: false,
+                    ctrlKey: false,
+                    shiftKey: true,
+                })
+
+            expect(props.onClick).toBeCalledTimes(1)
+            expect(props.onClick).toBeCalledWith({
+                isCtrlPressed: false,
+                isShiftPressed: true,
+                index: 0,
+                id: props.id,
+            })
+        })
+    })
+})

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/__tests__/UnselectedItem.spec.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/__tests__/UnselectedItem.spec.js
@@ -1,0 +1,106 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Item from '../UnselectedItem'
+
+describe('Unselected item component', () => {
+    let props
+    let shallowItem
+
+    const item = () => {
+        if (!shallowItem) {
+            shallowItem = shallow(<Item {...props} />)
+        }
+        return shallowItem
+    }
+
+    beforeEach(() => {
+        props = {
+            id: 'unselected-item-test-id',
+            name: 'I am an unselected item',
+            index: 0,
+            highlighted: false,
+            onClick: jest.fn(),
+        }
+        shallowItem = undefined
+    })
+
+    it('renders an unhighlighted item', () => {
+        const wrapper = item()
+
+        expect(wrapper).toMatchSnapshot()
+    })
+
+    it('renders a highlighted item', () => {
+        props.highlighted = true
+        const wrapper = item()
+
+        expect(wrapper).toMatchSnapshot()
+    })
+
+    describe('onClick', () => {
+        it('fires onClick property', () => {
+            item()
+                .props()
+                .onClick({ preventDefault: () => undefined })
+
+            expect(props.onClick).toBeCalledTimes(1)
+        })
+
+        it('fires onClick with correct arguments when metaKey pressed', () => {
+            item()
+                .props()
+                .onClick({
+                    preventDefault: () => undefined,
+                    metaKey: true,
+                    ctrlKey: false,
+                    shiftKey: false,
+                })
+
+            expect(props.onClick).toBeCalledTimes(1)
+            expect(props.onClick).toBeCalledWith({
+                isCtrlPressed: true,
+                isShiftPressed: false,
+                index: 0,
+                id: props.id,
+            })
+        })
+
+        it('fires onClick with correct arguments when ctrlKey pressed', () => {
+            item()
+                .props()
+                .onClick({
+                    preventDefault: () => undefined,
+                    metaKey: false,
+                    ctrlKey: true,
+                    shiftKey: false,
+                })
+
+            expect(props.onClick).toBeCalledTimes(1)
+            expect(props.onClick).toBeCalledWith({
+                isCtrlPressed: true,
+                isShiftPressed: false,
+                index: 0,
+                id: props.id,
+            })
+        })
+
+        it('fires onClick with correct arguments when shiftKey pressed', () => {
+            item()
+                .props()
+                .onClick({
+                    preventDefault: () => undefined,
+                    metaKey: false,
+                    ctrlKey: false,
+                    shiftKey: true,
+                })
+
+            expect(props.onClick).toBeCalledTimes(1)
+            expect(props.onClick).toBeCalledWith({
+                isCtrlPressed: false,
+                isShiftPressed: true,
+                index: 0,
+                id: props.id,
+            })
+        })
+    })
+})

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/__tests__/__snapshots__/SelectedItem.spec.js.snap
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/__tests__/__snapshots__/SelectedItem.spec.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Selected item component renders a ghost item 1`] = `
+<div
+  className="item ghost selected-item"
+  data-test="dimension-item-selected-item-test-id"
+  onClick={[Function]}
+>
+  <ItemIcon
+    backgroundColor="#00796b"
+  />
+  <span
+    className="item-label"
+  >
+    I am a selected item
+  </span>
+  <DeselectIconButton
+    fill="#00796b"
+    onClick={[Function]}
+  />
+  <style />
+</div>
+`;
+
+exports[`Selected item component renders a highlighted item 1`] = `
+<div
+  className="item highlighted-item"
+  data-test="dimension-item-selected-item-test-id"
+  onClick={[Function]}
+>
+  <ItemIcon
+    backgroundColor="#ffffff"
+  />
+  <span
+    className="item-label highlighted-text"
+  >
+    I am a selected item
+  </span>
+  <DeselectIconButton
+    fill="#ffffff"
+    onClick={[Function]}
+  />
+  <style />
+</div>
+`;
+
+exports[`Selected item component renders an unhighlighted item 1`] = `
+<div
+  className="item selected-item"
+  data-test="dimension-item-selected-item-test-id"
+  onClick={[Function]}
+>
+  <ItemIcon
+    backgroundColor="#00796b"
+  />
+  <span
+    className="item-label"
+  >
+    I am a selected item
+  </span>
+  <DeselectIconButton
+    fill="#00796b"
+    onClick={[Function]}
+  />
+  <style />
+</div>
+`;

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/__tests__/__snapshots__/SelectedItem.spec.js.snap
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/__tests__/__snapshots__/SelectedItem.spec.js.snap
@@ -2,15 +2,32 @@
 
 exports[`Selected item component renders a ghost item 1`] = `
 <div
-  className="item ghost selected-item"
+  className="selected-period-item"
   data-test="dimension-item-selected-item-test-id"
   onClick={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#b2dfdb",
+      "borderRadius": "4px",
+      "cursor": "pointer",
+      "display": "flex",
+      "opacity": "0.2",
+      "padding": "3px",
+      "transition": "opacity 0.2s ease",
+    }
+  }
 >
   <ItemIcon
     backgroundColor="#00796b"
   />
   <span
-    className="item-label"
+    style={
+      Object {
+        "fontSize": "14px",
+        "padding": "2px",
+      }
+    }
   >
     I am a selected item
   </span>
@@ -18,43 +35,72 @@ exports[`Selected item component renders a ghost item 1`] = `
     fill="#00796b"
     onClick={[Function]}
   />
-  <style />
 </div>
 `;
 
 exports[`Selected item component renders a highlighted item 1`] = `
 <div
-  className="item highlighted-item"
+  className="selected-period-item highlighted"
   data-test="dimension-item-selected-item-test-id"
   onClick={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#004d40",
+      "borderRadius": "4px",
+      "cursor": "pointer",
+      "display": "flex",
+      "padding": "3px",
+    }
+  }
 >
   <ItemIcon
-    backgroundColor="#ffffff"
+    backgroundColor="#fff"
   />
   <span
-    className="item-label highlighted-text"
+    style={
+      Object {
+        "color": "#fff",
+        "fontSize": "14px",
+        "padding": "2px",
+      }
+    }
   >
     I am a selected item
   </span>
   <DeselectIconButton
-    fill="#ffffff"
+    fill="#fff"
     onClick={[Function]}
   />
-  <style />
 </div>
 `;
 
 exports[`Selected item component renders an unhighlighted item 1`] = `
 <div
-  className="item selected-item"
+  className="selected-period-item"
   data-test="dimension-item-selected-item-test-id"
   onClick={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#b2dfdb",
+      "borderRadius": "4px",
+      "cursor": "pointer",
+      "display": "flex",
+      "padding": "3px",
+    }
+  }
 >
   <ItemIcon
     backgroundColor="#00796b"
   />
   <span
-    className="item-label"
+    style={
+      Object {
+        "fontSize": "14px",
+        "padding": "2px",
+      }
+    }
   >
     I am a selected item
   </span>
@@ -62,6 +108,5 @@ exports[`Selected item component renders an unhighlighted item 1`] = `
     fill="#00796b"
     onClick={[Function]}
   />
-  <style />
 </div>
 `;

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/__tests__/__snapshots__/UnselectedItem.spec.js.snap
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/__tests__/__snapshots__/UnselectedItem.spec.js.snap
@@ -2,36 +2,64 @@
 
 exports[`Unselected item component renders a highlighted item 1`] = `
 <div
-  className="item highlighted-item"
+  className="unselected-period-item highlighted"
   data-test="dimension-item-unselected-item-test-id"
   onClick={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#004d40",
+      "borderRadius": "4px",
+      "cursor": "pointer",
+      "display": "flex",
+      "padding": "3px",
+    }
+  }
 >
   <ItemIcon
     backgroundColor="#a0adba"
   />
   <span
-    className="item-label highlighted-text"
+    style={
+      Object {
+        "color": "#fff",
+        "fontSize": "14px",
+        "padding": "2px 5px 2px 2px",
+      }
+    }
   >
     I am an unselected item
   </span>
-  <style />
 </div>
 `;
 
 exports[`Unselected item component renders an unhighlighted item 1`] = `
 <div
-  className="item unselected-item"
+  className="unselected-period-item"
   data-test="dimension-item-unselected-item-test-id"
   onClick={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "borderRadius": "4px",
+      "cursor": "pointer",
+      "display": "flex",
+      "padding": "3px",
+    }
+  }
 >
   <ItemIcon
     backgroundColor="#a0adba"
   />
   <span
-    className="item-label"
+    style={
+      Object {
+        "fontSize": "14px",
+        "padding": "2px 5px 2px 2px",
+      }
+    }
   >
     I am an unselected item
   </span>
-  <style />
 </div>
 `;

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/__tests__/__snapshots__/UnselectedItem.spec.js.snap
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/__tests__/__snapshots__/UnselectedItem.spec.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Unselected item component renders a highlighted item 1`] = `
+<div
+  className="item highlighted-item"
+  data-test="dimension-item-unselected-item-test-id"
+  onClick={[Function]}
+>
+  <ItemIcon
+    backgroundColor="#a0adba"
+  />
+  <span
+    className="item-label highlighted-text"
+  >
+    I am an unselected item
+  </span>
+  <style />
+</div>
+`;
+
+exports[`Unselected item component renders an unhighlighted item 1`] = `
+<div
+  className="item unselected-item"
+  data-test="dimension-item-unselected-item-test-id"
+  onClick={[Function]}
+>
+  <ItemIcon
+    backgroundColor="#a0adba"
+  />
+  <span
+    className="item-label"
+  >
+    I am an unselected item
+  </span>
+  <style />
+</div>
+`;

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/styles/ArrowButton.style.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/styles/ArrowButton.style.js
@@ -1,6 +1,5 @@
 export default {
     arrowButton: {
-        backgroundColor: 'transparent',
         border: '1px solid #d5dde5',
         borderRadius: '4px',
         height: '36px',

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/styles/ArrowButton.style.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/styles/ArrowButton.style.js
@@ -1,0 +1,17 @@
+export default {
+    arrowButton: {
+        backgroundColor: 'transparent',
+        border: '1px solid #d5dde5',
+        borderRadius: '4px',
+        height: '36px',
+        minHeight: '36px',
+        minWidth: '40px',
+        padding: '0',
+        width: '40px',
+    },
+    arrowIcon: {
+        fill: '#4a5768',
+        height: '20px',
+        width: '24px',
+    }
+}

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/styles/DeselectIconButton.style.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/styles/DeselectIconButton.style.js
@@ -1,0 +1,10 @@
+export default {
+    deselectIconButton: {
+        background: 'none',
+        border: 'none',
+        height: '18px',
+        outline: 'none',
+        padding: '0px',
+        width: '18px',
+    }
+}

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/styles/SelectedItem.style.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/styles/SelectedItem.style.js
@@ -1,0 +1,33 @@
+export default {
+    highlightedText: {
+        color: '#fff',
+    },
+    icon: {
+        backgroundColor: '#00796b',
+    },
+    item: {
+        alignItems: 'center',
+        borderRadius: '4px',
+        cursor: 'pointer',
+        display: 'flex',
+        padding: '3px',
+    },
+    ghost: {
+        opacity: '0.2',
+        transition: 'opacity 0.2s ease',
+    },
+    selectedItem: {
+        backgroundColor: '#b2dfdb',
+        
+    },
+    highlightedItem: {
+        backgroundColor: '#004d40',
+    },
+    inactiveItem: {
+        opacity: '0.3',
+    },
+    itemLabel: {
+        fontSize: '14px',
+        padding: '2px'
+    }
+}

--- a/packages/period-selector-dialog/src/ItemSelector/widgets/styles/UnselectedItem.style.js
+++ b/packages/period-selector-dialog/src/ItemSelector/widgets/styles/UnselectedItem.style.js
@@ -1,0 +1,19 @@
+export default {
+    highlightedText: {
+        color: '#fff',
+    },
+    item: {
+        alignItems: 'center',
+        borderRadius: '4px',
+        cursor: 'pointer',
+        display: 'flex',
+        padding: '3px',
+    },
+    highlightedItem: {
+        backgroundColor: '#004d40',
+    },
+    itemLabel: {
+        fontSize: '14px',
+        padding: '2px 5px 2px 2px',
+    }
+}

--- a/packages/period-selector-dialog/src/PeriodSelector.js
+++ b/packages/period-selector-dialog/src/PeriodSelector.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
-import { ItemSelector } from '@dhis2/analytics';
+import ItemSelector from './ItemSelector/ItemSelector';
 
 import PeriodTypeButton from './PeriodTypeButton';
 import FixedPeriodFilter from './FixedPeriodFilter';

--- a/packages/translation-dialog/src/translationForm.actions.js
+++ b/packages/translation-dialog/src/translationForm.actions.js
@@ -2,6 +2,7 @@ import { getInstance } from 'd2';
 import { Observable } from 'rxjs';
 import Action from '@dhis2/d2-ui-core/action/Action';
 
+
 export function getLocales() {
     if (!getLocales.localePromise) {
         getLocales.localePromise = getInstance()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,12 +1021,12 @@
     "@babel/plugin-transform-typescript" "^7.9.0"
 
 "@babel/runtime-corejs2@^7.4.2":
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.4.3.tgz#40271fc260e570fb356da984e42e5990bd275860"
-  integrity sha512-anTLTF7IK8Hd5f73zpPzt875I27UaaTWARJlfMGgnmQhvEe1uNHQRKBUbXL0Gc0VEYiVzsHsTPso5XdK8NGvFg==
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.12.13.tgz#c543e5797b9dc4a19af570bccfd0743d127f20fe"
+  integrity sha512-BPjEhhHe12QsV4k2iRNvP95yB1Gpjj6/NMmVP++5Yw295Se/ZVXPePV8cC5cZ6nrZBmmsQ9n0JmeUobM8TbskA==
   dependencies:
     core-js "^2.6.5"
-    regenerator-runtime "^0.13.2"
+    regenerator-runtime "^0.13.4"
 
 "@babel/runtime-corejs3@^7.8.3":
   version "7.9.2"
@@ -1056,13 +1056,6 @@
   integrity sha512-cTIudHnzuWLS56ik4DnRnqqNf8MkdUzV4iFFI1h7Jo9xvrpQROYaAnaSd2mHLQAzzZAPfATynX5ord6YlNYNMA==
   dependencies:
     regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.2.0":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
-  integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
-  dependencies:
-    regenerator-runtime "^0.12.0"
 
 "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.9.2"
@@ -1173,68 +1166,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@dhis2/analytics@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.1.0.tgz#fe7e8e76af7f6fce98238e5e3c531d122e8fbe92"
-  integrity sha512-iYmd3BYSGXClj951iDKH1XxzNNhTuz2BDc2SryhgIUQDDkdjBbBQE73AEednTo/Cbt5SiqnEl66Bp0wZsZ4/+g==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@dhis2/d2-ui-org-unit-dialog" "^6.1.0"
-    "@dhis2/d2-ui-period-selector-dialog" "^6.1.0"
-    "@material-ui/core" "^3.9.3"
-    "@material-ui/icons" "^3.0.2"
-    classnames "^2.2.6"
-    d2-utilizr "^0.2.16"
-    d3-color "^1.2.3"
-    highcharts "^7.1.2"
-    highcharts-exporting "^0.1.7"
-    highcharts-more "^0.1.7"
-    highcharts-no-data-to-display "^0.1.7"
-    highcharts-solid-gauge "^0.1.7"
-    lodash "^4.17.11"
-    react-beautiful-dnd "^10.1.1"
-    styled-jsx "^3.2.1"
-
-"@dhis2/analytics@^3.3.3":
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-3.3.3.tgz#17d77317ebe046710f3099abb90863423955d974"
-  integrity sha512-RDgu8bik1JTQdIwAv3jEkvx0ZhRcYRBW+4OHOtGwS/+8Mf3oTdwAA+myYLLKA2Al4PDyBoKxSXXGmRN+uRD+lw==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@dhis2/d2-ui-org-unit-dialog" "^6.3.2"
-    "@dhis2/d2-ui-period-selector-dialog" "^6.3.2"
-    "@dhis2/ui-core" "^4.7.1"
-    "@material-ui/core" "^3.9.3"
-    "@material-ui/icons" "^3.0.2"
-    classnames "^2.2.6"
-    d2-utilizr "^0.2.16"
-    d3-color "^1.2.3"
-    highcharts "^7.2.1"
-    lodash "^4.17.13"
-    react-beautiful-dnd "^10.1.1"
-    resize-observer-polyfill "^1.5.1"
-    styled-jsx "^3.2.1"
-
-"@dhis2/analytics@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-4.0.1.tgz#7b3f88379265ca387a821c7e3e24b58db485638f"
-  integrity sha512-3XQEzvYuay0ObKRRtKbgR7PpotTvE80kY0UrFuQ4k4Kqj89p18oTSgT3NXTV8bXTk4RDVn19+ffoGt7ZsSAwkw==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@dhis2/d2-ui-org-unit-dialog" "^6.5.6"
-    "@dhis2/d2-ui-period-selector-dialog" "^6.5.6"
-    "@dhis2/ui-core" "^4.9.1"
-    "@material-ui/core" "^3.9.3"
-    "@material-ui/icons" "^3.0.2"
-    classnames "^2.2.6"
-    d2-utilizr "^0.2.16"
-    d3-color "^1.2.3"
-    highcharts "^7.2.1"
-    lodash "^4.17.13"
-    react-beautiful-dnd "^10.1.1"
-    resize-observer-polyfill "^1.5.1"
-    styled-jsx "^3.2.1"
-
 "@dhis2/app-adapter@4.0.3":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-4.0.3.tgz#e2944eb32afdf1dcbc00afa104139456f733720b"
@@ -1324,13 +1255,6 @@
     update-notifier "^3.0.0"
     yargs "^13.1.0"
 
-"@dhis2/d2-i18n@^1.0.3", "@dhis2/d2-i18n@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.4.tgz#8fbd113f56699b9832a401e1cb8f54d75bc36b9a"
-  integrity sha512-xI2j69q3bwlb374JOAs3wpo47V4BqDAz4h1PfGLVhdORPLAuz0CkKuwesfpW2eunDSHiKpMbOg7goTip/5ROew==
-  dependencies:
-    i18next "^10.3"
-
 "@dhis2/d2-i18n@^1.0.5", "@dhis2/d2-i18n@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.6.tgz#2914be8acf296f3a6bf7b51c76c46da6a120b0ff"
@@ -1338,259 +1262,6 @@
   dependencies:
     i18next "^10.3"
     moment "^2.24.0"
-
-"@dhis2/d2-ui-analytics@^0.0.18":
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-analytics/-/d2-ui-analytics-0.0.18.tgz#1d512a870ccd055197fdefb7302138426a9a79a6"
-  integrity sha512-9EIXHIxK5IOPGHM+DC4aHWd/Be249h0xGL24k4hgzRyxUYBI1uRXxo4Ckn0FcUOI2GkSxMbGdf3uw5sP80AkTg==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@dhis2/d2-ui-org-unit-dialog" "5.3.1"
-    "@dhis2/d2-ui-period-selector-dialog" "^5.3.1"
-    "@material-ui/core" "^3.9.3"
-    "@material-ui/icons" "^3.0.2"
-    classnames "^2.2.6"
-    lodash "^4.17.11"
-    react-beautiful-dnd "^10.1.1"
-    styled-jsx "^3.2.1"
-
-"@dhis2/d2-ui-analytics@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-analytics/-/d2-ui-analytics-1.0.0.tgz#356bf6be3096072f189c846600b2a0f31a7fafba"
-  integrity sha512-+serD9G41zbhcksW0m8aj59eNusCoAK8QJSt8k6Rg2EUCr8Q4ODLpMVvMzjMbH3Q5zEJahPC8YlgwfaNJrXKnA==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@dhis2/d2-ui-org-unit-dialog" "^5.3.6"
-    "@dhis2/d2-ui-period-selector-dialog" "^5.3.6"
-    "@material-ui/core" "^3.9.3"
-    "@material-ui/icons" "^3.0.2"
-    classnames "^2.2.6"
-    lodash "^4.17.11"
-    react-beautiful-dnd "^10.1.1"
-    styled-jsx "^3.2.1"
-
-"@dhis2/d2-ui-core@5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-5.3.1.tgz#73d8c91b7191f4e6813201598848ea379f3417eb"
-  integrity sha512-g/Ub9bCyDFIs3FPtSDOt4m+aRGBUX0R+cmcSRCNn7+pW2b9VS8yjRm5pfCvm+sv+PkfAmEt1jaOIwb9SA5AOsA==
-  dependencies:
-    babel-runtime "^6.26.0"
-    d2 "~31.7"
-    lodash "^4.17.10"
-    material-ui "^0.20.0"
-
-"@dhis2/d2-ui-core@5.3.6":
-  version "5.3.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-5.3.6.tgz#dabc385fc34d982fabe19c90df76d39e1c56e438"
-  integrity sha512-TpOEPR7Z1NBq6cY/zEU1HGn2/fp1CJOrgl2F5Dkj7ZXzLP1USgLp23burMH8TnQg9a6tWZw21umFcAi2WbmSRA==
-  dependencies:
-    babel-runtime "^6.26.0"
-    d2 "~31.7"
-    lodash "^4.17.10"
-    material-ui "^0.20.0"
-
-"@dhis2/d2-ui-core@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-6.1.1.tgz#c0ef84ff3267e4645989cf538ca3e4a8ab4a4c0e"
-  integrity sha512-+r8n07NXnolbFQyGKpxP02HBFP26/vueAEmAkiUYBSkZxj5IzuAmMlJB55kRTvkS2DO52mitGWaBPFfgrrAlHA==
-  dependencies:
-    babel-runtime "^6.26.0"
-    d2 "~31.7"
-    lodash "^4.17.10"
-    material-ui "^0.20.0"
-
-"@dhis2/d2-ui-core@6.5.5":
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-6.5.5.tgz#d75455a8388ef2c63a79824652a62f920441dfc6"
-  integrity sha512-5LQSB9Doy8X38qiDh9c4xmYtqhjKKi9NImi1JSqdHdL+rlaBXYxlnSX7Od/DtX4PMOBJt47dqOTF3s+UXitRVg==
-  dependencies:
-    babel-runtime "^6.26.0"
-    d2 "~31.7"
-    lodash "^4.17.10"
-    material-ui "^0.20.0"
-
-"@dhis2/d2-ui-core@6.5.6":
-  version "6.5.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-6.5.6.tgz#7d893aa8a7372bb401019a18ff219c259eaa0d46"
-  integrity sha512-4+dQLQu43Ptm311uii0P0bZ8HII6KCpGml4rL2xQHHvp9suXUyCiKL63rN1EGeTd8ELY0pLwS5XYcF2/ZxbEjQ==
-  dependencies:
-    babel-runtime "^6.26.0"
-    d2 "~31.7"
-    lodash "^4.17.10"
-    material-ui "^0.20.0"
-
-"@dhis2/d2-ui-org-unit-dialog@5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-5.3.1.tgz#291fc5e1160b9820a8c1ee4bebc99c6b944b26b5"
-  integrity sha512-ZTYPcvWaeC37vJSWvMDND0E9p85JcJzq5uym4wPjpzeckq5PWPzj/95emPjLEzneD6XTBpmr1hMwBA7G5z/G0w==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.3"
-    "@dhis2/d2-ui-org-unit-tree" "5.3.1"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    prop-types "^15.5.10"
-
-"@dhis2/d2-ui-org-unit-dialog@^5.3.6":
-  version "5.3.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-5.3.6.tgz#6845717248ad6b5ef9393c40340181d40243f0ea"
-  integrity sha512-ZTHFgQDyR6ZvaSJDxlUvMes9jL+rw9LoQ/2PwOKAdUzKX32N7rFlhgZK4sLiDwJ0A4x5Tt5CpjkzTUAmwlcu9w==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.3"
-    "@dhis2/d2-ui-org-unit-tree" "5.3.6"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    prop-types "^15.5.10"
-
-"@dhis2/d2-ui-org-unit-dialog@^6.1.0":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-6.1.1.tgz#219d9aeb5daecdaa8008eaba8fa87cc6f861080b"
-  integrity sha512-DNTw2lJRcFWSl/TCzFbjV86gv2rSlJgWG41fxKwSOwG7XWXv7Vr8YdbSy11v8cwVHsc+307XloiGhk3JXAPNGg==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.3"
-    "@dhis2/d2-ui-org-unit-tree" "6.1.1"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    prop-types "^15.5.10"
-
-"@dhis2/d2-ui-org-unit-dialog@^6.3.2":
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-6.5.5.tgz#3f793111bd1c2c61649c45430c2cb191074992b9"
-  integrity sha512-w1xg+YGib2SvezIF3V1PO4jBZVuIJgy1FxIzz/EKMkb/X9Nbt6NYlVbRCZh7v0idThKa1PgrhcxB5KWOWWoEnQ==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.3"
-    "@dhis2/d2-ui-org-unit-tree" "6.5.5"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    prop-types "^15.5.10"
-
-"@dhis2/d2-ui-org-unit-dialog@^6.5.6":
-  version "6.5.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-6.5.6.tgz#c3a8c6c377dce9cb03e0ca85bc3b32bb308e0b42"
-  integrity sha512-vZtr+BVyhUIK233pJj6Iplh09cItYD2xiksMrb1tWG/gn0rPR6JWaI52iuGiiTIOdI8wZlaexjVZLt2i4ksrDQ==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.3"
-    "@dhis2/d2-ui-org-unit-tree" "6.5.6"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    prop-types "^15.5.10"
-
-"@dhis2/d2-ui-org-unit-tree@5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-5.3.1.tgz#168144886c4b7f872822066a97181f9636884cc4"
-  integrity sha512-T0hYR6rc9foawFsqI+p7e3Dz6EtUORaXhvAXw+DYfilahe+7NDC/LYBU7CF3ri/pyA4N88LFi3U+zF8XPP253Q==
-  dependencies:
-    "@dhis2/d2-ui-core" "5.3.1"
-    "@material-ui/core" "^3.3.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.5.10"
-    recompose "^0.26.0"
-    rxjs "^5.5.7"
-
-"@dhis2/d2-ui-org-unit-tree@5.3.6":
-  version "5.3.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-5.3.6.tgz#94efa1d8ca1b088c1bf375f06517b84b4b129bcc"
-  integrity sha512-O+47uUMUzL5pYUjbFPk6S3+mVIqa4luSTyOEepFOxyvtHXFc6FzBlV7GE5fxM6WRWnKYlJlVKFsns/JeKFZ67w==
-  dependencies:
-    "@dhis2/d2-ui-core" "5.3.6"
-    "@material-ui/core" "^3.3.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.5.10"
-    recompose "^0.26.0"
-    rxjs "^5.5.7"
-
-"@dhis2/d2-ui-org-unit-tree@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-6.1.1.tgz#e090b90fc452031d9e8aaa9c4d8bae7846dbd975"
-  integrity sha512-ys8br3vjbUaiOR0XjPfx6eZiMjU2DVFA5TnPsIX2rq9561MRU4nOyHNe21BdPvawUZO0L7nkrNy4xA8N8dwV2Q==
-  dependencies:
-    "@dhis2/d2-ui-core" "6.1.1"
-    "@material-ui/core" "^3.3.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.5.10"
-
-"@dhis2/d2-ui-org-unit-tree@6.5.5":
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-6.5.5.tgz#eabd3c2ad9a21e67f74aaa3b9b33c563bec710fc"
-  integrity sha512-PmHUGhPmsg5pgSdCVNDq9HdGF4L6uMqqzM5KpmSYY64z7FyupB9Azt0HuetRbXEnusDrQ72R0YCWv4av5FLi8Q==
-  dependencies:
-    "@dhis2/d2-ui-core" "6.5.5"
-    "@material-ui/core" "^3.3.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.5.10"
-
-"@dhis2/d2-ui-org-unit-tree@6.5.6":
-  version "6.5.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-6.5.6.tgz#bc985fe40973e8ed00829145cc8666dfc8ffe717"
-  integrity sha512-5jK1V/f5zY187xju8rzy5Vhbux/8bVbkzIPeFyXfjFunlo2aXdv54J4LR1d4CgJY0oQENcNJ9f2j4mx2pGc4MQ==
-  dependencies:
-    "@dhis2/d2-ui-core" "6.5.6"
-    "@material-ui/core" "^3.3.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.5.10"
-
-"@dhis2/d2-ui-period-selector-dialog@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-5.3.1.tgz#9a5e81a2b5b5cd2980ab3ae9f9a88163503dc545"
-  integrity sha512-Bm+dyRcplgmkw9Iutnqrb7JN9kciPljpiNo7ZmOIRODYdRMKRwhCtmolAWOOdjPjrYFKAyYvd942C0BjYz5W4g==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    babel-runtime "^6.26.0"
-    lodash "^4.17.11"
-    prop-types "^15.6.0"
-    react-redux "^5.0.7"
-    react-sortable-hoc "^0.8.4"
-    redux "^4.0.1"
-
-"@dhis2/d2-ui-period-selector-dialog@^5.3.6":
-  version "5.3.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-5.3.6.tgz#ed92995728a19ef2396ec272293024073bf2caec"
-  integrity sha512-83xITm74HoYsUqCoq5d7u+brs5o7ONwwzJp+kFckLD1xA1vAoo1fH2jYcpV62hcJ+jjxj4vpQOYUQuIsRqDbtw==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@dhis2/d2-ui-analytics" "^0.0.18"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    babel-runtime "^6.26.0"
-    lodash "^4.17.11"
-    prop-types "^15.6.0"
-
-"@dhis2/d2-ui-period-selector-dialog@^6.1.0":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-6.1.1.tgz#791924bafbad8dfb792c4691136b19e16ca6e41e"
-  integrity sha512-51MsNJbsKFPAAgs/msRtJnKo3iO1zO+aBue0mZJzsUi4RA2n82ZG/2GSWHROz4hGLdTcd0m0wArfDH1aOY31gA==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@dhis2/d2-ui-analytics" "^1.0.0"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.6.0"
-
-"@dhis2/d2-ui-period-selector-dialog@^6.3.2":
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-6.5.5.tgz#df3c704b79524fcbad207a3f4fbbb76f1e55addf"
-  integrity sha512-o2kDYjiUiWzi0TmPndFo7/jl1s9qEnQj7QEIcVR6UIRBoNzgP+NB0L6bus9mf4XEtBz3zHyD16PgYdDZPbSYhQ==
-  dependencies:
-    "@dhis2/analytics" "^2.1.0"
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.6.0"
-
-"@dhis2/d2-ui-period-selector-dialog@^6.5.6":
-  version "6.5.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-6.5.6.tgz#9d3459e2880ea473693600423d73d995938b84f1"
-  integrity sha512-fhj+AmJBTbzqITH/oEtRVNIk75luC4dlfc0jl5Z0hbeHMj91PcoQCchBZhpyUOlMDT274R3rZ1Zep+pbB3eCsA==
-  dependencies:
-    "@dhis2/analytics" "^3.3.3"
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.6.0"
 
 "@dhis2/packages@^1.1.2":
   version "1.1.2"
@@ -1610,13 +1281,6 @@
   dependencies:
     prop-types "^15"
 
-"@dhis2/prop-types@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-1.5.0.tgz#7e69919f66698be373dd21940a8a770234ded6a1"
-  integrity sha512-dueFkkAMOIMbXiU7Mhr3Y+DBRyOd/rHA+5/IDiYWN1xttlUTSuGZLQ5AnJ7osBicEhx+qElaGbTdRYQj3SMBtA==
-  dependencies:
-    prop-types "^15"
-
 "@dhis2/ui-core@^4.6.1":
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.17.1.tgz#960f3184f1ba69b1fa299863ae5c6b498dd871a1"
@@ -1624,15 +1288,6 @@
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
     "@popperjs/core" "^2.1.0"
-    classnames "^2.2.6"
-
-"@dhis2/ui-core@^4.7.1", "@dhis2/ui-core@^4.9.1":
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.9.1.tgz#13ebaa43deceb5c3fa2955668c183131241847fa"
-  integrity sha512-ejKHYNiY49QIqgu6auLk6fL9It9+eZL1mmBk4Tqpst1u6YrSlnCyxfi/zV+UYqJLATAQX2aEAuB2ibRG5InZJA==
-  dependencies:
-    "@dhis2/prop-types" "^1.5.0"
-    "@popperjs/core" "^2.0.6"
     classnames "^2.2.6"
 
 "@dhis2/ui-widgets@^2.0.4":
@@ -1902,39 +1557,6 @@
     recompose "0.28.0 - 0.30.0"
     warning "^4.0.1"
 
-"@material-ui/core@^3.9.3":
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.9.3.tgz#d378c1f4beb18df9a534ca7258c2c33fb8e0e51f"
-  integrity sha512-REIj62+zEvTgI/C//YL4fZxrCVIySygmpZglsu/Nl5jPqy3CDjZv1F9ubBYorHqmRgeVPh64EghMMWqk4egmfg==
-  dependencies:
-    "@babel/runtime" "^7.2.0"
-    "@material-ui/system" "^3.0.0-alpha.0"
-    "@material-ui/utils" "^3.0.0-alpha.2"
-    "@types/jss" "^9.5.6"
-    "@types/react-transition-group" "^2.0.8"
-    brcast "^3.0.1"
-    classnames "^2.2.5"
-    csstype "^2.5.2"
-    debounce "^1.1.0"
-    deepmerge "^3.0.0"
-    dom-helpers "^3.2.1"
-    hoist-non-react-statics "^3.2.1"
-    is-plain-object "^2.0.4"
-    jss "^9.8.7"
-    jss-camel-case "^6.0.0"
-    jss-default-unit "^8.0.2"
-    jss-global "^3.0.0"
-    jss-nested "^6.0.1"
-    jss-props-sort "^6.0.0"
-    jss-vendor-prefixer "^7.0.0"
-    normalize-scroll-left "^0.1.2"
-    popper.js "^1.14.1"
-    prop-types "^15.6.0"
-    react-event-listener "^0.6.2"
-    react-transition-group "^2.2.1"
-    recompose "0.28.0 - 0.30.0"
-    warning "^4.0.1"
-
 "@material-ui/icons@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-3.0.1.tgz#671fb3d04dcaf9351dbbd2bf82ae2ae72e3d93cd"
@@ -1942,33 +1564,6 @@
   dependencies:
     "@babel/runtime" "7.0.0"
     recompose "^0.29.0"
-
-"@material-ui/icons@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-3.0.2.tgz#d67a6dd1ec8312d3a88ec97944a63daeef24fe10"
-  integrity sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==
-  dependencies:
-    "@babel/runtime" "^7.2.0"
-    recompose "0.28.0 - 0.30.0"
-
-"@material-ui/system@^3.0.0-alpha.0":
-  version "3.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-3.0.0-alpha.2.tgz#096e80c8bb0f70aea435b9e38ea7749ee77b4e46"
-  integrity sha512-odmxQ0peKpP7RQBQ8koly06YhsPzcoVib1vByVPBH4QhwqBXuYoqlCjt02846fYspAqkrWzjxnWUD311EBbxOA==
-  dependencies:
-    "@babel/runtime" "^7.2.0"
-    deepmerge "^3.0.0"
-    prop-types "^15.6.0"
-    warning "^4.0.1"
-
-"@material-ui/utils@^3.0.0-alpha.2":
-  version "3.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-3.0.0-alpha.3.tgz#836c62ea46f5ffc6f0b5ea05ab814704a86908b1"
-  integrity sha512-rwMdMZptX0DivkqBuC+Jdq7BYTXwqKai5G5ejPpuEDKpWzi1Oxp+LygGw329FrKpuKeiqpcymlqJTjmy+quWng==
-  dependencies:
-    "@babel/runtime" "^7.2.0"
-    prop-types "^15.6.0"
-    react-is "^16.6.3"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -1982,11 +1577,6 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
-
-"@popperjs/core@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.0.6.tgz#5a39ac118811ca844155b0ad5190b8c24f35e533"
-  integrity sha512-zj7Gw8QC4jmR92eKUvtrZUEpl2ypRbq+qlE4pwf9n2hnUO9BOAcWUs4/Ht+gNIbFt98xtqhLvccdCfD469MzpQ==
 
 "@popperjs/core@^2.1.0":
   version "2.3.3"
@@ -4603,7 +4193,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.26.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
+babel-runtime@6.26.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -4637,7 +4227,7 @@ babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-tra
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@6.26.0, babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.26.0, babel-types@^6.6.0:
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.26.0, babel-types@^6.6.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
@@ -6138,13 +5728,6 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-convert-source-map@1.6.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
-  integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
-  dependencies:
-    safe-buffer "~5.1.1"
-
 convert-source-map@1.7.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
@@ -6156,6 +5739,13 @@ convert-source-map@^0.3.3:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-0.3.5.tgz#f1d802950af7dd2631a1febe0596550c86ab3190"
   integrity sha1-8dgClQr33SYxof6+BZZVDIarMZA=
+
+convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+  integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
+  dependencies:
+    safe-buffer "~5.1.1"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -6213,9 +5803,9 @@ core-js@^2.4.0, core-js@^2.5.0:
   integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
 
 core-js@^2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
-  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.5.0:
   version "3.6.5"
@@ -6420,11 +6010,11 @@ css-blank-pseudo@^0.1.4:
     postcss "^7.0.5"
 
 css-box-model@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.1.1.tgz#c9fd8e7a8b1d59d41d6812fd1765433f671b2ee0"
-  integrity sha512-ZxbuLFeAPEDb0wPbGfT7783Vb00MVAkvOlMKwr0kA2PD5EGxk6P3MAhedvVuyVJCWb54bb+6HQ7pdPYENf8AZw==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
   dependencies:
-    tiny-invariant "^1.0.3"
+    tiny-invariant "^1.0.6"
 
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
@@ -6798,7 +6388,7 @@ cyclist@~0.2.2:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
-d2-utilizr@^0.2.15, d2-utilizr@^0.2.16:
+d2-utilizr@^0.2.15:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/d2-utilizr/-/d2-utilizr-0.2.16.tgz#b71df7ca8c7ab5125ca8bdb4899611bc6782a754"
   integrity sha512-8Cqwe/3TIsHeLfRVsWFKYqRrY3ZzuHAJqkEMCPGW9gyNCAAnTPVjROFwBwonv0zodQhVntn1DlJCay/GTBPj1A==
@@ -6842,11 +6432,6 @@ d3-color@1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.3.tgz#6c67bb2af6df3cc8d79efcc4d3a3e83e28c8048f"
   integrity sha512-x37qq3ChOTLd26hnps36lexMRhNXEtVxZ4B25rL0DVdDsGQIJGB18S7y9XDwlDD6MD/ZBzITCf4JjGMM10TZkw==
-
-d3-color@^1.2.3:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.5.tgz#5810ea1808f2f993d04508cb2fad764f48134788"
-  integrity sha512-u4CaFaqQKRofuhr9uo/xLdaGvvzdsMX7MgP42XgQJHLBRWnn0C0T+48rvj80cN9KXAauHEMEfe7ehacIoxmP/g==
 
 d3-format@1, d3-format@^1.1.0:
   version "1.3.2"
@@ -7018,11 +6603,6 @@ deepmerge@^2.0.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
   integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
-
-deepmerge@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.1.0.tgz#a612626ce4803da410d77554bfd80361599c034d"
-  integrity sha512-/TnecbwXEdycfbsM2++O3eGiatEFHjjNciHEwJclM+T5Kd94qD1AP+2elP/Mq0L5b9VZJao5znR01Mz6eX8Seg==
 
 deepmerge@^4.0.0:
   version "4.2.2"
@@ -9851,36 +9431,6 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highcharts-exporting@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-exporting/-/highcharts-exporting-0.1.7.tgz#f38024b9ef78ce2ac3a39f853f83b55822ae1630"
-  integrity sha1-84Akue94zirDo5+FP4O1WCKuFjA=
-
-highcharts-more@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-more/-/highcharts-more-0.1.7.tgz#43cd6274cccba443166c94d4536d904bbabf9c77"
-  integrity sha1-Q81idMzLpEMWbJTUU22QS7q/nHc=
-
-highcharts-no-data-to-display@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-no-data-to-display/-/highcharts-no-data-to-display-0.1.7.tgz#a9eb8b28da3df299d0d8262b78437cfe7d81d877"
-  integrity sha1-qeuLKNo98pnQ2CYreEN8/n2B2Hc=
-
-highcharts-solid-gauge@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-solid-gauge/-/highcharts-solid-gauge-0.1.7.tgz#4bf2dca76b5f559034b59d0c6d4755d1c71a6a5b"
-  integrity sha1-S/Lcp2tfVZA0tZ0MbUdV0ccaals=
-
-highcharts@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-7.1.2.tgz#f337e75cf0614f58f87fb28fbab48e1096265b5d"
-  integrity sha512-diSTVxWKefQzShi22gaV63pdrIFlQAsTGe3f328Ur7cqBoYFvHMtiMP+q+VOFdM2mdGVtlUR0QQSxj62LLsPpg==
-
-highcharts@^7.2.1:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-7.2.1.tgz#313c434bbfd4525a72b76c6bfbd9c39dfe2d1993"
-  integrity sha512-/fSUZiONmM+x49IQJNf8XwZGiNGOPRmxEOcd0xdJP9Xc3OlG46ZiUWgSLfhYQ9Oyhmzc3V3SKYCLud8+rKLi+w==
-
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -9901,13 +9451,6 @@ hoist-non-react-statics@^3.0.0:
   integrity sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==
   dependencies:
     react-is "^16.3.2"
-
-hoist-non-react-statics@^3.2.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
-  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
-  dependencies:
-    react-is "^16.7.0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -10589,7 +10132,7 @@ interpret@^1.0.0, interpret@^1.1.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
   integrity sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
 
-invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -12636,7 +12179,7 @@ jss-vendor-prefixer@^7.0.0:
   dependencies:
     css-vendor "^0.3.8"
 
-jss@^9.3.3, jss@^9.8.7:
+jss@^9.3.3:
   version "9.8.7"
   resolved "https://registry.yarnpkg.com/jss/-/jss-9.8.7.tgz#ed9763fc0f2f0260fc8260dac657af61e622ce05"
   integrity sha512-awj3XRZYxbrmmrx9LUSj5pXSUfm12m8xzi/VKeqI1ZwWBtQ0kVPTs3vYs32t4rFw83CgFDukA8wKzOE9sMQnoQ==
@@ -13447,9 +12990,9 @@ memoize-one@^4.0.0:
   integrity sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg==
 
 memoize-one@^5.0.1:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.4.tgz#005928aced5c43d890a4dfab18ca908b0ec92cbc"
-  integrity sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA==
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
 memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
   version "0.4.1"
@@ -16540,9 +16083,9 @@ querystringify@^2.0.0:
   integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
 
 raf-schd@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.0.tgz#9855756c5045ff4ed4516e14a47719387c3c907b"
-  integrity sha512-m7zq0JkIrECzw9mO5Zcq6jN4KayE34yoIS9hJoiZNXyOAT06PPA8PrR+WtJIeFW09YjUfNkMMN9lrmAt6BURCA==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
+  integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
 
 raf@3.4.0, raf@^3.4.0:
   version "3.4.0"
@@ -16787,11 +16330,6 @@ react-is@^16.6.3:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
   integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
 
-react-is@^16.7.0:
-  version "16.8.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.0.tgz#518db476214f3fb0716af9f82dfd420225ae970f"
-  integrity sha512-LOy+3La39aduxaPfuj+lCXC5RQ8ukjVPAAsFJ3yQ+DIOLf4eR9OMKeWKF0IzjRyE95xMj5QELwiXGgfQsIJguA==
-
 react-is@^16.8.1:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
@@ -16944,15 +16482,6 @@ react-select@^2.0.0:
     raf "^3.4.0"
     react-input-autosize "^2.2.1"
     react-transition-group "^2.2.1"
-
-react-sortable-hoc@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-0.8.4.tgz#11aa1f3e07ded79764a8bae9d107990ab9b3954b"
-  integrity sha512-J9AFEQAJ7u2YWdVzkU5E3ewrG82xQ4xF1ZPrZYKliDwlVBDkmjri+iKFAEt6NCDIRiBZ4hiN5vzI8pwy/dGPHw==
-  dependencies:
-    babel-runtime "^6.11.6"
-    invariant "^2.2.1"
-    prop-types "^15.5.7"
 
 react-stub-context@^0.8.1:
   version "0.8.1"
@@ -17293,9 +16822,9 @@ redux@^3.7.2:
     symbol-observable "^1.0.3"
 
 redux@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
-  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
@@ -17326,11 +16855,6 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
-
-regenerator-runtime@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
-  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4:
   version "0.13.5"
@@ -17616,11 +17140,6 @@ requizzle@~0.2.1:
   integrity sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=
   dependencies:
     underscore "~1.6.0"
-
-resize-observer-polyfill@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
-  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -19187,20 +18706,6 @@ style-loader@^0.18.2:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
-styled-jsx@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.1.tgz#452051fe50df5e9c7c7f3dd20fa46c3060ac65b0"
-  integrity sha512-gM/WOrWYRpWReivzQqetEGohUc/TJSvUoZ5T/UJxJZIsVIPlRQLnp7R8Oue4q49sI08EBRQjQl2oBL3sfdrw2g==
-  dependencies:
-    babel-plugin-syntax-jsx "6.18.0"
-    babel-types "6.26.0"
-    convert-source-map "1.6.0"
-    loader-utils "1.2.3"
-    source-map "0.7.3"
-    string-hash "1.1.3"
-    stylis "3.5.4"
-    stylis-rule-sheet "0.0.10"
-
 styled-jsx@^3.2.2, styled-jsx@^3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.5.tgz#0172a3e13a0d6d8bf09167dcaf32cf7102d932ca"
@@ -19655,15 +19160,10 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-invariant@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.3.tgz#91efaaa0269ccb6271f0296aeedb05fc3e067b7a"
-  integrity sha512-ytQx8T4DL8PjlX53yYzcIC0WhIZbpR0p1qcYjw2pHu3w6UtgWwFJQ/02cnhOnBBhlFx/edUIfcagCaQSe3KMWg==
-
-tiny-invariant@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.4.tgz#346b5415fd93cb696b0c4e8a96697ff590f92463"
-  integrity sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g==
+tiny-invariant@^1.0.4, tiny-invariant@^1.0.6:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
 tinycolor2@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
This fix allows us to remove the dependency to @dhis2/analytics. And since PeriodSelector is the only component in dhis2 to still be using the ItemSelector we can remove the ItemSelector from analytics.

These are the changes to ItemSelector (from its latest version in analytics)
* convert styles from styled-jsx to css-in-js. Pseudoclass selectors were moved to PeriodSelector.css A few !importants were needed in order to avoid a larger refactor of the component styling
* removed data-test attributes since they aren't used anymore, and were causing warnings while running jest tests

https://user-images.githubusercontent.com/6113918/108528111-584c6680-72d3-11eb-9d5d-a018bad9d730.mov

