### PR TITLE
fix: show new interpretation form when user/group has access DHIS2-12617

### DIFF
--- a/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
+++ b/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
@@ -48,14 +48,14 @@ export class InterpretationsComponent extends React.Component {
     }
 
     async loadModel(props) {
-        const users = await props.d2.currentUser.getUserGroupIds();
+        const userGroupIds = await props.d2.currentUser.getUserGroupIds();
 
         return getFavoriteWithInterpretations(
             props.d2,
             props.type,
             props.id
         ).then((model) => {
-            this.setState({ model, userGroups: users });
+            this.setState({ model, userGroups: userGroupIds });
             return model;
         });
     }

--- a/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
+++ b/packages/interpretations/src/components/InterpretationsComponent/InterpretationsComponent.js
@@ -54,15 +54,15 @@ export class InterpretationsComponent extends React.Component {
             props.d2,
             props.type,
             props.id
-        ).then(model => {
-            this.setState({ model, userGroups: Array.from(users.keys()) });
+        ).then((model) => {
+            this.setState({ model, userGroups: users });
             return model;
         });
     }
 
     async onChange() {
         return this.loadModel(this.props).then(
-            newModel => this.props.onChange && this.props.onChange(newModel)
+            (newModel) => this.props.onChange && this.props.onChange(newModel)
         );
     }
 
@@ -118,7 +118,7 @@ export class InterpretationsComponent extends React.Component {
 
 InterpretationsComponent.defaultProps = {
     insertTheme: false,
-    isOffline: false
+    isOffline: false,
 };
 
 InterpretationsComponent.propTypes = {


### PR DESCRIPTION
Fixes [DHIS2-12617](https://jira.dhis2.org/browse/DHIS2-12617)

Changes proposed in this pull request:

- fix bug when checking if a user belongs to a group

This bug prevented to verify that the user belongs to a group and thus had access to write
a new interpretation.

Before:
<img width="387" alt="Screenshot 2022-04-01 at 18 14 07" src="https://user-images.githubusercontent.com/150978/161501114-f3f11510-d839-4668-8df7-ab61379ca8f4.png">

After:
<img width="384" alt="Screenshot 2022-04-01 at 18 25 06" src="https://user-images.githubusercontent.com/150978/161501130-b2ceb6d5-765e-414f-bb7d-494ad62d3091.png">

