### PR TITLE
fix: make sure locales are recognised by Intl

### DIFF
--- a/packages/interpretations/src/dateformats/dateformatter.js
+++ b/packages/interpretations/src/dateformats/dateformatter.js
@@ -2,29 +2,34 @@ import moment from 'moment';
 
 export function formatDate(value = '', uiLocale = 'en') {
     if (typeof global.Intl !== 'undefined' && Intl.DateTimeFormat) {
-        return new Intl.DateTimeFormat(uiLocale, {
+        // convert locale to BCP 47 format
+        const convertedUiLocale = uiLocale.replace('_', '-');
+
+        return new Intl.DateTimeFormat(convertedUiLocale, {
             year: 'numeric',
             month: 'short',
             day: 'numeric',
         }).format(new Date(value));
     }
-    
+
     return value.substr(0, 19).replace('T', ' ');
 }
 
 export function formatRelative(value, uiLocale) {
     const createdRelativeDate = moment(value, moment.ISO_8601).fromNow();
 
-    return dateIsOver24Hours(createdRelativeDate) ? formatDate(value, uiLocale) : createdRelativeDate;
-};
+    return dateIsOver24Hours(createdRelativeDate)
+        ? formatDate(value, uiLocale)
+        : createdRelativeDate;
+}
 
 export function dateIsOver24Hours(relativeDate) {
     let shouldFormatToDate = false;
-    ['day', 'year', 'month'].forEach(item => { 
-        if(relativeDate.includes(item)) {
+    ['day', 'year', 'month'].forEach((item) => {
+        if (relativeDate.includes(item)) {
             shouldFormatToDate = true;
-        }  
-    }); 
+        }
+    });
 
     return shouldFormatToDate;
-};
+}


### PR DESCRIPTION
`Intl` wants locale in BCP 47 format, ie. de-AT with hyphen, but the
locale string coming from the api uses `_` instead.

Fixes a crash when opening the interpretations panel when the user's locale is contains the extended country information.