### PR TITLE
fix: add theme provider to translation and sharing dialogs [DHIS2-10143]

### DIFF
--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { mui3theme } from '@dhis2/d2-ui-core';
 import Dialog from '@material-ui/core/Dialog';
@@ -193,43 +193,56 @@ class SharingDialog extends React.Component {
         return pick(this.props);
     }
 
-    render() {
+    getContent = () => {
         const dataShareable = this.state.dataShareableTypes.indexOf(this.props.type) !== -1;
         const errorOccurred = this.state.errorMessage !== '';
         const isLoading = !this.state.sharedObject && this.props.open && !errorOccurred;
 
         return (
-            <div>
+            <Fragment>
                 <Snackbar
                     open={errorOccurred}
                     message={this.state.errorMessage}
                     autoHideDuration={3000}
                 />
-                <MuiThemeProvider theme={createMuiTheme(mui3theme)}>
-                    <Dialog
-                        maxWidth="lg"
-                        onClose={this.closeDialog}
-                        {...this.muiDialogProps()}
-                    >
-                        <DialogTitle>{this.props.d2.i18n.getTranslation('share')}</DialogTitle>
-                        <DialogContent>
-                            { isLoading && <LoadingMask /> }
-                            { this.state.sharedObject &&
-                                <Sharing
-                                    sharedObject={this.state.sharedObject}
-                                    dataShareable={dataShareable}
-                                    onChange={this.onSharingChanged}
-                                    onSearch={this.onSearchRequest}
-                                />
-                            }
-                        </DialogContent>
-                        <DialogActions>
-                            <Button key="closeonly" color="primary" onClick={this.closeDialog}>{this.translate('close')}</Button>,
-                        </DialogActions>
-                    </Dialog>
-                </MuiThemeProvider>
-            </div>
-        );
+                <Dialog
+                    maxWidth="lg"
+                    onClose={this.closeDialog}
+                    {...this.muiDialogProps()}
+                >
+                    <DialogTitle>{this.props.d2.i18n.getTranslation('share')}</DialogTitle>
+                    <DialogContent>
+                        { isLoading && <LoadingMask /> }
+                        { this.state.sharedObject &&
+                            <Sharing
+                                sharedObject={this.state.sharedObject}
+                                dataShareable={dataShareable}
+                                onChange={this.onSharingChanged}
+                                onSearch={this.onSearchRequest}
+                            />
+                        }
+                    </DialogContent>
+                    <DialogActions>
+                        <Button key="closeonly" color="primary" onClick={this.closeDialog}>{this.translate('close')}</Button>,
+                    </DialogActions>
+                </Dialog>
+            </Fragment>
+        )
+    }
+
+    render() {
+        console.log('insertTheme', this.props.insertTheme)
+        if (this.props.insertTheme) {
+            return (
+                <div>
+                    <MuiThemeProvider theme={createMuiTheme(mui3theme)}>
+                        {this.getContent()}
+                    </MuiThemeProvider>
+                </div>
+            );
+        }
+
+        return this.getContent()
     }
 }
 
@@ -252,6 +265,11 @@ SharingDialog.propTypes = {
      * Id of the sharable object. Can be supplied after initial render.
      */
     id: PropTypes.string,
+
+    /**
+     * If true, then wrap dialog component in material-ui theme
+     */
+    insertTheme: PropTypes.bool,
 
     /**
      * Do not post new sharing settings. Rather, let the user save the new
@@ -301,6 +319,7 @@ SharingDialog.propTypes = {
 SharingDialog.defaultProps = {
     type: '',
     id: '',
+    insertTheme: false,
     doNotPost: false,
     sharedObject: null,
 };

--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -11,7 +11,6 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import PropTypes from 'prop-types';
 import Sharing from './Sharing.component';
 
-
 const defaultState = {
     sharedObject: null,
     errorMessage: '',

--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -1,4 +1,7 @@
+
 import React from 'react';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { mui3theme } from '@dhis2/d2-ui-core';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -8,6 +11,7 @@ import Snackbar from '@material-ui/core/Snackbar';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import PropTypes from 'prop-types';
 import Sharing from './Sharing.component';
+
 
 const defaultState = {
     sharedObject: null,
@@ -203,27 +207,29 @@ class SharingDialog extends React.Component {
                     message={this.state.errorMessage}
                     autoHideDuration={3000}
                 />
-                <Dialog
-                    maxWidth="lg"
-                    onClose={this.closeDialog}
-                    {...this.muiDialogProps()}
-                >
-                    <DialogTitle>{this.props.d2.i18n.getTranslation('share')}</DialogTitle>
-                    <DialogContent>
-                        { isLoading && <LoadingMask /> }
-                        { this.state.sharedObject &&
-                            <Sharing
-                                sharedObject={this.state.sharedObject}
-                                dataShareable={dataShareable}
-                                onChange={this.onSharingChanged}
-                                onSearch={this.onSearchRequest}
-                            />
-                        }
-                    </DialogContent>
-                    <DialogActions>
-                        <Button key="closeonly" color="primary" onClick={this.closeDialog}>{this.translate('close')}</Button>,
-                    </DialogActions>
-                </Dialog>
+                <MuiThemeProvider theme={createMuiTheme(mui3theme)}>
+                    <Dialog
+                        maxWidth="lg"
+                        onClose={this.closeDialog}
+                        {...this.muiDialogProps()}
+                    >
+                        <DialogTitle>{this.props.d2.i18n.getTranslation('share')}</DialogTitle>
+                        <DialogContent>
+                            { isLoading && <LoadingMask /> }
+                            { this.state.sharedObject &&
+                                <Sharing
+                                    sharedObject={this.state.sharedObject}
+                                    dataShareable={dataShareable}
+                                    onChange={this.onSharingChanged}
+                                    onSearch={this.onSearchRequest}
+                                />
+                            }
+                        </DialogContent>
+                        <DialogActions>
+                            <Button key="closeonly" color="primary" onClick={this.closeDialog}>{this.translate('close')}</Button>,
+                        </DialogActions>
+                    </Dialog>
+                </MuiThemeProvider>
             </div>
         );
     }

--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -233,11 +233,9 @@ class SharingDialog extends React.Component {
     render() {
         if (this.props.insertTheme) {
             return (
-                <div>
-                    <MuiThemeProvider theme={createMuiTheme(mui3theme)}>
-                        {this.getContent()}
-                    </MuiThemeProvider>
-                </div>
+                <MuiThemeProvider theme={createMuiTheme(mui3theme)}>
+                    {this.getContent()}
+                </MuiThemeProvider>
             );
         }
 

--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { mui3theme } from '@dhis2/d2-ui-core';

--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -231,7 +231,6 @@ class SharingDialog extends React.Component {
     }
 
     render() {
-        console.log('insertTheme', this.props.insertTheme)
         if (this.props.insertTheme) {
             return (
                 <div>

--- a/packages/translation-dialog/src/TranslationDialog.component.js
+++ b/packages/translation-dialog/src/TranslationDialog.component.js
@@ -45,33 +45,43 @@ class TranslationDialog extends Component {
         return pick(this.props);
     }
 
+    getDialog = () => (
+        <Dialog
+            onClose={this.closeDialog}
+            maxWidth="lg"
+            {...this.muiDialogProps()}
+        >
+            <DialogTitle id="form-dialog-title">{this.i18n.getTranslation('translation_dialog_title')}</DialogTitle>
+            <TranslationFormWithData
+                model={this.props.objectToTranslate}
+                onTranslationSaved={this.translationSaved}
+                onTranslationError={this.translationError}
+                onCancel={this.closeDialog}
+                fieldsToTranslate={this.props.fieldsToTranslate}
+            />
+        </Dialog>
+    )
+
     render() {
-        return (
-            <MuiThemeProvider theme={createMuiTheme(mui3theme)}>
-                <Dialog
-                    onClose={this.closeDialog}
-                    maxWidth="lg"
-                    {...this.muiDialogProps()}
-                >
-                    <DialogTitle id="form-dialog-title">{this.i18n.getTranslation('translation_dialog_title')}</DialogTitle>
-                    <TranslationFormWithData
-                        model={this.props.objectToTranslate}
-                        onTranslationSaved={this.translationSaved}
-                        onTranslationError={this.translationError}
-                        onCancel={this.closeDialog}
-                        fieldsToTranslate={this.props.fieldsToTranslate}
-                    />
-                </Dialog>
-            </MuiThemeProvider>
-        );
+        if (this.props.insertTheme) {
+            return (
+                <MuiThemeProvider theme={createMuiTheme(mui3theme)}>
+                    {this.getDialog()}
+                </MuiThemeProvider>
+            );
+        }
+
+        return this.getDialog()
     }
 }
 
 TranslationDialog.defaultProps = {
     fieldsToTranslate: [],
+    insertTheme: false,
 };
 
 TranslationDialog.propTypes = {
+    insertTheme: PropTypes.bool,
     objectToTranslate: PropTypes.shape({
         id: PropTypes.string.isRequired,
     }).isRequired,

--- a/packages/translation-dialog/src/TranslationDialog.component.js
+++ b/packages/translation-dialog/src/TranslationDialog.component.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { mui3theme } from '@dhis2/d2-ui-core';
 import PropTypes from 'prop-types';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -45,20 +47,22 @@ class TranslationDialog extends Component {
 
     render() {
         return (
-            <Dialog
-                onClose={this.closeDialog}
-                maxWidth="lg"
-                {...this.muiDialogProps()}
-            >
-                <DialogTitle id="form-dialog-title">{this.i18n.getTranslation('translation_dialog_title')}</DialogTitle>
-                <TranslationFormWithData
-                    model={this.props.objectToTranslate}
-                    onTranslationSaved={this.translationSaved}
-                    onTranslationError={this.translationError}
-                    onCancel={this.closeDialog}
-                    fieldsToTranslate={this.props.fieldsToTranslate}
-                />
-            </Dialog>
+            <MuiThemeProvider theme={createMuiTheme(mui3theme)}>
+                <Dialog
+                    onClose={this.closeDialog}
+                    maxWidth="lg"
+                    {...this.muiDialogProps()}
+                >
+                    <DialogTitle id="form-dialog-title">{this.i18n.getTranslation('translation_dialog_title')}</DialogTitle>
+                    <TranslationFormWithData
+                        model={this.props.objectToTranslate}
+                        onTranslationSaved={this.translationSaved}
+                        onTranslationError={this.translationError}
+                        onCancel={this.closeDialog}
+                        fieldsToTranslate={this.props.fieldsToTranslate}
+                    />
+                </Dialog>
+            </MuiThemeProvider>
         );
     }
 }


### PR DESCRIPTION
Part of fix for <DHIS2-10143>.

Add option to use the mui theme provider directly in the Sharing and Translation dialogs so that the parent app does not need to do this. In some cases the app will no longer need to have material-ui as a direct dependency (i.e., dashboard-app). Related PR:  https://github.com/dhis2/dashboard-app/pull/1704/)

Although it doesn't seem to matter if the theme is provided at multiple points (i.e., both at the app level and the component level), I added an option to avoid any potential errors I might not have found.

To test, remove the mui theme from the cra App.js, and change the insertTheme property in sharing.js and translation.js

