### PR TITLE
fix: interpretation panel crash BETA-42

### DIFF
--- a/packages/interpretations/src/authorization/auth.js
+++ b/packages/interpretations/src/authorization/auth.js
@@ -7,7 +7,7 @@ export const userCanManage = (d2, object) => {
         return false;
     } else if (object.user.id === currentUser.id) {
         return true;
-    } else if (currentUser.authorities.has("ALL")) {
+    } else if (currentUser.authorities.has('ALL')) {
         return true;
     } else {
         return false;
@@ -17,7 +17,7 @@ export const userCanManage = (d2, object) => {
 export const haveReadAccess = (d2, userGroups, object) => {
     const { currentUser } = d2 || {};
 
-    if (!object || !currentUser) {
+    if (!object || !currentUser) {
         return false;
     } else if (object.user && currentUser.id === object.user.id) {
         return true;
@@ -36,8 +36,8 @@ export const haveReadAccess = (d2, userGroups, object) => {
 
 export const haveWriteAccess = (d2, userGroups, object) => {
     const { currentUser } = d2 || {};
-    
-    if (!object || !currentUser) {
+
+    if (!object || !currentUser) {
         return false;
     } else if (object.user && currentUser.id === object.user.id) {
         return true;
@@ -54,22 +54,22 @@ export const haveWriteAccess = (d2, userGroups, object) => {
     }
 };
 
-
 const sharedUserAccess = (userId, users, accessBit) =>
-    some(user => user.id === userId && user.access.includes(accessBit), users);
+    some((user) => user.id === userId && user.access.includes(accessBit), users);
 
 const sharedUserGroups = (userGroups, objectGroups, accessBit) => {
     let isMember = false;
 
-    userGroups.forEach(id => {
-        if(some(objectGroup => 
-                objectGroup.id === id && 
-                objectGroup.access.includes(accessBit), objectGroups
-            )) {
-                isMember = true;
-            }
-    })
+    userGroups.forEach((id) => {
+        if (
+            some(
+                (objectGroup) => objectGroup.id === id && objectGroup.access.includes(accessBit),
+                objectGroups
+            )
+        ) {
+            isMember = true;
+        }
+    });
 
     return isMember;
 };
-

--- a/packages/interpretations/src/authorization/auth.js
+++ b/packages/interpretations/src/authorization/auth.js
@@ -23,7 +23,7 @@ export const haveReadAccess = (d2, userGroups, object) => {
         return true;
     } else if (currentUser.authorities.has('ALL')) {
         return true;
-    } else if (object.publicAccess.includes('r')) {
+    } else if (object.publicAccess && object.publicAccess.includes('r')) {
         return true;
     } else if (sharedUserAccess(currentUser.id, object.userAccesses, 'r')) {
         return true;


### PR DESCRIPTION
Fixes [BETA-42](https://dhis2.atlassian.net/browse/BETA-42).

Changes proposed in this pull request:

- avoid interpretations panel crashing when `publicAccess` is not present in the AO

The sharing info shown will show **Unknown** for `public`.

From v41 of the api, `publicAccess` and other sharing related properties are moved in the `sharing` object.
By then hopefully we can replace `d2-ui-interpretations` still used in dashboard with a new solutions based on the new sharing components already in use in analytics apps.

Before:
<img width="539" alt="Screenshot 2023-03-09 at 10 53 35" src="https://user-images.githubusercontent.com/150978/234818937-8d06f577-6c78-4026-9e47-3259c6224310.png">
<img width="579" alt="Screenshot 2023-03-09 at 10 59 18" src="https://user-images.githubusercontent.com/150978/234818974-1cf6b777-0e98-47ef-bc8f-9fe55e0bb767.png">


After:
<img width="449" alt="Screenshot 2023-04-27 at 11 12 45" src="https://user-images.githubusercontent.com/150978/234818871-d95b7b4d-931b-4133-94a6-bcea931f8298.png">

