### PR TITLE
fix: children prop-type in interpretations CollapsibleCard is type node

### DIFF
--- a/packages/interpretations/src/components/Cards/CollapsibleCard.js
+++ b/packages/interpretations/src/components/Cards/CollapsibleCard.js
@@ -51,7 +51,7 @@ export class CollapsibleCard extends React.Component {
 CollapsibleCard.propTypes = {
     classes: PropTypes.object.isRequired,
     title: PropTypes.string.isRequired,
-    children: PropTypes.array.isRequired,
+    children: PropTypes.node.isRequired,
 };
 
 export default withStyles(styles)(CollapsibleCard);


### PR DESCRIPTION
This fixes a console warning
