### PR TITLE
fix(interpretations): reduce user groups response size (DHIS2-10625)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhis2/d2-ui",
-  "version": "7.1.5",
+  "version": "7.1.6",
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {

--- a/packages/interpretations/config/test-context.js
+++ b/packages/interpretations/config/test-context.js
@@ -54,6 +54,7 @@ export function getStubContext() {
                         keys: () => jest.fn(),
                     })
                 ),
+                getUserGroupIds: jest.fn().mockReturnValue([]),
             },
         },
         locale: 'en',

--- a/packages/interpretations/config/test-context.js
+++ b/packages/interpretations/config/test-context.js
@@ -17,14 +17,16 @@ export function getStubContext() {
                 },
             },
             Api: {
-                getApi: jest.fn().mockReturnValue({baseUrl: 'http://localhost:8080'}),
+                getApi: jest
+                    .fn()
+                    .mockReturnValue({ baseUrl: 'http://localhost:8080' }),
             },
             system: {
                 settings: {
                     all: jest.fn().mockReturnValue(Promise.resolve({})),
                 },
                 systemInfo: {
-                    contextPath: "http://test-dhis-server.org",
+                    contextPath: 'http://test-dhis-server.org',
                 },
             },
             currentUser: {
@@ -33,23 +35,28 @@ export function getStubContext() {
                 userSettings: {
                     keyStyle: 'vietnam/vietnam.css',
                     settings: {
-                        keyUiLocale: "en",
+                        keyUiLocale: 'en',
                     },
                 },
                 authorities: new Set(),
                 userGroupAccesses: [
                     {
-                        access: "rw------",
-                        userGroupUid: "wl5cDMuUhmF",
-                        displayName: "Administrators",
-                        id: "wl5cDMuUhmF"
-                    }
+                        access: 'rw------',
+                        userGroupUid: 'wl5cDMuUhmF',
+                        displayName: 'Administrators',
+                        id: 'wl5cDMuUhmF',
+                    },
                 ],
                 userAccesses: [],
-                getUserGroups: jest.fn().mockReturnValue(Promise.resolve({valuesContainerMap: [], keys: () => jest.fn()})),
+                getUserGroups: jest.fn().mockReturnValue(
+                    Promise.resolve({
+                        valuesContainerMap: [],
+                        keys: () => jest.fn(),
+                    })
+                ),
             },
         },
         locale: 'en',
-        appName: 'CHART'
+        appName: 'CHART',
     };
 }

--- a/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
+++ b/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
@@ -46,7 +46,7 @@ export class InterpretationsComponent extends React.Component {
     }
 
     async loadModel(props) {
-        const users = await props.d2.currentUser.getUserGroups({ fields: 'id' });
+        const users = await props.d2.currentUser.getUserGroupIds();
 
         return getFavoriteWithInterpretations(
             props.d2,

--- a/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
+++ b/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
@@ -11,52 +11,65 @@ import InterpretationsCard from '../Cards/InterpretationsCard';
 import styles from './styles/InterpretationsComponent.style';
 
 export class InterpretationsComponent extends React.Component {
-    state = { model: null, userGroups: []};
+    state = { model: null, userGroups: [] };
 
     constructor(props) {
         super(props);
         this.onChange = this.onChange.bind(this);
-    };
+    }
 
     getChildContext() {
         return {
             d2: this.props.d2,
-            locale: this.props.d2.currentUser.userSettings.settings.keyUiLocale || 'en',
-            appName: this.props.appName || '',
-            item: this.props.item || {},
+            locale:
+                this.props.d2.currentUser.userSettings.settings.keyUiLocale ||
+                'en',
+            appName: this.props.appName || '',
+            item: this.props.item || {},
         };
-    };
+    }
 
     componentDidMount() {
         this.loadModel(this.props);
-    };
+    }
 
     componentWillReceiveProps(nextProps) {
         const fields = ['type', 'id', 'lastUpdated'];
-        const modelFieldsChanged = !isEqual(pick(fields, this.props), pick(fields, nextProps));
-        
+        const modelFieldsChanged = !isEqual(
+            pick(fields, this.props),
+            pick(fields, nextProps)
+        );
+
         if (modelFieldsChanged) {
             this.loadModel(nextProps);
         }
-    };
+    }
 
     async loadModel(props) {
         const users = await props.d2.currentUser.getUserGroups({ fields: 'id' });
-        
-        return getFavoriteWithInterpretations(props.d2, props.type, props.id).then(model => {
+
+        return getFavoriteWithInterpretations(
+            props.d2,
+            props.type,
+            props.id
+        ).then((model) => {
             this.setState({ model, userGroups: Array.from(users.keys()) });
             return model;
         });
-    };
+    }
 
     async onChange() {
         return this.loadModel(this.props).then(
-            newModel => this.props.onChange && this.props.onChange(newModel)
+            (newModel) => this.props.onChange && this.props.onChange(newModel)
         );
-    };
+    }
 
     render() {
-        const { classes, currentInterpretationId, onCurrentInterpretationChange } = this.props;
+        const {
+            classes,
+            currentInterpretationId,
+            onCurrentInterpretationChange,
+        } = this.props;
         const { model, userGroups } = this.state;
 
         if (!model) {
@@ -66,24 +79,26 @@ export class InterpretationsComponent extends React.Component {
         return (
             <div>
                 <div className={classes.interpretationsContainer}>
-                    <Details 
-                        model={model} 
-                        onChange={this.onChange} 
-                        type={this.props.type} 
+                    <Details
+                        model={model}
+                        onChange={this.onChange}
+                        type={this.props.type}
                     />
                     <InterpretationsCard
                         model={model}
                         userGroups={userGroups}
                         onChange={this.onChange}
                         currentInterpretationId={currentInterpretationId}
-                        onCurrentInterpretationChange={onCurrentInterpretationChange}
+                        onCurrentInterpretationChange={
+                            onCurrentInterpretationChange
+                        }
                         type={this.props.type}
                     />
                 </div>
             </div>
         );
-    };
-};
+    }
+}
 
 InterpretationsComponent.propTypes = {
     classes: PropTypes.object.isRequired,

--- a/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
+++ b/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
@@ -41,7 +41,7 @@ export class InterpretationsComponent extends React.Component {
     };
 
     async loadModel(props) {
-        const users = await props.d2.currentUser.getUserGroups();
+        const users = await props.d2.currentUser.getUserGroups({ fields: 'id' });
         
         return getFavoriteWithInterpretations(props.d2, props.type, props.id).then(model => {
             this.setState({ model, userGroups: Array.from(users.keys()) });


### PR DESCRIPTION
Requires the patched `d2`.

Fixes [DHIS2-10625](https://jira.dhis2.org/browse/DHIS2-10625).

Changes proposed in this pull request:

- pass `fields=id` to `getUserGroups()` to greatly reduce the response size

The default used otherwise is `fields=:all`.
The interpretations component only uses the group ids:
https://github.com/dhis2/d2-ui/blob/master/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js#L47


![Screenshot 2021-03-05 at 16 44 39](https://user-images.githubusercontent.com/150978/110138312-21e21180-7dd2-11eb-9266-adc90d8b3e4a.png)
![Screenshot 2021-03-05 at 16 44 21](https://user-images.githubusercontent.com/150978/110138314-23133e80-7dd2-11eb-958e-32e03f498798.png)
