### PR TITLE
fix: add and propagate insertTheme prop (DHIS2-10143)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhis2/d2-ui",
-  "version": "7.1.8",
+  "version": "7.2.0",
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {

--- a/packages/favorites-dialog/package.json
+++ b/packages/favorites-dialog/package.json
@@ -5,9 +5,7 @@
     "module": "./build/index.js",
     "license": "BSD-3-Clause",
     "author": "Edoardo Sabadelli <edoardo@dhis2.org>",
-    "contributors": [
-        "Viktor Varland <viktor@dhis2.org>"
-    ],
+    "contributors": ["Viktor Varland <viktor@dhis2.org>"],
     "peerDependencies": {
         "@dhis2/d2-i18n": "^1.0.6",
         "d2": "^31.1.1",
@@ -27,6 +25,7 @@
         "@dhis2/d2-ui-sharing-dialog": "0.0.0-PLACEHOLDER",
         "@material-ui/core": "^3.3.1",
         "@material-ui/icons": "^3.0.1",
+        "lodash": "^4.17.10",
         "babel-runtime": "^6.26.0",
         "prop-types": "^15.6.0",
         "react-redux": "^5.0.7",

--- a/packages/favorites-dialog/src/Favorites.js
+++ b/packages/favorites-dialog/src/Favorites.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
-
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -35,10 +34,10 @@ class Favorites extends Component {
         }
     }
 
-    render() {
+    render = () => {
         const { open, onRequestClose, onFavoriteSelect, type } = this.props;
 
-        const handleOnFavoriteSelect = (id) => {
+        const handleOnFavoriteSelect = id => {
             onFavoriteSelect(id);
             // XXX should this be in the favoriteSelect callback?
             onRequestClose();
@@ -51,8 +50,8 @@ class Favorites extends Component {
                 open={open}
                 onClose={onRequestClose}
                 disableEnforceFocus
-                maxWidth="md"
                 fullWidth
+                maxWidth="lg"
             >
                 <DialogContent>
                     <EnhancedToolbar showTypeFilter={showTypeColumn} />
@@ -68,7 +67,7 @@ class Favorites extends Component {
                 </DialogActions>
             </Dialog>
         );
-    }
+    };
 }
 
 Favorites.propTypes = {
@@ -81,7 +80,7 @@ Favorites.propTypes = {
     fetchData: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
     dataIsLoaded: state.data.totalRecords > 0,
 });
 
@@ -89,4 +88,7 @@ const mapDispatchToProps = {
     fetchData,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Favorites);
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(Favorites);

--- a/packages/favorites-dialog/src/FavoritesDialog.js
+++ b/packages/favorites-dialog/src/FavoritesDialog.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { mui3theme } from '@dhis2/d2-ui-core';
 
 import Favorites from './Favorites';
 import configureStore from './configureStore';
@@ -30,7 +32,7 @@ class FavoritesDialog extends Component {
         };
     }
 
-    render() {
+    getContent() {
         const {
             open,
             type,
@@ -51,14 +53,43 @@ class FavoritesDialog extends Component {
             </Provider>
         );
     }
+
+    render() {
+        if (this.props.insertTheme) {
+            return (
+                <MuiThemeProvider
+                    theme={createMuiTheme(
+                        // override the lg width to make it wider
+                        Object.assign({}, mui3theme, {
+                            overrides: {
+                                MuiDialog: {
+                                    paperWidthLg: {
+                                        flex: '0 1 960px',
+                                        width: '960px',
+                                        maxWidth: '960px',
+                                    },
+                                },
+                            },
+                        })
+                    )}
+                >
+                    {this.getContent()}
+                </MuiThemeProvider>
+            );
+        }
+
+        return this.getContent();
+    }
 }
 
 FavoritesDialog.defaultProps = {
     refreshData: false,
+    insertTheme: false,
 };
 
 FavoritesDialog.propTypes = {
     open: PropTypes.bool.isRequired,
+    insertTheme: PropTypes.bool,
     refreshData: PropTypes.bool,
     type: PropTypes.oneOf([
         'visualization',

--- a/packages/favorites-dialog/src/FavoritesDialog.js
+++ b/packages/favorites-dialog/src/FavoritesDialog.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import cloneDeep from 'lodash/cloneDeep';
 import { mui3theme } from '@dhis2/d2-ui-core';
 
 import Favorites from './Favorites';
@@ -56,23 +57,17 @@ class FavoritesDialog extends Component {
 
     render() {
         if (this.props.insertTheme) {
+            const theme = cloneDeep(mui3theme);
+
+            // override the MuiDialog style to make it wider
+            theme.overrides.MuiDialog.paperWidthLg = {
+                flex: '0 1 960px',
+                width: '960px',
+                maxWidth: '960px',
+            };
+
             return (
-                <MuiThemeProvider
-                    theme={createMuiTheme(
-                        // override the lg width to make it wider
-                        Object.assign({}, mui3theme, {
-                            overrides: {
-                                MuiDialog: {
-                                    paperWidthLg: {
-                                        flex: '0 1 960px',
-                                        width: '960px',
-                                        maxWidth: '960px',
-                                    },
-                                },
-                            },
-                        })
-                    )}
-                >
+                <MuiThemeProvider theme={createMuiTheme(theme)}>
                     {this.getContent()}
                 </MuiThemeProvider>
             );

--- a/packages/file-menu/src/FileMenu.js
+++ b/packages/file-menu/src/FileMenu.js
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { mui3theme } from '@dhis2/d2-ui-core';
 import { withStyles } from '@material-ui/core/styles';
 import Menu from '@material-ui/core/Menu';
 import Button from '@material-ui/core/Button';
@@ -34,6 +35,7 @@ export class FileMenu extends Component {
 
     getChildContext = () => ({
         d2: this.props.d2,
+        insertTheme: this.props.insertTheme,
     });
 
     componentDidMount = () => {
@@ -122,7 +124,7 @@ export class FileMenu extends Component {
         });
     };
 
-    render() {
+    getContent() {
         const {
             classes,
             fileType,
@@ -237,16 +239,30 @@ export class FileMenu extends Component {
             </Fragment>
         );
     }
+
+    render() {
+        if (this.props.insertTheme) {
+            return (
+                <MuiThemeProvider theme={createMuiTheme(mui3theme)}>
+                    {this.getContent()}
+                </MuiThemeProvider>
+            );
+        }
+
+        return this.getContent();
+    }
 }
 
 FileMenu.childContextTypes = {
     d2: PropTypes.object,
+    insertTheme: PropTypes.bool,
 };
 
 FileMenu.defaultProps = {
     d2: null,
     fileType: 'chart',
     fileId: null,
+    insertTheme: false,
     onNew: Function.prototype,
     onOpen: Function.prototype,
     onSave: Function.prototype,
@@ -262,6 +278,7 @@ FileMenu.propTypes = {
     d2: PropTypes.object,
     fileType: PropTypes.oneOf(supportedFileTypes),
     fileId: PropTypes.string,
+    insertTheme: PropTypes.bool,
     onNew: PropTypes.func,
     onOpen: PropTypes.func,
     onSave: PropTypes.func,

--- a/packages/file-menu/src/OpenMenuItem.js
+++ b/packages/file-menu/src/OpenMenuItem.js
@@ -38,6 +38,7 @@ class OpenMenuItem extends Component {
 
     render() {
         const { refreshDialogData, fileType, onRename, onDelete } = this.props;
+        const { d2, insertTheme } = this.context;
 
         return (
             <Fragment>
@@ -51,11 +52,12 @@ class OpenMenuItem extends Component {
                     open={this.state.dialogIsOpen}
                     refreshData={refreshDialogData}
                     type={fileType}
-                    d2={this.context.d2}
+                    d2={d2}
                     onRequestClose={this.onClose}
                     onFavoriteSelect={this.onOpen}
                     onFavoriteRename={onRename}
                     onFavoriteDelete={onDelete}
+                    insertTheme={insertTheme}
                 />
             </Fragment>
         );
@@ -64,6 +66,7 @@ class OpenMenuItem extends Component {
 
 OpenMenuItem.contextTypes = {
     d2: PropTypes.object,
+    insertTheme: PropTypes.bool,
 };
 
 OpenMenuItem.defaultProps = {

--- a/packages/file-menu/src/ShareMenuItem.js
+++ b/packages/file-menu/src/ShareMenuItem.js
@@ -42,6 +42,7 @@ class ShareMenuItem extends Component {
 
     render() {
         const { enabled, fileModel, fileType } = this.props;
+        const { d2, insertTheme } = this.context;
 
         return (
             <Fragment>
@@ -58,9 +59,10 @@ class ShareMenuItem extends Component {
                     <SharingDialog
                         open={this.state.dialogIsOpen}
                         onRequestClose={this.onShare}
-                        d2={this.context.d2}
+                        d2={d2}
                         id={fileModel.id}
                         type={fileType}
+                        insertTheme={insertTheme}
                     />
                 ) : null}
             </Fragment>
@@ -70,6 +72,7 @@ class ShareMenuItem extends Component {
 
 ShareMenuItem.contextTypes = {
     d2: PropTypes.object,
+    insertTheme: PropTypes.bool,
 };
 
 ShareMenuItem.defaultProps = {

--- a/packages/file-menu/src/TranslateMenuItem.js
+++ b/packages/file-menu/src/TranslateMenuItem.js
@@ -26,7 +26,7 @@ class TranslateMenuItem extends Component {
         }
     };
 
-    onDialogReturn = success => (args) => {
+    onDialogReturn = success => args => {
         const { onTranslate, onTranslateError } = this.props;
 
         this.toggleTranslationDialog();
@@ -44,10 +44,14 @@ class TranslateMenuItem extends Component {
 
     render() {
         const { enabled, fileModel } = this.props;
+        const { d2, insertTheme } = this.context;
 
         return (
             <Fragment>
-                <MenuItem disabled={!enabled} onClick={this.toggleTranslationDialog}>
+                <MenuItem
+                    disabled={!enabled}
+                    onClick={this.toggleTranslationDialog}
+                >
                     <ListItemIcon>
                         <Translate />
                     </ListItemIcon>
@@ -55,13 +59,14 @@ class TranslateMenuItem extends Component {
                 </MenuItem>
                 {fileModel ? (
                     <TranslationDialog
-                        d2={this.context.d2}
+                        d2={d2}
                         open={this.state.dialogIsOpen}
                         onRequestClose={this.onClose}
                         objectToTranslate={fileModel}
                         fieldsToTranslate={['name', 'description']}
                         onTranslationSaved={this.onDialogReturn(true)}
                         onTranslationError={this.onDialogReturn(false)}
+                        insertTheme={insertTheme}
                     />
                 ) : null}
             </Fragment>
@@ -71,6 +76,7 @@ class TranslateMenuItem extends Component {
 
 TranslateMenuItem.contextTypes = {
     d2: PropTypes.object,
+    insertTheme: PropTypes.bool,
 };
 
 TranslateMenuItem.defaultProps = {

--- a/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
+++ b/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { mui3theme } from '@dhis2/d2-ui-core';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { withStyles } from '@material-ui/core/styles';
 import isEqual from 'lodash/fp/isEqual';
@@ -52,7 +54,7 @@ export class InterpretationsComponent extends React.Component {
             props.d2,
             props.type,
             props.id
-        ).then((model) => {
+        ).then(model => {
             this.setState({ model, userGroups: Array.from(users.keys()) });
             return model;
         });
@@ -60,11 +62,11 @@ export class InterpretationsComponent extends React.Component {
 
     async onChange() {
         return this.loadModel(this.props).then(
-            (newModel) => this.props.onChange && this.props.onChange(newModel)
+            newModel => this.props.onChange && this.props.onChange(newModel)
         );
     }
 
-    render() {
+    getContent() {
         const {
             classes,
             currentInterpretationId,
@@ -98,13 +100,30 @@ export class InterpretationsComponent extends React.Component {
             </div>
         );
     }
+
+    render() {
+        if (this.props.insertTheme) {
+            return (
+                <MuiThemeProvider theme={createMuiTheme(mui3theme)}>
+                    {this.getContent()}
+                </MuiThemeProvider>
+            );
+        }
+
+        return this.getContent();
+    }
 }
+
+InterpretationsComponent.defaultProps = {
+    insertTheme: false,
+};
 
 InterpretationsComponent.propTypes = {
     classes: PropTypes.object.isRequired,
     d2: PropTypes.object.isRequired,
     type: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
+    insertTheme: PropTypes.bool,
     lastUpdated: PropTypes.string,
     currentInterpretationId: PropTypes.string,
     onChange: PropTypes.func,


### PR DESCRIPTION
Fixes narrow dialogs issue related to [DHIS2-10143](https://jira.dhis2.org/browse/DHIS2-10143) .

Changes proposed in this pull request:

- fix the narrow dialog issue due to missing MUI theme

Other than TranslationsDialog and SharingDialog, other components need the same fix:
- FileMenu
- FavoritesDialog
- Interpretations
