### PR TITLE
feat: disable parts of interpretations and sharing components when offline [DHIS2-10874]

### DIFF
--- a/packages/interpretations/i18n/en.pot
+++ b/packages/interpretations/i18n/en.pot
@@ -5,8 +5,26 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-12-09T10:46:11.729Z\n"
-"PO-Revision-Date: 2020-12-09T10:46:11.729Z\n"
+"POT-Creation-Date: 2021-05-20T08:53:00.620Z\n"
+"PO-Revision-Date: 2021-05-20T08:53:00.620Z\n"
+
+msgid "Pivot Tables"
+msgstr "Pivot Tables"
+
+msgid "Visualizer"
+msgstr "Visualizer"
+
+msgid "Maps"
+msgstr "Maps"
+
+msgid "Event Reports"
+msgstr "Event Reports"
+
+msgid "Event Visualizer"
+msgstr "Event Visualizer"
+
+msgid "View in {{appName}} app"
+msgstr "View in {{appName}} app"
 
 msgid "View"
 msgstr "View"
@@ -31,24 +49,6 @@ msgstr "Manage sharing"
 
 msgid "Delete"
 msgstr "Delete"
-
-msgid "Pivot Tables"
-msgstr "Pivot Tables"
-
-msgid "Visualizer"
-msgstr "Visualizer"
-
-msgid "Maps"
-msgstr "Maps"
-
-msgid "Event Reports"
-msgstr "Event Reports"
-
-msgid "Event Visualizer"
-msgstr "Event Visualizer"
-
-msgid "View in {{appName}} app"
-msgstr "View in {{appName}} app"
 
 msgid "Back to all interpretations"
 msgstr "Back to all interpretations"
@@ -82,6 +82,9 @@ msgstr "Unsubscribe from this {{object}} and stop receiving notifications"
 
 msgid "Subscribe to this {{object}} and start receiving notifications"
 msgstr "Subscribe to this {{object}} and start receiving notifications"
+
+msgid "Not available offline"
+msgstr "Not available offline"
 
 msgid "Table details"
 msgstr "Table details"

--- a/packages/interpretations/src/components/Cards/InterpretationsCard.js
+++ b/packages/interpretations/src/components/Cards/InterpretationsCard.js
@@ -137,7 +137,14 @@ export class InterpretationsCard extends React.Component {
         const InputField = this.renderInputField();
         
         return (
-            <CollapsibleCard title={i18n.t("Interpretations")}>
+            <CollapsibleCard title={i18n.t("Interpretations")} style={{ position: 'relative' }}>
+                {!this.props.isOnline && (
+                    <div style={{position: 'absolute', inset: 0, zIndex: 2000, background: 'rgba(33, 43, 54, 0.4)'}} >
+                        <div style={{width: '100%', height: '100%', display: 'flex', justifyContent: 'space-around', flexDirection: 'row', pointerEvents: 'none', WebkitBoxAlign: 'center', alignItems: 'center',}}>
+                            <span style={{backgroundColor: 'white', padding: '10px', borderRadius: '3px'}}>Not available offline</span>
+                        </div>
+                    </div>
+                )}
                 {BackButton}
                 {Interpretations}
                 {InputField}
@@ -150,6 +157,7 @@ InterpretationsCard.propTypes = {
     classes: PropTypes.object.isRequired,
     model: PropTypes.object.isRequired,
     currentInterpretationId: PropTypes.string,
+    isOnline: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
     onCurrentInterpretationChange: PropTypes.func
 };

--- a/packages/interpretations/src/components/Cards/InterpretationsCard.js
+++ b/packages/interpretations/src/components/Cards/InterpretationsCard.js
@@ -157,7 +157,7 @@ InterpretationsCard.propTypes = {
     classes: PropTypes.object.isRequired,
     model: PropTypes.object.isRequired,
     currentInterpretationId: PropTypes.string,
-    ifOffline: PropTypes.bool,
+    isOffline: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
     onCurrentInterpretationChange: PropTypes.func
 };

--- a/packages/interpretations/src/components/Cards/InterpretationsCard.js
+++ b/packages/interpretations/src/components/Cards/InterpretationsCard.js
@@ -141,7 +141,7 @@ export class InterpretationsCard extends React.Component {
                 {!this.props.isOnline && (
                     <div style={styles.overlay} >
                         <div style={styles.center}>
-                            <span style={styles.offlineMessage}>Not available offline</span>
+                            <span style={styles.offlineMessage}>{i18n.t('Not available offline')}</span>
                         </div>
                     </div>
                 )}

--- a/packages/interpretations/src/components/Cards/InterpretationsCard.js
+++ b/packages/interpretations/src/components/Cards/InterpretationsCard.js
@@ -138,7 +138,7 @@ export class InterpretationsCard extends React.Component {
         
         return (
             <CollapsibleCard title={i18n.t("Interpretations")} style={{ position: 'relative' }}>
-                {!this.props.isOnline && (
+                {this.props.isOffline && (
                     <div style={styles.overlay} >
                         <div style={styles.center}>
                             <span style={styles.offlineMessage}>{i18n.t('Not available offline')}</span>
@@ -157,7 +157,7 @@ InterpretationsCard.propTypes = {
     classes: PropTypes.object.isRequired,
     model: PropTypes.object.isRequired,
     currentInterpretationId: PropTypes.string,
-    isOnline: PropTypes.bool,
+    ifOffline: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
     onCurrentInterpretationChange: PropTypes.func
 };

--- a/packages/interpretations/src/components/Cards/InterpretationsCard.js
+++ b/packages/interpretations/src/components/Cards/InterpretationsCard.js
@@ -139,9 +139,9 @@ export class InterpretationsCard extends React.Component {
         return (
             <CollapsibleCard title={i18n.t("Interpretations")} style={{ position: 'relative' }}>
                 {!this.props.isOnline && (
-                    <div style={{position: 'absolute', inset: 0, zIndex: 2000, background: 'rgba(33, 43, 54, 0.4)'}} >
-                        <div style={{width: '100%', height: '100%', display: 'flex', justifyContent: 'space-around', flexDirection: 'row', pointerEvents: 'none', WebkitBoxAlign: 'center', alignItems: 'center',}}>
-                            <span style={{backgroundColor: 'white', padding: '10px', borderRadius: '3px'}}>Not available offline</span>
+                    <div style={styles.overlay} >
+                        <div style={styles.center}>
+                            <span style={styles.offlineMessage}>Not available offline</span>
                         </div>
                     </div>
                 )}

--- a/packages/interpretations/src/components/Cards/styles/InterpretationsCard.style.js
+++ b/packages/interpretations/src/components/Cards/styles/InterpretationsCard.style.js
@@ -9,4 +9,28 @@ export default {
         fontSize: '13px',
         textTransform: 'inherit',
     },
+
+    overlay: {
+        position: 'absolute',
+        inset: 0,
+        zIndex: 2000,
+        background: 'rgba(33, 43, 54, 0.4)',
+    },
+
+    center: {
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        justifyContent: 'space-around',
+        flexDirection: 'row',
+        pointerEvents: 'none',
+        WebkitBoxAlign: 'center',
+        alignItems: 'center',
+    },
+
+    offlineMessage: {
+        backgroundColor: 'white',
+        padding: '10px',
+        borderRadius: '3px'
+    },
 };

--- a/packages/interpretations/src/components/DetailsPanel/Description.js
+++ b/packages/interpretations/src/components/DetailsPanel/Description.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import { Parser as RichTextParser } from '@dhis2/d2-ui-rich-text';

--- a/packages/interpretations/src/components/DetailsPanel/Description.js
+++ b/packages/interpretations/src/components/DetailsPanel/Description.js
@@ -24,7 +24,7 @@ export const Description = ({ displayDescription, isToggled, onToggleDescription
         <p style={{fontStyle: 'italic'}}>{description}</p>;
 
     return (
-        <Fragment>
+        <div style={{display: 'flex', flexDirection: 'column'}}>
             {DescriptionElement}
             {displayDescription.length > descriptionMaxLength && (
                 <Link
@@ -32,7 +32,7 @@ export const Description = ({ displayDescription, isToggled, onToggleDescription
                     label={showMoreLessLabel}
                 />
             )}
-        </Fragment>
+        </div>
     );
 };
 

--- a/packages/interpretations/src/components/DetailsPanel/Details.js
+++ b/packages/interpretations/src/components/DetailsPanel/Details.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
 import SubscriberIconEnabled from '@material-ui/icons/Notifications';
 import SubscriberIconDisabled from '@material-ui/icons/AddAlert';
 import { withStyles } from '@material-ui/core/styles';
@@ -45,6 +46,21 @@ export class Details extends React.Component {
                 SubscriberIconDisabled,
                 i18n.t('Subscribe to this {{object}} and start receiving notifications', tOpts),
               ];
+    
+            if(!this.props.isOnline) {
+                return (
+                    <Tooltip title={i18n.t('Not available offline')} classes={{ tooltip: this.props.classes.uiTooltip }}>
+                        <span>
+                            <IconButton
+                                style={styles.subscriberIcon}
+                                disabled
+                            >
+                                <SubscriberIcon />
+                            </IconButton>
+                        </span>
+                    </Tooltip>
+                )
+            }
 
         return (
             <IconButton
@@ -76,16 +92,15 @@ export class Details extends React.Component {
 
         return (
             <CollapsibleCard title={this.getCardTitle(this.props.type.toUpperCase())}>
-                {SubscriptionButton}
                 <div className={classes.detailsCardList}>
-                    <Item text={
+                    <div style={styles.descSubscribe}>
                         <Description
                             displayDescription={model.displayDescription}
                             isToggled={this.state.showCompleteDescription}
                             onToggleDescription={this.toggleDescription}
                         />
-                        } 
-                    />
+                        {SubscriptionButton}
+                    </div>
                     <Item label={i18n.t('Owner')} text={owner} />
                     <Item
                         label={i18n.t('Created')}
@@ -110,6 +125,7 @@ Details.contextTypes = {
 };
 
 Details.propTypes = {
+    isOnline: PropTypes.bool,
     model: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
 };

--- a/packages/interpretations/src/components/DetailsPanel/Details.js
+++ b/packages/interpretations/src/components/DetailsPanel/Details.js
@@ -47,7 +47,7 @@ export class Details extends React.Component {
                 i18n.t('Subscribe to this {{object}} and start receiving notifications', tOpts),
               ];
     
-            if(!this.props.isOnline) {
+            if(this.props.isOffline) {
                 return (
                     <Tooltip title={i18n.t('Not available offline')} classes={{ tooltip: this.props.classes.uiTooltip }}>
                         <span>
@@ -125,7 +125,7 @@ Details.contextTypes = {
 };
 
 Details.propTypes = {
-    isOnline: PropTypes.bool,
+    isOffline: PropTypes.bool,
     model: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
 };

--- a/packages/interpretations/src/components/DetailsPanel/styles/Details.style.js
+++ b/packages/interpretations/src/components/DetailsPanel/styles/Details.style.js
@@ -44,11 +44,25 @@ export default {
     },
 
     subscriberIcon: {
-        float: 'right',
-        top: '0px',
-        right: '0px',
         padding: '8px',
         margin: '4px',
+    },
+
+    descSubscribe: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        padding: '4px 0'
+    },
+
+    uiTooltip: {
+        backgroundColor: '#404b5a',
+        padding: '6px 8px',
+        borderRadius: '3px',
+        color: '#fff',
+        fontSize: '12px',
+        lineHeight: '16px',
+        opacity: '1',
     },
     
     item: {

--- a/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
+++ b/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
@@ -85,6 +85,7 @@ export class InterpretationsComponent extends React.Component {
                         model={model}
                         onChange={this.onChange}
                         type={this.props.type}
+                        isOnline={this.props.isOnline}
                     />
                     <InterpretationsCard
                         model={model}
@@ -95,6 +96,7 @@ export class InterpretationsComponent extends React.Component {
                             onCurrentInterpretationChange
                         }
                         type={this.props.type}
+                        isOnline={this.props.isOnline}
                     />
                 </div>
             </div>
@@ -116,6 +118,7 @@ export class InterpretationsComponent extends React.Component {
 
 InterpretationsComponent.defaultProps = {
     insertTheme: false,
+    isOnline: true
 };
 
 InterpretationsComponent.propTypes = {
@@ -123,6 +126,7 @@ InterpretationsComponent.propTypes = {
     d2: PropTypes.object.isRequired,
     type: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
+    isOnline: PropTypes.bool,
     insertTheme: PropTypes.bool,
     lastUpdated: PropTypes.string,
     currentInterpretationId: PropTypes.string,

--- a/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
+++ b/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
@@ -85,7 +85,7 @@ export class InterpretationsComponent extends React.Component {
                         model={model}
                         onChange={this.onChange}
                         type={this.props.type}
-                        isOnline={this.props.isOnline}
+                        isOffline={this.props.isOffline}
                     />
                     <InterpretationsCard
                         model={model}
@@ -96,7 +96,7 @@ export class InterpretationsComponent extends React.Component {
                             onCurrentInterpretationChange
                         }
                         type={this.props.type}
-                        isOnline={this.props.isOnline}
+                        isOffline={this.props.isOffline}
                     />
                 </div>
             </div>
@@ -118,7 +118,7 @@ export class InterpretationsComponent extends React.Component {
 
 InterpretationsComponent.defaultProps = {
     insertTheme: false,
-    isOnline: true
+    isOffline: false
 };
 
 InterpretationsComponent.propTypes = {
@@ -126,7 +126,7 @@ InterpretationsComponent.propTypes = {
     d2: PropTypes.object.isRequired,
     type: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
-    isOnline: PropTypes.bool,
+    isOffline: PropTypes.bool,
     insertTheme: PropTypes.bool,
     lastUpdated: PropTypes.string,
     currentInterpretationId: PropTypes.string,

--- a/packages/sharing-dialog/src/Sharing.component.js
+++ b/packages/sharing-dialog/src/Sharing.component.js
@@ -22,6 +22,29 @@ const styles = {
         height: '240px',
         overflowY: 'scroll',
     },
+    overlay: {
+        position: 'absolute',
+        inset: 0,
+        zIndex: 2000,
+        background: 'rgba(33, 43, 54, 0.4)',
+    },
+
+    center: {
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        justifyContent: 'space-around',
+        flexDirection: 'row',
+        pointerEvents: 'none',
+        WebkitBoxAlign: 'center',
+        alignItems: 'center',
+    },
+
+    offlineMessage: {
+        backgroundColor: 'white',
+        padding: '10px',
+        borderRadius: '3px'
+    },
 };
 
 /**
@@ -110,7 +133,14 @@ class Sharing extends React.Component {
             .concat((userGroupAccesses || []).map(access => access.id));
 
         return (
-            <div>
+            <div style={{position: 'relative'}}>
+                {this.props.isOffline && (
+                    <div style={styles.overlay} >
+                        <div style={styles.center}>
+                            <span style={styles.offlineMessage}>{this.props.offlineMessage}</span>
+                        </div>
+                    </div>
+                )}
                 <Heading text={displayName} level={2} />
                 <CreatedBy author={user} />
                 <div style={styles.titleBodySpace} />
@@ -190,6 +220,9 @@ Sharing.propTypes = {
      * Takes a string and a callback, and returns matching users and userGroups.
      */
     onSearch: PropTypes.func.isRequired,
+
+    isOffline: PropTypes.bool,
+    offlineMessage: PropTypes.string,
 };
 
 Sharing.contextTypes = {

--- a/packages/sharing-dialog/src/SharingDialog.component.js
+++ b/packages/sharing-dialog/src/SharingDialog.component.js
@@ -219,6 +219,8 @@ class SharingDialog extends React.Component {
                                 dataShareable={dataShareable}
                                 onChange={this.onSharingChanged}
                                 onSearch={this.onSearchRequest}
+                                isOffline={this.props.isOffline}
+                                offlineMessage={this.props.offlineMessage}
                             />
                         }
                     </DialogContent>
@@ -311,6 +313,16 @@ SharingDialog.propTypes = {
      * d2 instance to use.
      */
     d2: PropTypes.object.isRequired,
+
+    /**
+     * isOffline - indicates whether there is internet connectivity
+     */
+    isOffline: PropTypes.bool,
+
+    /**
+     * offlineMessage - message to display in overlay when no internet connectivity
+     */
+    offlineMessage: PropTypes.string,
 };
 
 SharingDialog.defaultProps = {
@@ -319,6 +331,7 @@ SharingDialog.defaultProps = {
     insertTheme: false,
     doNotPost: false,
     sharedObject: null,
+    isOffline: false,
 };
 
 export default SharingDialog;


### PR DESCRIPTION
Part of fix for https://jira.dhis2.org/browse/DHIS2-10874

Changes proposed in this pull request:
* Interpretations: When the containing app is offline, then the input areas of the Interpretation are covered with an overlay containing text "Not available offline". Also, the subscription bell (in the description area) is disabled and has a tooltip on hover.
* Sharing: Place an overlay over everything but the CLOSE button
 
I decided not to introduce dhis2/ui as a dependency and instead copied css from the dhis2/ui ComponentCover and Center components. The Mui Tooltip also has the dhis2/ui Tooltip styling.

Some html and css changes were needed to get the tooltip on the subscription bell to work correctly. (like switching from `float` to `flexbox`.

Before:
![image](https://user-images.githubusercontent.com/6113918/118948424-8ab04300-b958-11eb-9e5a-7d9e9e0ea78a.png)


After:
Online: (notice that the subscription bell has more space around it and the description text does not wrap around it):
![image](https://user-images.githubusercontent.com/6113918/118948363-7cfabd80-b958-11eb-9883-2981eff1ac4d.png)


Offline:
The subscription bell:
![image](https://user-images.githubusercontent.com/6113918/118948610-b9c6b480-b958-11eb-8b6e-f6983c9c301c.png)

The interpretation area with inputs and other interactions (some but not all needing connectivity) is completely covered.
![image](https://user-images.githubusercontent.com/6113918/118948648-c2b78600-b958-11eb-9a49-89ee742ff092.png)

Another example where there are a few interpretations:
![image](https://user-images.githubusercontent.com/6113918/118951753-a537eb80-b95b-11eb-8006-86f9578cf4e8.png)




Sharing Dialog offline:
![image](https://user-images.githubusercontent.com/6113918/118967173-ad4b5780-b96a-11eb-8a34-9cfefadb194d.png)

