### PR TITLE
fix(interpretations): add title for LL visualizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhis2/d2-ui",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {

--- a/packages/interpretations/i18n/en.pot
+++ b/packages/interpretations/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-05-20T08:53:00.620Z\n"
-"PO-Revision-Date: 2021-05-20T08:53:00.620Z\n"
+"POT-Creation-Date: 2023-03-14T12:23:26.708Z\n"
+"PO-Revision-Date: 2023-03-14T12:23:26.708Z\n"
 
 msgid "Pivot Tables"
 msgstr "Pivot Tables"
@@ -22,6 +22,9 @@ msgstr "Event Reports"
 
 msgid "Event Visualizer"
 msgstr "Event Visualizer"
+
+msgid "Line Listing"
+msgstr "Line Listing"
 
 msgid "View in {{appName}} app"
 msgstr "View in {{appName}} app"
@@ -56,6 +59,9 @@ msgstr "Back to all interpretations"
 msgid "Interpretations"
 msgstr "Interpretations"
 
+msgid "Not available offline"
+msgstr "Not available offline"
+
 msgid "Save reply"
 msgstr "Save reply"
 
@@ -83,9 +89,6 @@ msgstr "Unsubscribe from this {{object}} and stop receiving notifications"
 msgid "Subscribe to this {{object}} and start receiving notifications"
 msgstr "Subscribe to this {{object}} and start receiving notifications"
 
-msgid "Not available offline"
-msgstr "Not available offline"
-
 msgid "Table details"
 msgstr "Table details"
 
@@ -97,6 +100,9 @@ msgstr "Map details"
 
 msgid "Visualization details"
 msgstr "Visualization details"
+
+msgid "Line list details"
+msgstr "Line list details"
 
 msgid "Owner"
 msgstr "Owner"
@@ -198,6 +204,9 @@ msgid "{{count}} user groups"
 msgid_plural "{{count}} user groups"
 msgstr[0] "{{count}} user group"
 msgstr[1] "{{count}} user groups"
+
+msgid "visualization"
+msgstr "visualization"
 
 msgid "chart"
 msgstr "chart"

--- a/packages/interpretations/src/components/DetailsPanel/Details.js
+++ b/packages/interpretations/src/components/DetailsPanel/Details.js
@@ -81,7 +81,8 @@ export class Details extends React.Component {
             EVENT_REPORT: i18n.t('Table details'),
             EVENT_CHART: i18n.t('Chart details'),
             VISUALIZATION: i18n.t('Visualization details'),
-        }
+            EVENT_VISUALIZATION: i18n.t('Line list details'),
+        };
         return typeTitleMap[type];
     }
 

--- a/packages/interpretations/src/components/DetailsPanel/Details.js
+++ b/packages/interpretations/src/components/DetailsPanel/Details.js
@@ -34,33 +34,33 @@ export class Details extends React.Component {
 
     renderSubscriptionButton() {
         const tOpts = { object: translateModelName(this.props.model.modelName) };
-        const [ SubscriberIcon, subscriptionTooltip ] = this.props.model.subscribed
+        const [SubscriberIcon, subscriptionTooltip] = this.props.model.subscribed
             ? [
-                SubscriberIconEnabled,
-                i18n.t(
-                    'Unsubscribe from this {{object}} and stop receiving notifications',
-                    tOpts
-                ),
+                  SubscriberIconEnabled,
+                  i18n.t(
+                      'Unsubscribe from this {{object}} and stop receiving notifications',
+                      tOpts
+                  ),
               ]
             : [
-                SubscriberIconDisabled,
-                i18n.t('Subscribe to this {{object}} and start receiving notifications', tOpts),
+                  SubscriberIconDisabled,
+                  i18n.t('Subscribe to this {{object}} and start receiving notifications', tOpts),
               ];
-    
-            if(this.props.isOffline) {
-                return (
-                    <Tooltip title={i18n.t('Not available offline')} classes={{ tooltip: this.props.classes.uiTooltip }}>
-                        <span>
-                            <IconButton
-                                style={styles.subscriberIcon}
-                                disabled
-                            >
-                                <SubscriberIcon />
-                            </IconButton>
-                        </span>
-                    </Tooltip>
-                )
-            }
+
+        if (this.props.isOffline) {
+            return (
+                <Tooltip
+                    title={i18n.t('Not available offline')}
+                    classes={{ tooltip: this.props.classes.uiTooltip }}
+                >
+                    <span>
+                        <IconButton style={styles.subscriberIcon} disabled>
+                            <SubscriberIcon />
+                        </IconButton>
+                    </span>
+                </Tooltip>
+            );
+        }
 
         return (
             <IconButton
@@ -71,20 +71,20 @@ export class Details extends React.Component {
                 <SubscriberIcon />
             </IconButton>
         );
-    };
+    }
 
-    getCardTitle = type => {
+    getCardTitle = (type) => {
         const typeTitleMap = {
             REPORT_TABLE: i18n.t('Table details'),
             CHART: i18n.t('Chart details'),
-            MAP:  i18n.t('Map details'),
+            MAP: i18n.t('Map details'),
             EVENT_REPORT: i18n.t('Table details'),
             EVENT_CHART: i18n.t('Chart details'),
             VISUALIZATION: i18n.t('Visualization details'),
             EVENT_VISUALIZATION: i18n.t('Line list details'),
         };
         return typeTitleMap[type];
-    }
+    };
 
     render() {
         const { model, classes } = this.props;
@@ -116,8 +116,8 @@ export class Details extends React.Component {
                 </div>
             </CollapsibleCard>
         );
-    };
-};
+    }
+}
 
 Details.contextTypes = {
     d2: PropTypes.object.isRequired,


### PR DESCRIPTION
Changes proposed in this pull request:

- add missing title for LL visualizations

Before:
<img width="425" alt="Screenshot 2023-03-10 at 11 24 18" src="https://user-images.githubusercontent.com/150978/224291784-2825d774-838a-4381-a676-7c47c2897441.png">

After:
<img width="436" alt="Screenshot 2023-03-10 at 11 23 58" src="https://user-images.githubusercontent.com/150978/224291799-5bb2dd08-116e-4e53-97fe-801aa426021f.png">


