### PR TITLE
fix: disable save button in translation dlg if offline [DHIS2-10874

### DIFF
--- a/packages/translation-dialog/src/TranslationDialog.component.js
+++ b/packages/translation-dialog/src/TranslationDialog.component.js
@@ -58,6 +58,7 @@ class TranslationDialog extends Component {
                 onTranslationError={this.translationError}
                 onCancel={this.closeDialog}
                 fieldsToTranslate={this.props.fieldsToTranslate}
+                isOnline={this.props.isOnline}
             />
         </Dialog>
     )
@@ -82,6 +83,7 @@ TranslationDialog.defaultProps = {
 
 TranslationDialog.propTypes = {
     insertTheme: PropTypes.bool,
+    isOnline: PropTypes.bool,
     objectToTranslate: PropTypes.shape({
         id: PropTypes.string.isRequired,
     }).isRequired,

--- a/packages/translation-dialog/src/TranslationForm.component.js
+++ b/packages/translation-dialog/src/TranslationForm.component.js
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import TextField from '@material-ui/core/TextField';
+import Tooltip from '@material-ui/core/Tooltip';
 import Button from '@material-ui/core/Button';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -139,11 +140,31 @@ class TranslationForm extends Component {
                     color="primary"
                     onClick={this.props.onCancel}
                 >{this.getTranslation('cancel')}</Button>
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={this.saveTranslations}
-                >{this.getTranslation('save')}</Button>
+                {this.props.isOnline ? (
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={this.saveTranslations}
+                    >
+                        {this.getTranslation("save")}
+                    </Button>
+                ) : (
+                    <Tooltip
+                        title={this.getTranslation("Cannot save while offline")}
+                        placement="top-start"
+                    >
+                        <span>
+                            <Button
+                                style={{ color: "white" }}
+                                disabled
+                                variant="contained"
+                                color="primary"
+                            >
+                                {this.getTranslation("save")}
+                            </Button>
+                        </span>
+                    </Tooltip>
+                )}
             </DialogActions>
         );
     }
@@ -191,11 +212,13 @@ TranslationForm.propTypes = {
     translations: PropTypes.array,
     setTranslations: PropTypes.func,
     fieldsToTranslate: PropTypes.arrayOf(PropTypes.string),
+    isOnline: PropTypes.bool,
 };
 
 TranslationForm.defaultProps = {
     fieldsToTranslate: ['name', 'shortName', 'description'],
     locales: [],
+    isOnline: true,
 };
 
 TranslationForm.contextTypes = {


### PR DESCRIPTION
A new property `isOnline` is added so that the Save button in Translation Dialog can be disabled if connectivity is lost.

https://user-images.githubusercontent.com/6113918/130642664-e7bdd1fe-f77f-4131-a7ba-98b2269e976e.mov

